### PR TITLE
missing req property on response object from nocked response

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -50,6 +50,8 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
       i,
       l;
 
+  response.req = req;
+
   if (options.headers) {
     headers = options.headers;
     keys = Object.keys(headers);

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -1790,3 +1790,15 @@ test('allow string json spec', function(t) {
     t.end();
   });
 });
+
+test('has a req property on the response', function(t) {
+  var scope = nock('http://wtfjs.org').get('/like-wtf').reply(200);
+  req = http.request('http://wtfjs.org/like-wtf', function(res) {
+    res.on('end', function() {
+      t.ok(res.req, "req property doesn't exist");
+      scope.done();
+      t.end();
+    });
+  });
+  req.end();
+});


### PR DESCRIPTION
node's http.request puts the request object on the response under a property called 'req'. It looks like nock isn't doing the same thing. I'm not sure if there's a different way that you'd prefer this be fixed, but this passes the (previously failing) test case I just added and also works in the code I was trying to use nock in that was previously failing.
