### PR TITLE
proxy error events when proxying a streamed response

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -200,6 +200,9 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
       responseBody.on('end', function() {
         response.emit('end');
       });
+      responseBody.on('error', function(err) {
+        response.emit('error', err);
+      });
     } else  if (responseBody && !Buffer.isBuffer(responseBody)) {
       if (typeof responseBody === 'string') {
         responseBody = new Buffer(responseBody);


### PR DESCRIPTION
When using a stream as the response body, proxy-ing it's `error` events provides a very basic way to emit errors from simulated responses.

I realize that it doesn't quite provide a framework for mocking network level errors, as stated in #97, but as an undocumented feature it would probably be more helpful then it would be harmful.

``` js
var serverMock = nock('http://esbox.1.com')
  .get('/')
  .reply(200, function () {
    // using the event-stream module to make the stream
    var str = es.readable(function (count, cb) {
      cb(new Error('force error'));
    });
    str.setEncoding = function () {}; // force nock's stream detection
    return str;
  });
```

Fixes #97
