### PR TITLE
Exposes _headers for returned request object

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -40,6 +40,23 @@ function stringifyRequest(options) {
   return method + ' ' + path + ' ' + body;
 }
 
+function getHeader(request, name) {
+  if (!request._headers) return;
+
+  var key = name.toLowerCase();
+
+  return request._headers[key];
+}
+
+function setHeader(request, name, value) {
+  var key = name.toLowerCase();
+
+  request._headers = request._headers || {};
+  request._headerNames = request._headerNames || {};
+  request._headers[key] = value;
+  request._headerNames[key] = name;
+}
+
 function processRequest(interceptors, options, callback) {
   var req = new EventEmitter()
     , response = new EventEmitter()
@@ -48,7 +65,27 @@ function processRequest(interceptors, options, callback) {
     , end
     , ended;
 
-  req._headers = options.headers;
+  if (options.headers) {
+    var headers = options.headers;
+    var keys = Object.keys(headers);
+
+    for (var i = 0, l = keys.length; i < l; i++) {
+      var key = keys[i];
+
+      setHeader(req, key, headers[key]);
+    };
+  }
+
+  if (options.host && !getHeader(req, 'host')) {
+    var hostHeader = options.host;
+
+    if (options.host && +options.port !== 80) {
+      hostHeader += ':' + options.port;
+    }
+
+    setHeader(req, 'Host', hostHeader);
+  }
+
   req.write = function(buffer, encoding) {
     if (buffer && !aborted) {
       if (! Buffer.isBuffer(buffer)) {

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -111,10 +111,11 @@ tap.test("request headers exposed", function(t) {
     , method: 'GET'
     , path: '/'
     , port: 80
-    , headers: { 'X-My-Headers': 'My custom Header value' }
+    , headers: {'X-My-Headers': 'My custom Header value'}
   });
 
-  t.similar(req._headers, {'X-My-Headers': 'My custom Header value'});
+  console.dir(req._headers)
+  t.equivalent(req._headers, {'x-my-headers': 'My custom Header value', 'host': 'www.headdy.com'});
   t.end();
 });
 


### PR DESCRIPTION
The object returned by `http.request` exposes its headers via the `_headers` property. You can find the corresponding code [here](https://github.com/joyent/node/blob/v0.4.12/lib/http.js#L531). To match that expectation I added a simple copy of the get/setHeader functionality from the core. The code also takes care about the implicit addition of the host header.

Maybe at some point it would make sense to flesh out the `req` Object at make it full compliant.
