### PR TITLE
Fixed a bug with the chaining API

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -63,7 +63,8 @@ function processRequest(interceptors, options, callback) {
       , responseBody
       , interceptor
       , paused
-      , next = [];
+      , next = []
+      , callnext;
 
     requestBody = requestBodyBuffers.map(function(buffer) {
       return buffer.toString(encoding);

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -527,3 +527,42 @@ tap.test("pause response after data", function(t) {
     });
   });
 });
+
+tap.test("chaining API", function(t) {
+  var scope = nock('http://chainchomp.com')
+    .get('/one')
+    .reply(200, 'first one')
+    .get('/two')
+    .reply(200, 'second one');
+
+  http.get({
+    host: 'chainchomp.com'
+   , path: '/one'
+  }, function(res) {
+    res.setEncoding('utf8');
+    t.equal(res.statusCode, 200, 'status should be ok');
+    res.on('data', function(data) {
+      t.equal(data, 'first one', 'should be equal to first reply');
+    });
+
+    res.on('end', function() {
+
+      http.get({
+        host: 'chainchomp.com'
+       , path: '/two'
+      }, function(res) {
+        res.setEncoding('utf8');
+        t.equal(res.statusCode, 200, 'status should be ok');
+        res.on('data', function(data) {
+          t.equal(data, 'second one', 'should be qual to second reply');
+        });
+
+        res.on('end', function() {
+          scope.done();
+          t.end();
+        });
+      });
+
+    });
+  });
+});


### PR DESCRIPTION
There was a variable I forgot to declare in the last pull request. Using the chain API would cause nock to share the callnext variable and give an error. This patch fixes that.
