### PR TITLE
Head should be a first class interceptor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,12 @@ You can also specify default reply headers for all responses like this:
 
 ## HTTP Verbs
 
-Nock supports any HTTP verb, and it has convenience methods for the GET, POST, PUT and DELETE HTTP verbs.
+Nock supports any HTTP verb, and it has convenience methods for the GET, POST, PUT, HEAD and DELETE HTTP verbs.
 
 You can intercept any HTTP verb using `.intercept(path, verb [, requestBody [, options]])`:
 
     scope('http://my.domain.com')
-      .intercept('/path', 'HEAD')
+      .intercept('/path', 'PATCH')
       .reply(304);
 
 ## Support for HTTP and HTTPS

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -195,6 +195,10 @@ function startScope(basePath, options) {
   function put(uri, requestBody, options) {
     return intercept(uri, 'PUT', requestBody, options);
   }
+  
+  function head(uri, requestBody, options) {
+    return intercept(uri, 'HEAD', requestBody, options);
+  }
 
   function _delete(uri, requestBody, options) {
     return intercept(uri, 'DELETE', requestBody, options);
@@ -293,6 +297,7 @@ function startScope(basePath, options) {
     , post: post
     , delete: _delete
     , put: put
+    , head: head
     , intercept: intercept
     , done: done
     , isDone: isDone

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -107,6 +107,30 @@ tap.test("post", function(t) {
    req.end();
 });
 
+tap.test("head", function(t) {
+  var dataCalled = false;
+  
+  var scope = nock('http://www.google.com')
+     .head('/form')
+     .reply(201, "OK!");
+
+   var req = http.request({
+       host: "www.google.com"
+     , method: 'HEAD'
+     , path: '/form'
+     , port: 80
+   }, function(res) {
+
+     t.equal(res.statusCode, 201);
+     res.on('end', function() {
+       scope.done();
+       t.end();
+     });
+   });
+
+   req.end();
+});
+
 tap.test("get with reply callback", function(t) {
   var scope = nock('http://www.google.com')
      .get('/')


### PR DESCRIPTION
I think HEAD is a common enough HTTP method that it should be a first class interceptor.

It should also not require a reply body, but that's a separate issue?
