### PR TITLE
[fix] needed methods and flow timing for streaming response

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -135,7 +135,9 @@ function RequestOverrider(req, options, interceptors, remove) {
       responseBody.on('end', function() {
         response.emit('end');
       });
-      responseBody.resume();
+      process.nextTick(function() {
+        responseBody.resume();
+      });
     } else  if (! Buffer.isBuffer(responseBody)) {
       responseBody = new Buffer(responseBody);
     }
@@ -149,10 +151,16 @@ function RequestOverrider(req, options, interceptors, remove) {
 
     response.pause = function() {
       paused = true;
+      if (isStream(responseBody)) {
+        responseBody.pause();
+      }
     };
 
     response.resume = function() {
       paused = false;
+      if (isStream(responseBody)) {
+        responseBody.resume();
+      }
       callnext();
     };
 


### PR DESCRIPTION
Hi, I added 2 missing methods to the `response` object if it's a file readstream.

And I put `responseBody.resume()` inside of a `process.nextTick()`. This is needed because in some cases `data` events will be emitted in the same call stack if they've been buffered. If they are, the request callback won't have a chance to listen to them. `response.paused` will still be false.
