### PR TITLE
Allow lowercase method names in requests.

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -119,7 +119,7 @@ function startScope(basePath, options) {
         return false;
       }
 
-      var matchKey = method + ' ' + proto + '://' + options.host;
+      var matchKey = method.toUpperCase() + ' ' + proto + '://' + options.host;
       if (
            options.port && options.host.indexOf(':') < 0 &&
            (options.port !== 80 || options.proto !== 'http') &&

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -107,6 +107,37 @@ tap.test("post", function(t) {
    req.end();
 });
 
+tap.test("post, lowercase", function(t) {
+  var dataCalled = false;
+  
+  var scope = nock('http://www.google.com')
+     .post('/form')
+     .reply(201, "OK!");
+
+   var req = http.request({
+       host: "www.google.com"
+     , method: 'post'
+     , path: '/form'
+     , port: 80
+   }, function(res) {
+
+     t.equal(res.statusCode, 201);
+     res.on('end', function() {
+       t.ok(dataCalled);
+       scope.done();
+       t.end();
+     });
+     res.on('data', function(data) {
+       dataCalled = true;
+       t.ok(data instanceof Buffer, "data should be buffer");
+       t.equal(data.toString(), "OK!", "response should match");
+     });
+
+   });
+
+   req.end();
+});
+
 tap.test("get with reply callback", function(t) {
   var scope = nock('http://www.google.com')
      .get('/')


### PR DESCRIPTION
I think if you're going to normalize method names by uppercasing when defining the intercept(scope.intercept, https://github.com/flatiron/nock/blob/master/lib/scope.js#L40), you should normalize when doing the match.
