### PR TITLE
Repeat response n times

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,18 @@ var scope = nock('http://my.server.com:8081')
   ...
 ```
 
+## Repeat response n times
+
+You are able to specify the number of times to repeat the same response.
+
+```js
+nock('http://zombo.com').get('/').times(2).reply(200, 'Ok');
+
+http.get('http://zombo.com/'); // respond body "Ok"
+http.get('http://zombo.com/'); // respond body "Ok"
+http.get('http://zombo.com/'); // respond with zombo.com result
+```
+
 ## Chaining
 
 You can chain behaviour like this:

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -54,6 +54,11 @@ function add(key, interceptor, scope) {
 
 function remove(interceptor) {
   if (interceptor.__nock_scope.shouldPersist()) return;
+  
+  if (interceptor.counter > 1) {
+    interceptor.counter -= 1;
+    return;
+  }
 
   var key          = interceptor._key.split(' '),
       u            = url.parse(key[1]),

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -174,9 +174,18 @@ function startScope(basePath, options) {
       interceptorMatchHeaders.push({ name: name, value: value });
       return this;
     }
+    
+    function times(newCounter) {
+      if (newCounter < 1) return this;
+      
+      this.counter = newCounter;
+
+      return this;
+    }
 
     var interceptor = {
         _key: key
+      , counter: 1
       , _requestBody: requestBody
       , reply: reply
       , replyWithFile: replyWithFile
@@ -185,6 +194,7 @@ function startScope(basePath, options) {
       , matchIndependentOfBody: matchIndependentOfBody
       , filteringPath: filteringPath
       , matchHeader: matchHeader
+      , times: times
     };
     
     return interceptor;

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -1803,7 +1803,7 @@ test('has a req property on the response', function(t) {
   req.end();
 });
 
-test("disabled real HTTP request", function(t) {
+test('disabled real HTTP request', function(t) {
   nock.disableNetConnect();
   
   try {
@@ -1818,7 +1818,7 @@ test("disabled real HTTP request", function(t) {
   nock.enableNetConnect();
 });
 
-test("enable real HTTP request only for google.com, via string", function(t) {
+test('enable real HTTP request only for google.com, via string', function(t) {
   nock.enableNetConnect('google.com');
   
   try {
@@ -1837,7 +1837,7 @@ test("enable real HTTP request only for google.com, via string", function(t) {
   nock.enableNetConnect();
 });
 
-test("enable real HTTP request only for google.com, via regexp", function(t) {
+test('enable real HTTP request only for google.com, via regexp', function(t) {
   nock.enableNetConnect(/google\.com/);
   
   try {
@@ -1853,5 +1853,27 @@ test("enable real HTTP request only for google.com, via regexp", function(t) {
     t.end();
   }
   
+  nock.enableNetConnect();
+});
+
+test('repeating response 2 times', function(t) {
+  nock.disableNetConnect();
+
+  var _mock = nock('http://zombo.com')
+    .get('/')
+    .times(2)
+    .reply(200, "Hello World!");
+
+  http.get('http://zombo.com', function(res) {
+    t.equal(200, res.statusCode, 'first request');
+  });
+
+  http.get('http://zombo.com', function(res) {
+    t.equal(200, res.statusCode, 'second request');
+  });
+  
+  nock.cleanAll()
+  t.end();
+
   nock.enableNetConnect();
 });


### PR DESCRIPTION
You are able to specify the number of times to repeat the same response.

``` js
nock('http://zombo.com').get('/').times(2).reply(200, 'Ok');

http.get('http://zombo.com/'); // respond body "Ok"
http.get('http://zombo.com/'); // respond body "Ok"
http.get('http://zombo.com/'); // respond with zombo.com result
```
