### PR TITLE
Match request with no hostname

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -140,7 +140,7 @@ function interceptorsFor(options) {
 }
 
 
-function activate() n{
+function activate() {
   // ----- Extending http.ClientRequest
 
   function OverridenClientRequest(options, cb) {


### PR DESCRIPTION
Node's http module allows to make requests without specifying a host or hostname, assuming 'localhost'. Such requests break when trying to be mocked by nock, that tries to split the host string.
