### PR TITLE
Output body in error message

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -1,10 +1,9 @@
 var Piper            = require('./piper'),
     EventEmitter     = require('events').EventEmitter;
 
-function stringifyRequest(options) {
+function stringifyRequest(options, body) {
   var method = options.method || 'GET',
-      path = options.path,
-      body = options.body;
+      path = options.path;
 
   if (body && typeof(body) !== 'string') {
     body = body.toString();
@@ -119,7 +118,7 @@ function RequestOverrider(req, options, interceptors, remove) {
       return interceptor.match(options, requestBody);
     });
     
-    if (interceptors.length < 1) { throw new Error("Nock: No match for HTTP request " + stringifyRequest(options)); }
+    if (interceptors.length < 1) { throw new Error("Nock: No match for HTTP request " + stringifyRequest(options, requestBody)); }
     interceptor = interceptors.shift();
 
     response.statusCode = interceptor.statusCode || 200;


### PR DESCRIPTION
The error message would always spit out something like

> No match for HTTP request POST /gists undefined

Include the actual body instead.
