### PR TITLE
Expose pendingMocks method on the nock object

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -326,6 +326,7 @@ function startScope(basePath, options) {
     , log: log
     , persist: _persist
     , shouldPersist: shouldPersist
+    , pendingMocks: pendingMocks
   };
 
   return scope;


### PR DESCRIPTION
I'm requesting that this method be publicly available.  

We have code that runs after our integration tests that will issue a warning if all mocks haven't been satisfied.  However, it'd be really useful to dump out _which_ mocks have been unsatisfied as well.

The `done` method would output these, but I don't really want an exception to be thrown.
