### PR TITLE
Allow allowUnmocked to hit base path

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -122,7 +122,7 @@ function startScope(basePath, options) {
       }
 
       var matchKey = method + ' ' + proto + '://' + options.host + path;
-      return this._key.indexOf(matchKey) === 0;
+      return this._key === matchKey
     }
     
     function filteringPath() {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 , "engines" : ["node >= 0.4.10"]
 , "main" : "./index"
 , "devDependencies": {
-    "tap": "0.0.x"
+    "tap": "0.2.x"
 }
 , "scripts": { "test": "node node_modules/tap/bin/tap.js tests" }
 }

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -1070,6 +1070,19 @@ tap.test("allow unmocked option works", function(t) {
     .get('/wont/get/here')
     .reply(200, 'Hi!');
 
+  function secondIsDone() {
+    console.log('ended ---- ');
+    t.ok(! scope.isDone());
+    http.request({
+        host: "www.google.com"
+      , path: "/"
+      , port: 80
+    }, function(res) {
+      t.assert(res.statusCode === 200, 'GET Google Home page');
+      t.end();
+    }).end();
+  }
+
   function firstIsDone() {
     console.log('ended ---- ');
     t.ok(! scope.isDone());
@@ -1079,7 +1092,7 @@ tap.test("allow unmocked option works", function(t) {
       , port: 80
     }, function(res) {
       t.assert(res.statusCode === 404, 'Google say it does not exist');
-      t.end();
+      res.on('end', secondIsDone);
     }).end();
   }
 


### PR DESCRIPTION
I know the intent of `return this._key.indexOf(matchKey) === 0;` was to find potential matches before the body gets passed to the request, but inadvertently it disallowed requests to '/' because every URL for a given host always contains the base.

I made the potential match slightly more strict and added a test for it.

Also, upgraded Tap (which gives us a lot of nice CLI options to work with).
