### PR TITLE
accept options in `http.request()` to be a string

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -4,6 +4,7 @@ var RequestOverrider = require('./request_overrider'),
     inherits         = require('util').inherits,
     EventEmitter     = require('events').EventEmitter,
     http             = require('http'),
+    parse            = require('url').parse
     ClientRequest    = http.ClientRequest;
 
 
@@ -93,6 +94,7 @@ http.ClientRequest = OverridenClientRequest;
           req,
           res;
           
+      if (typeof options === 'string') { options = parse(options); }
       options.proto = proto;
       interceptors = interceptorsFor(options);
 

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -1508,3 +1508,25 @@ tap.test('post with object', function(t) {
   }).end('{"some_data":"something"}');
 
 });
+
+tap.test('accept string as request target', function(t) {
+  var scope = nock('http://www.example.com')
+    .get('/')
+    .reply(200, "Hello World!");
+
+  http.get('http://www.example.com', function(res) {
+    t.equal(res.statusCode, 200);
+
+    res.on('data', function(data) {
+      dataCalled = true;
+      t.ok(data instanceof Buffer, "data should be buffer");
+      t.equal(data.toString(), "Hello World!", "response should match");
+    });
+
+    res.on('end', function() {
+      t.ok(dataCalled);
+      scope.done();
+      t.end();
+    });
+  });
+});


### PR DESCRIPTION
See #71

`http.request()` API changed from node v0.6 to v0.8, it now accepts `options` to be a string

http://nodejs.org/docs/v0.6.0/api/http.html#http.request

http://nodejs.org/api/http.html#http_http_request_options_callback
