### PR TITLE
Modified the way that streams are resumed

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -190,14 +190,12 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
     }
 
     if (isStream(responseBody)) {
+      responseBody.pause();
       responseBody.on('data', function(d) {
         response.emit('data', d);
       });
       responseBody.on('end', function() {
         response.emit('end');
-      });
-      process.nextTick(function() {
-        responseBody.resume();
       });
     } else  if (responseBody && !Buffer.isBuffer(responseBody)) {
       if (typeof responseBody === 'string') {
@@ -278,6 +276,9 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
         callback(response);
       }
       req.emit('response', response);
+      if (isStream(responseBody)) {
+        responseBody.resume();
+      }
       callnext();
     });
   };


### PR DESCRIPTION
Previously, streams were consumed by listening for "data" and "end" events, then proxying those to the response object sent back to the user. WIth streams2 though, attaching a listener for data causes the stream to be resumed and therefore starts the flow of data before a user can attach their own event listeners.

Now, when the response body is a stream it is manually paused and resumed so that we can still proxy the events, but give the user time to listen for them.

Closes #137
