### PR TITLE
Reply with callback is now really a callback :)

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -127,7 +127,13 @@ function RequestOverrider(req, options, interceptors, remove) {
 
     response.statusCode = interceptor.statusCode || 200;
     response.headers = interceptor.headers || {};
-    responseBody = interceptor.body;
+
+    if (typeof interceptor.body === 'function') {
+        responseBody = interceptor.body(options.path, requestBody) || '';
+    } else {
+        responseBody = interceptor.body;
+    }
+
     if (isStream(responseBody)) {
       responseBody.on('data', function(d) {
         response.emit('data', d);

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -58,11 +58,7 @@ function startScope(basePath, options) {
         }
       }
 
-      if (typeof(body) === 'function') {
-        body = body.call(this, uri, requestBody);
-      }
-
-      if (typeof(body) !== 'string' && !Buffer.isBuffer(body) && !isStream(body)) {
+      if (typeof(body) !== 'string' && typeof(body) !== 'function' && !Buffer.isBuffer(body) && !isStream(body)) {
         try {
           body = JSON.stringify(body);
         } catch(err) {


### PR DESCRIPTION
The callback now receives the original request URI and request body, and evaluates per incoming request.
One can also use it to end an async testcase like this:

``` javascript
it("should exit when mocked request is sent", function(done) {
  var mock = nock("http://google.com")
  .filteringPath(/.*/, '*')
  .filteringRequestBody(/.*/, '*')
  .post("*", "*")
  .reply(200, function(uri, requestBody) {
    // uri and requestBody are the originals (before filtering)
    done();
  });
  [...]
}
```

ps: My next patch will enable the usage of regexps in post() and get(), to get rid of the superfluous filtering\* calls.
