### PR TITLE
Allow the response body to be a callback to construct dynamic responses based on the requestBody.

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -55,7 +55,7 @@ function startScope(basePath, options) {
       }
 
       if (typeof(body) === 'function') {
-        body = body.call(this, requestBody);
+        body = body.call(this, uri, requestBody);
       }
 
       if (typeof(body) !== 'string' && !Buffer.isBuffer(body)) {

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -131,13 +131,13 @@ tap.test("get with reply callback", function(t) {
   req.end();
 });
 
-tap.test("post with reply callback and requestBody", function(t) {
+tap.test("post with reply callback, uri, and request body", function(t) {
   var input = 'key=val';
 
   var scope = nock('http://www.google.com')
      .post('/echo', input)
-     .reply(200, function(requestBody) {
-        return 'OK ' + requestBody ;
+     .reply(200, function(uri, body) {
+        return ['OK', uri, body].join(' ');
      });
 
   var req = http.request({
@@ -151,7 +151,7 @@ tap.test("post with reply callback and requestBody", function(t) {
       t.end();
     });
     res.on('data', function(data) {
-      t.equal(data.toString(), 'OK ' + input, 'response should match');
+      t.equal(data.toString(), 'OK /echo key=val' , 'response should match');
     });
   });
 


### PR DESCRIPTION
The only drawback I found with this is that there is no way to access the **original** requestBody that was actually submitted. The fundamental problem with this is because all replies appear to be evaluated before an http request is actually made as opposed to being evaluated on demand.

For example:

``` javascript
var nock = require('nock')
  , http = require('http');

var scope = nock('http://www.google.com')
   .filteringRequestBody(/.*/, '*')
   .post('/echo', '*')
   .reply(201, function(uri, requestBody) {
     return requestBody;
   });

 var req = http.request({
     host: 'www.google.com'
   , method: 'POST'
   , path: '/echo'
   , port: 80
 }, function(res) {

   res.on('end', function() {
     scope.done();
   });
   res.on('data', function(data) {
     console.log('requestBody:',data.toString());
   });

});

req.write('key=val');
req.end();
```

requestBody is always `*`
