### PR TITLE
Global leak variables

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -20,6 +20,7 @@ function remove(interceptor) {
   var hostKey = u.protocol + '//' + u.host;
   var interceptors = allInterceptors[hostKey];
   var interceptor;
+  var thisInterceptor;
   
   for(var i = 0; i < interceptors.length; i++) {
     thisInterceptor = interceptors[i];
@@ -127,7 +128,6 @@ function processRequest(interceptors, options, callback) {
     requestBody = requestBodyBuffers.map(function(buffer) {
       return buffer.toString(encoding);
     }).join('');
-    body = undefined; // we don't need the request body buffers any more
     
     interceptors = interceptors.filter(function(interceptor) {
       return interceptor.match(options, requestBody);


### PR DESCRIPTION
I was using [mocha](http://visionmedia.github.com/mocha/) along with nock and it warned me about two global variable leaks, `thisInterceptor` and `body.

This small pull request fixes those leaks.
