### PR TITLE
Simplify tests

### DIFF
--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -747,8 +747,6 @@ tap.test("same URI", function(t) {
 });
 
 tap.test("can use hostname instead of host", function(t) {
-  var dataCalled = false
-
   var scope = nock('http://www.google.com')
     .get('/')
     .reply(200, "Hello World!");
@@ -760,24 +758,15 @@ tap.test("can use hostname instead of host", function(t) {
 
     t.equal(res.statusCode, 200);
     res.on('end', function() {
-      t.ok(dataCalled);
       scope.done();
       t.end();
     });
-    res.on('data', function(data) {
-      dataCalled = true;
-      t.ok(data instanceof Buffer, "data should be buffer");
-      t.equal(data.toString(), "Hello World!", "response should match");
-    });
-
   });
 
   req.end();
 });
 
 tap.test("can take a port", function(t) {
-  var dataCalled = false
-
   var scope = nock('http://www.myserver.com:3333')
     .get('/')
     .reply(200, "Hello World!");
@@ -790,16 +779,9 @@ tap.test("can take a port", function(t) {
 
     t.equal(res.statusCode, 200);
     res.on('end', function() {
-      t.ok(dataCalled);
       scope.done();
       t.end();
     });
-    res.on('data', function(data) {
-      dataCalled = true;
-      t.ok(data instanceof Buffer, "data should be buffer");
-      t.equal(data.toString(), "Hello World!", "response should match");
-    });
-
   });
 
   req.end();


### PR DESCRIPTION
Just a small follow-on from #17 and #18. We don't need all the extra checks in these tests now that `done()` is asserting properly.
