### PR TITLE
Header keys are lower cased

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -51,8 +51,20 @@ function startScope(basePath) {
         }
       }
       
+      
+      if (headers !== undefined) {
+        this.headers = {};
+
+        // makes sure all keys in headers are in lower case
+        var key2;
+        for (key2 in headers) {
+          if (headers.hasOwnProperty(key2)) {
+            this.headers[key2.toLowerCase()] = headers[key2];
+          }
+        }
+      }
+
       this.body = body;
-      this.headers = headers;
       add(key, this);
       return scope;
     }

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -158,7 +158,7 @@ tap.test("headers work", function(t) {
   }, function(res) {
    t.equal(res.statusCode, 200);
    res.on('end', function() {
-     t.similar(res.headers, {'X-My-Headers': 'My Header value'});
+     t.equivalent(res.headers, {'x-my-headers': 'My Header value'});
      t.end();
    });
   });


### PR DESCRIPTION
Node.js returns keys from the header hash in lower case.

To test this you can use this file
https://gist.github.com/1554430

This pull request might make others' tests not pass if they were using headers with not-lowercased keys. But it's ok, because this is the way node works and it's much better if your test fails than your deployed product.
