### PR TITLE
Delay a reply

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ var nock = require('nock');
 var couchdb = nock('http://myapp.iriscouch.com')
                 .get('/users/1')
                 .reply(200, {
-                  _id: '123ABC', 
-                  _rev: '946B7D1C', 
-                  username: 'pgte', 
+                  _id: '123ABC',
+                  _rev: '946B7D1C',
+                  username: 'pgte',
                   email: 'pedro.teixeira@gmail.com'
                  });
 ```
@@ -48,12 +48,12 @@ You can specify the request body to be matched as the second argument to the `ge
 ```js
 var scope = nock('http://myapp.iriscouch.com')
                 .post('/users', {
-                  username: 'pgte', 
+                  username: 'pgte',
                   email: 'pedro.teixeira@gmail.com'
                 })
                 .reply(201, {
-                  ok: true, 
-                  id: '123ABC', 
+                  ok: true,
+                  id: '123ABC',
                   rev: '946B7D1C'
                 });
 ```
@@ -84,8 +84,8 @@ or as a JSON-encoded object:
 var scope = nock('http://myapp.iriscouch.com')
                 .get('/')
                 .reply(200, {
-                  username: 'pgte', 
-                  email: 'pedro.teixeira@gmail.com', 
+                  username: 'pgte',
+                  email: 'pedro.teixeira@gmail.com',
                   _id: '4324243fsd'
                 });
 ```
@@ -109,6 +109,17 @@ var scope = nock('http://www.google.com')
    });
 ```
 
+
+A Stream works too:
+```js
+var scope = nock('http://www.google.com')
+   .get('/cat-poems')
+   .reply(200, function(uri, requestBody) {
+     return fs.createReadStream('cat-poems.txt');
+   });
+```
+
+
 ### Specifying Reply Headers
 
 You can specify the reply headers like this:
@@ -128,7 +139,7 @@ You can also specify default reply headers for all responses like this:
 ```js
 var scope = nock('http://www.headdy.com')
   .defaultReplyHeaders({
-    'X-Powered-By': 'Rails', 
+    'X-Powered-By': 'Rails',
     'Content-Type': 'application/json'
   })
   .get('/')
@@ -187,6 +198,19 @@ nock('http://zombo.com').get('/').twice().reply(200, 'Ok');
 nock('http://zombo.com').get('/').thrice().reply(200, 'Ok');
 ```
 
+## Delay the response
+
+You are able to specify the number of milliseconds that your reply should be delayed.
+
+```js
+nock('http://my.server.com')
+  .get('/')
+  .delay(2000) // 2 seconds
+  .reply(200, '<html></html>')
+```
+
+NOTE: the [`'response'`](http://nodejs.org/api/http.html#http_event_response) event will occur immediately, but the [IncomingMessage](http://nodejs.org/api/http.html#http_http_incomingmessage) not emit it's `'end'` event until after the delay.
+
 ## Chaining
 
 You can chain behaviour like this:
@@ -196,19 +220,19 @@ var scope = nock('http://myapp.iriscouch.com')
                 .get('/users/1')
                 .reply(404)
                 .post('/users', {
-                  username: 'pgte', 
+                  username: 'pgte',
                   email: 'pedro.teixeira@gmail.com'
                 })
                 .reply(201, {
-                  ok: true, 
-                  id: '123ABC', 
+                  ok: true,
+                  id: '123ABC',
                   rev: '946B7D1C'
                 })
                 .get('/users/123ABC')
                 .reply(200, {
-                  _id: '123ABC', 
-                  _rev: '946B7D1C', 
-                  username: 'pgte', 
+                  _id: '123ABC',
+                  _rev: '946B7D1C',
+                  username: 'pgte',
                   email: 'pedro.teixeira@gmail.com'
                 });
 ```

--- a/lib/delayed_body.js
+++ b/lib/delayed_body.js
@@ -1,0 +1,83 @@
+/**
+ * Creates a stream which becomes the response body of the interceptor when a
+ * delay is set. The stream outputs the intended body and EOF after the delay.
+ *
+ * @param  {String|Buffer|Stream} body - the body to write/pipe out
+ * @param  {Integer} ms - The delay in milliseconds
+ * @constructor
+ */
+module.exports = DelayedBody;
+
+var Transform = require('stream').Transform;
+var EventEmitter = require('events').EventEmitter;
+var noop = function () {};
+var util = require('util');
+
+function isStream(obj) {
+  var is = obj && (typeof a !== 'string') && (! Buffer.isBuffer(obj)) && (typeof obj.setEncoding == 'function');
+  return is;
+}
+
+if (!Transform) {
+  // for barebones compatibility for node < 0.10
+  var FakeTransformStream = function () {
+    EventEmitter.call(this);
+  };
+  util.inherits(FakeTransformStream, EventEmitter);
+  FakeTransformStream.prototype.pause = noop;
+  FakeTransformStream.prototype.resume = noop;
+  FakeTransformStream.prototype.setEncoding = noop;
+  FakeTransformStream.prototype.write = function (chunk, encoding) {
+    var self = this;
+    process.nextTick(function () {
+      self.emit('data', chunk, encoding);
+    });
+  };
+  FakeTransformStream.prototype.end = function (chunk) {
+    var self = this;
+    if (chunk) {
+      self.write(chunk);
+    }
+    process.nextTick(function () {
+      self.emit('end');
+    });
+  };
+
+  Transform = FakeTransformStream;
+}
+
+function DelayedBody(ms, body) {
+  Transform.call(this);
+
+  var self = this;
+  var data = '';
+  var ended = false;
+
+  if (isStream(body)) {
+    body.on('data', function (chunk) {
+      data += Buffer.isBuffer(chunk) ? chunk.toString() : chunk;
+    });
+
+    body.once('end', function () {
+      ended = true;
+    });
+
+    body.resume();
+  }
+
+  setTimeout(function () {
+    if (isStream(body) && !ended) {
+      body.once('end', function () {
+        self.end(data);
+      });
+    } else {
+      self.end(data || body);
+    }
+  }, ms);
+}
+util.inherits(DelayedBody, Transform);
+
+DelayedBody.prototype._transform = function (chunk, encoding, cb) {
+  this.push(chunk);
+  process.nextTick(cb);
+};

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -1,6 +1,7 @@
 var EventEmitter     = require('events').EventEmitter,
     http             = require('http'),
     propagate        = require('propagate'),
+    DelayedBody      = require('./delayed_body'),
     OutgoingMessage  = http.OutgoingMessage,
     ClientRequest    = http.ClientRequest;
   ;
@@ -176,6 +177,18 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
       responseBody = interceptor.body;
     }
 
+    if (responseBody && !Buffer.isBuffer(responseBody) && !isStream(responseBody)) {
+      if (typeof responseBody === 'string') {
+        responseBody = new Buffer(responseBody);
+      } else {
+        responseBody = JSON.stringify(responseBody);
+      }
+    }
+
+    if (interceptor.delayInMs) {
+      responseBody = new DelayedBody(interceptor.delayInMs, responseBody);
+    }
+
     if (isStream(responseBody)) {
       responseBody.on('data', function(d) {
         response.emit('data', d);
@@ -186,12 +199,6 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
       process.nextTick(function() {
         responseBody.resume();
       });
-    } else  if (responseBody && !Buffer.isBuffer(responseBody)) {
-      if (typeof responseBody === 'string') {
-        responseBody = new Buffer(responseBody);
-      } else {
-        responseBody = JSON.stringify(responseBody);
-      }
     }
 
     response.setEncoding = function(newEncoding) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1,4 +1,4 @@
-/** 
+/**
  * @module nock/scope
  */
 var path            = require('path')
@@ -26,9 +26,9 @@ function startScope(basePath, options) {
       urlParts = url.parse(basePath),
       port = urlParts.port || ((urlParts.protocol === 'http:') ? 80 : 443),
       persist = false;
-      
+
   basePath = urlParts.protocol + '//' + urlParts.hostname + ':' + port;
-  
+
   function add(key, interceptor, scope) {
     if (! interceptors.hasOwnProperty(key)) {
       interceptors[key] = [];
@@ -36,7 +36,7 @@ function startScope(basePath, options) {
     interceptors[key].push(interceptor);
     globalIntercept(basePath, interceptor, scope);
   }
-  
+
   function remove(key, interceptor) {
     if (persist) return;
     var arr = interceptors[key];
@@ -45,7 +45,7 @@ function startScope(basePath, options) {
       if (arr.length === 0) { delete interceptors[key]; }
     }
   }
-  
+
   function intercept(uri, method, requestBody, interceptorOptions) {
     var interceptorMatchHeaders = [];
     var key = method.toUpperCase() + ' ' + basePath + uri;
@@ -85,17 +85,18 @@ function startScope(basePath, options) {
       }
 
       this.body = body;
+
       add(key, this, scope);
       return scope;
     }
-    
+
     function replyWithFile(statusCode, filePath, headers) {
       var readStream = fs.createReadStream(filePath);
       readStream.pause();
       this.filePath = filePath;
       return reply.call(this, statusCode, readStream, headers);
     }
-    
+
     var matchStringOrRegexp = function(target, pattern) {
       if (pattern instanceof RegExp) {
         return target.match(pattern);
@@ -111,7 +112,7 @@ function startScope(basePath, options) {
         , path = options.path
         , matches
         , proto = options.proto;
-        
+
       if (transformPathFunction) { path = transformPathFunction(path); }
       if (typeof(body) !== 'string') {
         body = body.toString();
@@ -122,7 +123,7 @@ function startScope(basePath, options) {
       var checkHeaders = function(header) {
         return matchStringOrRegexp(options.getHeader(header.name), header.value);
       };
-      
+
       if (!matchHeaders.every(checkHeaders) ||
           !interceptorMatchHeaders.every(checkHeaders)) {
         return false;
@@ -148,7 +149,7 @@ function startScope(basePath, options) {
         , path = options.path
         , matches
         , proto = options.proto;
-        
+
       if (transformPathFunction) { path = transformPathFunction(path); }
 
       var checkHeaders = function(header) {
@@ -162,14 +163,14 @@ function startScope(basePath, options) {
       var matchKey = method + ' ' + proto + '://' + options.host + path;
       return this._key === matchKey
     }
-    
+
     function filteringPath() {
       if (typeof arguments[0] === 'function') {
         this.transformFunction = arguments[0];
       }
       return this;
     }
-    
+
     function discard() {
       if (persist && this.filePath) {
         this.body = fs.createReadStream(this.filePath);
@@ -183,7 +184,7 @@ function startScope(basePath, options) {
       interceptorMatchHeaders.push({ name: name, value: value });
       return this;
     }
-    
+
     /**
      * Set number of times will repeat the interceptor
      * @name times
@@ -195,12 +196,12 @@ function startScope(basePath, options) {
     */
     function times(newCounter) {
       if (newCounter < 1) return this;
-      
+
       this.counter = newCounter;
 
       return this;
     }
-    
+
     /**
      * An sugar sintaxe for times(1)
      * @name once
@@ -224,7 +225,7 @@ function startScope(basePath, options) {
     function twice() {
       return this.times(2);
     }
-    
+
     /**
      * An sugar sintaxe for times(3).
      * @name thrice
@@ -235,6 +236,17 @@ function startScope(basePath, options) {
     */
     function thrice() {
       return this.times(3);
+    }
+
+    /**
+     * Delay the response by a certain number of ms.
+     *
+     * @param  {integer} ms - Number of milliseconds to wait
+     * @return {scope} - the current scope for chaining
+     */
+    function delay(ms) {
+      this.delayInMs = ms;
+      return this;
     }
 
     var interceptor = {
@@ -252,15 +264,16 @@ function startScope(basePath, options) {
       , once: once
       , twice: twice
       , thrice: thrice
+      , delay: delay
     };
-    
+
     return interceptor;
   }
 
   function get(uri, requestBody, options) {
     return intercept(uri, 'GET', requestBody, options);
   }
-  
+
   function post(uri, requestBody, options) {
     return intercept(uri, 'POST', requestBody, options);
   }
@@ -268,7 +281,7 @@ function startScope(basePath, options) {
   function put(uri, requestBody, options) {
     return intercept(uri, 'PUT', requestBody, options);
   }
-  
+
   function head(uri, requestBody, options) {
     return intercept(uri, 'HEAD', requestBody, options);
   }
@@ -276,7 +289,7 @@ function startScope(basePath, options) {
   function patch(uri, requestBody, options) {
     return intercept(uri, 'PATCH', requestBody, options);
   }
-  
+
   function merge(uri, requestBody, options) {
     return intercept(uri, 'MERGE', requestBody, options);
   }
@@ -284,13 +297,13 @@ function startScope(basePath, options) {
   function _delete(uri, requestBody, options) {
     return intercept(uri, 'DELETE', requestBody, options);
   }
-  
+
   function pendingMocks() {
     return Object.keys(interceptors);
   }
-  
+
   function isDone() {
-    
+
     // if nock is turned off, it always says it's done
     if (! globalIntercept.isOn()) { return true; }
 
@@ -317,14 +330,14 @@ function startScope(basePath, options) {
       return (doneHostCount === keys.length);
     }
   }
-  
+
   function done() {
     assert.ok(isDone(), "Mocks not yet satisfied:\n" + pendingMocks().join("\n"));
   }
-  
+
   function buildFilter() {
     var filteringArguments = arguments;
-    
+
     if (arguments[0] instanceof RegExp) {
       return function(path) {
         if (path) {
@@ -343,7 +356,7 @@ function startScope(basePath, options) {
       throw new Error('Invalid arguments: filtering path should be a function or a regular expression');
     return this;
   }
-  
+
   function filteringRequestBody() {
     transformRequestBodyFunction = buildFilter.apply(undefined, arguments);
     if (!transformRequestBodyFunction)
@@ -360,7 +373,7 @@ function startScope(basePath, options) {
     this._defaultReplyHeaders = headers;
     return this;
   }
-  
+
   function log(newLogger) {
     logger = newLogger;
     return this;
@@ -374,7 +387,7 @@ function startScope(basePath, options) {
   function shouldPersist() {
     return persist;
   }
-  
+
   scope = {
       get: get
     , post: post


### PR DESCRIPTION
Added a delay function which causes the request to halt for N ms before replying. It is implemented by replacing the reply body with a stream which emits the original body after the timeout.

I believe it supports all of the possible reply methods, including replyWithFile and reply callbacks. If the reply callback returns a stream it will output the contents of that stream.

Includes tests and docs for the new functionality. (Sorry for the whitespace alterations.)

Closes #128
