### PR TITLE
Content-Type header can be capitalized

### DIFF
--- a/lib/match_body.js
+++ b/lib/match_body.js
@@ -11,17 +11,22 @@ function matchBody(spec, body) {
 
   // try to transform body to json
   var json;
+  console.log(options.headers)
   if (typeof spec == 'object') {
     try { json = JSON.parse(body);} catch(err) {}
     if (json !== undefined) body = json;
     else
       if (
         (typeof spec == 'object') &&
-        options.headers &&
-        options.headers['content-type'] &&
-        options.headers['content-type'].match(/application\/x-www-form-urlencoded/))
+        options.headers
+      )
       {
-        body = qs.parse(body);
+        var contentType = options.headers['Content-Type']
+                            || options.headers['content-type'];
+
+        if (contentType.match(/application\/x-www-form-urlencoded/)) {
+          body = qs.parse(body);
+        }
       }
   }
 


### PR DESCRIPTION
Hi,

   I was trying to mock a POST request with a body encoded with the content type "application/x-www-form-urlencoded" and found that the "Content-Type" header entry could be either capitalized or not.

   Example: [The Hipchat API](https://www.hipchat.com/docs/api/method/rooms/message)

   This fix make it work in both cases.

Hope it helps

Thank you

Aurélien

P.S: Build fix in another PR: https://github.com/flatiron/nock/pull/109
