### PR TITLE
Moves the defense check for next emptiness

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -306,8 +306,9 @@ function processRequest(interceptors, options, callback) {
     });
 
     callnext = function() {
-      if (paused || next.length === 0 || aborted) { return; }
       process.nextTick(function() {
+        if (paused || next.length === 0 || aborted) { return; }
+
         next.shift()();
         callnext();
       });


### PR DESCRIPTION
- Checks on nextTick if next is empty

In rare cases next can be empty when execution was deferred to next event loop cycle. This moves the defense check inside of the fn that is ending up on the loop. Only drawback I can spot is, that in the case when next is empty even before `process.nextTick` is called we putting a fn on the loop that will return immediately.
