### PR TITLE
fixed bug in https handling and global namespace pollution

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -22,7 +22,7 @@ function remove(interceptor) {
   var interceptor;
   
   for(var i = 0; i < interceptors.length; i++) {
-    thisInterceptor = interceptors[i];
+    var thisInterceptor = interceptors[i];
     if (thisInterceptor._key === interceptor._key) {
       interceptors.splice(i, 1);
       break;
@@ -127,7 +127,7 @@ function processRequest(interceptors, options, callback) {
     requestBody = requestBodyBuffers.map(function(buffer) {
       return buffer.toString(encoding);
     }).join('');
-    body = undefined; // we don't need the request body buffers any more
+    var body = undefined; // we don't need the request body buffers any more
     
     interceptors = interceptors.filter(function(interceptor) {
       return interceptor.match(options, requestBody);
@@ -350,7 +350,7 @@ https.request = function(options, callback) {
   if (interceptors && interceptors.length > 0) {
     return processRequest(interceptors, options, callback);
   } else {
-    return httpRequest.apply(http, arguments);
+    return httpsRequest.apply(https, arguments);
   }
 };
 


### PR DESCRIPTION
Hi,  

Nice library!

https handling wasn't working due to a typo, and I fixed a few variables which polluted the global namespace accidentally.   (I'm using mocha for testing in my project, which detects any global pollution).
