### PR TITLE
POST not working on node 0.11.12

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -29,6 +29,8 @@ function setHeader(request, name, value) {
 
   request._headers = request._headers || {};
   request._headerNames = request._headerNames || {};
+  request._removedHeader = request._removedHeader || {};
+
   request._headers[key] = value;
   request._headerNames[key] = name;
 }

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -2093,6 +2093,20 @@ test('superagent works with query string', function(t) {
   });
 });
 
+test('superagent posts', function(t) {
+  nock('http://superagent.cz')
+    .post('/somepath?b=c')
+    .reply(204);
+
+  superagent
+  .post('http://superagent.cz/somepath?b=c')
+  .send('some data')
+  .end(function(err, res) {
+    t.equal(res.status, 204);
+    t.end();
+  });
+});
+
 test('response is streams2 compatible', function(t) {
   var responseText = 'streams2 streams2 streams2';
   nock('http://stream2hostnameftw')


### PR DESCRIPTION
I'm getting this error on node 0.11.12 (latest unstable with harmony generators)

```
_http_outgoing.js:341
    this._removedHeader[key] = false;
                             ^
TypeError: Cannot set property 'content-length' of undefined
```

my code is following:

```
var nock = require("nock");
var agent = require("thunkagent");

var google = nock("http://google.com")
        .post("/post")
    .reply(204);

var request = agent
    .post("http://google.com/post")
    .send({a: 1})
    .end();
```
