### PR TITLE
Reply callbacks are broken for JSON objects

### DIFF
--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -167,7 +167,7 @@ tap.test("get with reply callback", function(t) {
   var scope = nock('http://www.google.com')
      .get('/')
      .reply(200, function() {
-        return 'OK!';
+        return { message: 'OK!' };
      });
 
   var req = http.request({
@@ -180,7 +180,7 @@ tap.test("get with reply callback", function(t) {
       t.end();
     });
     res.on('data', function(data) {
-      t.equal(data.toString(), 'OK!', 'response should match');
+      t.equal(data.toString(), JSON.stringify({ message: 'OK!' }), 'response should match');
     });
   });
 


### PR DESCRIPTION
 https://github.com/flatiron/nock/commit/86202c81aa1514d68c51360af13840ec3691e20b introduced a bug where JSON objects that are returned from a reply callback are completely ignored.

```
  not ok 17 response should match
      ---
        file:   /Users/theycallmeswift/dev/open-source/nock/tests/test_intercept.js
        line:   189
        column: 9
        stack:  
          - getCaller (/Users/theycallmeswift/dev/open-source/nock/node_modules/tap/lib/tap-assert.js:4
15:17)
          - assert (/Users/theycallmeswift/dev/open-source/nock/node_modules/tap/lib/tap-assert.js:20:1
6)
          - Function.equal (/Users/theycallmeswift/dev/open-source/nock/node_modules/tap/lib/tap-assert
.js:161:10)
          - Test._testAssert [as equal] (/Users/theycallmeswift/dev/open-source/nock/node_modules/tap/l
ib/tap-test.js:86:16)
          - IncomingMessage.<anonymous> (/Users/theycallmeswift/dev/open-source/nock/tests/test_interce
pt.js:189:9)
          - IncomingMessage.EventEmitter.emit (events.js:93:17)
          - end (/Users/theycallmeswift/dev/open-source/nock/lib/request_overrider.js:182:18)
          - end (/Users/theycallmeswift/dev/open-source/nock/lib/request_overrider.js:195:21)
          - process.startup.processNextTick.process._tickCallback (node.js:244:9)
        found:  
        wanted: {"message":"OK!"}
        diff:   |
          FOUND:  
          WANTED: {\"message\":\"OK!\"}
                  ^ (at position = 0)
      ...
```

Failing test case attached.
