### PR TITLE
[fix] remove console.log

### DIFF
--- a/lib/match_body.js
+++ b/lib/match_body.js
@@ -11,7 +11,6 @@ function matchBody(spec, body) {
 
   // try to transform body to json
   var json;
-  console.log(options.headers)
   if (typeof spec == 'object') {
     try { json = JSON.parse(body);} catch(err) {}
     if (json !== undefined) body = json;


### PR DESCRIPTION
A console.log was added as part of commit 1de8328 that fills STDOUT when running tests.

https://github.com/flatiron/nock/blob/1de832866b8decdbbe4498d8423c4296fabc778b/lib/match_body.js#L14

This patch removes the console.log. 
