### PR TITLE
Add support for mocking http[s].get("http://string_url")

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -51,7 +51,7 @@ function interceptorsFor(options) {
   options.port = options.port || ((options.proto === 'http') ? 80 : 443);
   options.hostname = options.hostname || options.host.split(':')[0];
   options.host = options.hostname + ':' + options.port;
-  
+
   basePath = options.proto + '://' + options.host;
 
   return allInterceptors[basePath] || [];
@@ -72,7 +72,7 @@ function OverridenClientRequest(options, defaultPort) {
   } else {
     ClientRequest.apply(this, arguments);
   }
-  
+
 }
 inherits(OverridenClientRequest, ClientRequest);
 
@@ -86,13 +86,13 @@ http.ClientRequest = OverridenClientRequest;
     var moduleName = proto, // 1 to 1 match of protocol and module is fortunate :)
         module = require(moduleName),
         oldRequest = module.request;
-        
+
     module.request = function(options, callback) {
 
       var interceptors,
           req,
           res;
-          
+
       options.proto = proto;
       interceptors = interceptorsFor(options);
 
@@ -122,6 +122,15 @@ http.ClientRequest = OverridenClientRequest;
       }
 
     };
+
+    module.get = function(options, callback) {
+      if (typeof(options) === 'string') {
+        options = url.parse(options);
+      }
+      var req = module.request(options, callback);
+      req.end();
+      return req;
+    }
   }
 );
 


### PR DESCRIPTION
I was checking out the node docs, and they specify being able to do a http.get("url_here") request with just a string as opposed to a hash of options. Nock wasn't working out with that, so I added that in and wrote a test for it.
