### PR TITLE
Fixed global scope of one variable

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -38,7 +38,8 @@ function RequestOverrider(req, options, interceptors, remove) {
       headers,
       keys,
       key,
-      i;
+      i,
+      l;
 
   if (options.headers) {
     headers = options.headers;


### PR DESCRIPTION
I use nock in a project where tests are done with mocha. Mocha lets tests fail when there are global variables. So, since your commit "separated request piping" (https://github.com/pgte/nock/commit/a83d8c6c98cf0e32beab07d7948a279efef45019) my tests fail...
