### PR TITLE
Expose `intercept` in scope returned from `startScope`

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -215,6 +215,7 @@ function startScope(basePath) {
     , post: post
     , delete: _delete
     , put: put
+    , intercept: intercept
     , done: done
     , isDone: isDone
     , filteringPath: filteringPath


### PR DESCRIPTION
This is a small one-line change to expose the intercept function in the scope returned from startScope. This allows you to do something like:

``` javascript
var scope = nock('http://example.com')
  .intercept('/mock/1', 'PATCH', {quux: 2})
  .reply(209, {foo: 1, quux: 2});
```

to support, for example, HTTP methods other that GET/PUT/POST/DELETE.
