### PR TITLE
Added loading of recorded objects

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -1,0 +1,97 @@
+
+var _ = require('lodash');
+var assert = require('assert');
+
+/**
+ * Normalizes the request options so that it always has `host` property.
+ *
+ * @param  {Object} options - a parsed options object of the request
+ */
+var normalizeRequestOptions = function(options) {
+  options.proto = options.proto || 'http';
+  options.port = options.port || ((options.proto === 'http') ? 80 : 443);
+  if (options.host) {
+    options.hostname = options.hostname || options.host.split(':')[0];
+  }
+  options.host = (options.hostname || 'localhost') + ':' + options.port;
+
+  return options;
+};
+
+/**
+ * Returns true if the data contained in buffer is binary which in this case means
+ * that it cannot be reconstructed from its utf8 representation.
+ *
+ * @param  {Object} buffer - a Buffer object
+ */
+var isBinaryBuffer = function(buffer) {
+
+  if(!Buffer.isBuffer(buffer)) {
+    return false;
+  }
+
+  //  Test if the buffer can be reconstructed verbatim from its utf8 encoding.
+  var utfEncodedBuffer = buffer.toString('utf8');
+  var reconstructedBuffer = new Buffer(utfEncodedBuffer, 'utf8');
+  var compareBuffers = function(lhs, rhs) {
+    if(lhs.length !== rhs.length) {
+      return false;
+    }
+
+    for(var i = 0; i < lhs.length; ++i) {
+      if(lhs[i] !== rhs[i]) {
+        return false;
+      }
+    }
+
+    return true;
+  };
+
+  //  If the buffers are *not* equal then this is a "binary buffer"
+  //  meaning that it cannot be faitfully represented in utf8.
+  return !compareBuffers(buffer, reconstructedBuffer);
+
+};
+
+/**
+ * If the chunks are Buffer objects then it returns a single Buffer object with the data from all the chunks.
+ * If the chunks are strings then it returns a single string value with data from all the chunks.
+ *
+ * @param  {Array} chunks - an array of Buffer objects or strings
+ */
+var mergeChunks = function(chunks) {
+
+  if(_.isEmpty(chunks)) {
+    return new Buffer(0);
+  }
+
+  //  We assume that all chunks are Buffer objects if the first is buffer object.
+  //  We later check this assumption.
+  var areBuffers = Buffer.isBuffer(_.first(chunks));
+
+  if(!areBuffers) {
+    //  When the chunks are not buffers we assume that they are strings.
+    return chunks.join('');
+  }
+
+  //  Merge all the buffers into a single Buffer object.
+  var size = 0;
+  chunks.forEach(function(chunk) {
+    assert(Buffer.isBuffer(chunk));
+    size += chunk.length;
+  });
+
+  var mergedChunks = new Buffer(size);
+  var copyToIndex = 0;
+  chunks.forEach(function(chunk) {
+    chunk.copy(mergedChunks, copyToIndex);
+    copyToIndex += chunk.length;
+  });
+
+  return mergedChunks;
+
+};
+
+exports.normalizeRequestOptions = normalizeRequestOptions;
+exports.isBinaryBuffer = isBinaryBuffer;
+exports.mergeChunks = mergeChunks;

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -1,9 +1,10 @@
-/** 
+/**
  * @module nock/intercepts
  */
 
 var RequestOverrider = require('./request_overrider'),
     mixin            = require('./mixin'),
+    normalizeRequestOptions = require('./common').normalizeRequestOptions,
     path             = require('path'),
     url              = require('url'),
     inherits         = require('util').inherits,
@@ -55,8 +56,8 @@ function enableNetConnect(matcher) {
 }
 
 function isEnabledForNetConnect(options) {
-  normalizeForRequest(options);
-  
+  normalizeRequestOptions(options);
+
   return allowNetConnect && allowNetConnect.test(options.host);
 }
 
@@ -89,7 +90,7 @@ function add(key, interceptor, scope) {
 
 function remove(interceptor) {
   if (interceptor.__nock_scope.shouldPersist()) return;
-  
+
   if (interceptor.counter > 1) {
     interceptor.counter -= 1;
     return;
@@ -118,21 +119,10 @@ function removeAll() {
   allInterceptors = {};
 }
 
-function normalizeForRequest(options) {
-  options.proto = options.proto || 'http';
-  options.port = options.port || ((options.proto === 'http') ? 80 : 443);
-  if (options.host) {
-    options.hostname = options.hostname || options.host.split(':')[0];
-  }
-  options.host = (options.hostname || 'localhost') + ':' + options.port;
-  
-  return options;
-}
-
 function interceptorsFor(options) {
   var basePath;
-  
-  normalizeForRequest(options);
+
+  normalizeRequestOptions(options);
 
   basePath = options.proto + '://' + options.host;
 
@@ -144,9 +134,11 @@ function activate() {
   // ----- Extending http.ClientRequest
 
   function OverridenClientRequest(options, cb) {
+    //  Filter the interceptors per request options.
     var interceptors = interceptorsFor(options);
 
     if (interceptors.length) {
+      //  Use filtered interceptors to intercept requests.
       var overrider = RequestOverrider(this, options, interceptors, remove, cb);
       for(var propName in overrider) {
         if (overrider.hasOwnProperty(propName)) {
@@ -154,29 +146,33 @@ function activate() {
         }
       }
     } else {
-      ClientRequest.apply(this, arguments);
+      //  Fallback to original ClientRequest if nock is off or the net connection is enabled.
+      if(isOff() || isEnabledForNetConnect(options)) {
+        ClientRequest.apply(this, arguments);
+      } else {
+        throw new NetConnectNotAllowedError(options.host);
+      }
     }
-    
   }
   inherits(OverridenClientRequest, ClientRequest);
 
   http.ClientRequest = OverridenClientRequest;
 
   // ----- Overriding http.request and https.request:
-  
-  [ 'http', 'https'].forEach(
+
+  ['http', 'https'].forEach(
     function(proto) {
 
       var moduleName = proto, // 1 to 1 match of protocol and module is fortunate :)
           module = require(moduleName),
           oldRequest = module.request;
-          
+
       module.request = function(options, callback) {
 
         var interceptors,
             req,
             res;
-            
+
         if (typeof options === 'string') { options = parse(options); }
         options.proto = proto;
         interceptors = interceptorsFor(options);

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -1,8 +1,10 @@
 var http = require('http');
 var https = require('https');
-var oldRequest = http.request;
+var oldHttpRequest = http.request;
 var oldHttpsRequest = https.request;
 var inspect = require('util').inspect;
+var parse = require('url').parse;
+var common = require('./common');
 
 var SEPARATOR = '\n<<<<<<-- cut here -->>>>>>\n';
 var recordingInProgress = false;
@@ -11,14 +13,22 @@ var outputs = [];
 
 function getScope(options) {
 
+  common.normalizeRequestOptions(options);
+
   var scope = [];
   if (options._https_) {
     scope.push('https://');
   } else {
     scope.push('http://');
   }
+
   scope.push(options.host);
-  if(options.port) {
+
+  //  If a non-standard port wasn't specified in options.host, include it from options.port.
+  if(options.host.indexOf(':') === -1
+    && options.port
+    && ((options._https_ && options.port.toString() !== '443')
+      || (!options._https_ && options.port.toString() !== '80'))) {
     scope.push(':');
     scope.push(options.port);
   }
@@ -33,47 +43,47 @@ function getMethod(options) {
 
 }
 
-function getRequestBody(body) {
+var getBodyFromChunks = function(chunks) {
 
-  var joinedBody = body.map(function(buffer) {
-    return buffer.toString('utf8');
-  }).join('');
+  var mergedBuffer = common.mergeChunks(chunks);
 
-  try {
-    return JSON.parse(joinedBody);
-  } catch(err) {
-    return joinedBody;
+  //  A buffer can be one of three things:
+  //    1.  A binary buffer which then has to be recorded as a hex string.
+  //    2.  A string buffer which represents a JSON object.
+  //    3.  A string buffer which doesn't represent a JSON object.
+
+  if(common.isBinaryBuffer(mergedBuffer)) {
+    return mergedBuffer.toString('hex');
+  } else {
+    var maybeStringifiedJson = mergedBuffer.toString('utf8');
+    try {
+      return JSON.parse(maybeStringifiedJson);
+    } catch(err) {
+      return maybeStringifiedJson;
+    }
   }
 
-}
+};
 
-function getResponseBody(body) {
-
-  return body.map(function(buffer) {
-    return buffer.toString('utf8');
-  }).join('');
-
-}
-
-function generateRequestAndResponseObject(body, options, res, datas) {
+function generateRequestAndResponseObject(req, bodyChunks, options, res, dataChunks) {
 
   return {
     scope:    getScope(options),
-    port:     options.port,
     method:   getMethod(options),
     path:     options.path,
-    body:     getRequestBody(body),
-    reply:    res.statusCode.toString(),
-    response: getResponseBody(datas),
-    headers:  res.headers ? inspect(res.headers) : undefined
+    body:     getBodyFromChunks(bodyChunks),
+    status:   res.statusCode,
+    response: getBodyFromChunks(dataChunks),
+    headers:  res.headers,
+    reqheaders:   req.headers
   };
 
 }
 
-function generateRequestAndResponse(body, options, res, datas) {
+function generateRequestAndResponse(req, bodyChunks, options, res, dataChunks) {
 
-  var requestBody = getRequestBody(body);
-  var responseBody = getResponseBody(datas);
+  var requestBody = getBodyFromChunks(bodyChunks);
+  var responseBody = getBodyFromChunks(dataChunks);
 
   var ret = [];
   ret.push('\nnock(\'');
@@ -89,6 +99,11 @@ function generateRequestAndResponse(body, options, res, datas) {
     ret.push(JSON.stringify(requestBody));
   }
   ret.push(")\n");
+  if (req.headers) {
+    for (var k in req.headers) {
+      ret.push('  .matchHeader(' + JSON.stringify(k) + ', ' + JSON.stringify(req.headers[k]) + ')\n');
+    }
+  }
 
   ret.push('  .reply(');
   ret.push(res.statusCode.toString());
@@ -103,7 +118,7 @@ function generateRequestAndResponse(body, options, res, datas) {
   return ret.join('');
 }
 
-function record(options) {
+function record(rec_options) {
 
   //  Trying to start recording with recording already in progress implies an error
   //  in the recording configuration (double recording makes no sense and used to lead
@@ -116,30 +131,37 @@ function record(options) {
 
   //  Originaly the parameters was a dont_print boolean flag.
   //  To keep the existing code compatible we take that case into account.
-  var dont_print = (typeof options === 'boolean' && options)
-    || (typeof options === 'object' && options.dont_print);
-  var output_objects = typeof options === 'object' && options.output_objects;
+  var dont_print = (typeof rec_options === 'boolean' && rec_options)
+    || (typeof rec_options === 'object' && rec_options.dont_print);
+  var output_objects = typeof rec_options === 'object' && rec_options.output_objects;
 
   [http, https].forEach(function(module) {
-    var oldRequest = module.request;
+    var overwrittenModuleRequest = module.request;
+
     module.request = function(options, callback) {
 
-    var body = []
+    var bodyChunks = []
       , req, oldWrite, oldEnd;
 
-    req = oldRequest.call(http, options, function(res) {
-      var datas = [];
+    req = overwrittenModuleRequest.call(http, options, function(res) {
+
+      if (typeof options === 'string') { options = parse(options); }
+
+      var dataChunks = [];
 
       res.on('data', function(data) {
-        datas.push(data);
+        dataChunks.push(data);
       });
 
       if (module === https) { options._https_ = true; }
 
       res.once('end', function() {
-        var out = !output_objects ?
-          generateRequestAndResponse(body, options, res, datas) :
-          generateRequestAndResponseObject(body, options, res, datas);
+        var out;
+        if(output_objects) {
+          out = generateRequestAndResponseObject(req, bodyChunks, options, res, dataChunks);
+        } else {
+          out = generateRequestAndResponse(req, bodyChunks, options, res, dataChunks);
+        }
 
         outputs.push(out);
         if (! dont_print) { console.log(SEPARATOR + out + SEPARATOR); }
@@ -153,7 +175,7 @@ function record(options) {
     oldWrite = req.write;
     req.write = function(data) {
       if ('undefined' !== typeof(data)) {
-        if (data) {body.push(data); }
+        if (data) {bodyChunks.push(data); }
         oldWrite.call(req, data);
       }
     };
@@ -164,7 +186,7 @@ function record(options) {
 }
 
 function restore() {
-  http.request = oldRequest;
+  http.request = oldHttpRequest;
   https.request = oldHttpsRequest;
   recordingInProgress = false;
 }

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -4,6 +4,7 @@ var EventEmitter     = require('events').EventEmitter,
     DelayedBody      = require('./delayed_body'),
     OutgoingMessage  = http.OutgoingMessage,
     ClientRequest    = http.ClientRequest;
+    common           = require('./common')
   ;
 
 function stringifyRequest(options, body) {
@@ -101,8 +102,6 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
     }
   };
 
-  var oldEnd = req.end;
-
   req.end = function(buffer, encoding) {
     if (!aborted && !ended) {
       req.write(buffer, encoding);
@@ -131,18 +130,13 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
         paused,
         next = [];
 
-    var requestBodySize = 0;
-    var copyTo = 0;
-    requestBodyBuffers.forEach(function(b) {
-      requestBodySize += b.length;
-    });
-    requestBody = new Buffer(requestBodySize);
-    requestBodyBuffers.forEach(function(b) {
-    b.copy(requestBody, copyTo);
-      copyTo += b.length;
-    });
-
-    requestBody = requestBody.toString();
+    requestBodyBuffer = common.mergeChunks(requestBodyBuffers);
+    var isBinaryRequestBodyBuffer = common.isBinaryBuffer(requestBodyBuffer);
+    if(isBinaryRequestBodyBuffer) {
+      requestBody = requestBodyBuffer.toString('hex');
+    } else {
+      requestBody = requestBodyBuffer.toString('utf8');
+    }
 
     /// put back the path into options
     /// because bad behaving agents like superagent
@@ -163,12 +157,14 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
         if (interceptor.options.allowUnmocked) {
           var newReq = new ClientRequest(options, cb);
           propagate(newReq, req);
-          newReq.end(requestBody);
+          //  We send the raw buffer as we received it, not as we interpreted it.
+          newReq.end(requestBodyBuffer);
           return;
         }
       }
       throw new Error("Nock: No match for HTTP request " + stringifyRequest(options, requestBody));
     }
+
     interceptor = interceptors.shift();
 
     response.statusCode = interceptor.statusCode || 200;
@@ -178,6 +174,12 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
       responseBody = interceptor.body(options.path, requestBody) || '';
     } else {
       responseBody = interceptor.body;
+
+      //  If the request was binary then we assume that the response will be binary as well.
+      //  In that case we send the response as a Buffer object as that's what the client will expect.
+      if(isBinaryRequestBodyBuffer && typeof(responseBody) === 'string') {
+        responseBody = new Buffer(responseBody, 'hex');
+      }
     }
 
     if (responseBody && !Buffer.isBuffer(responseBody) && !isStream(responseBody)) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -7,7 +7,8 @@ var path            = require('path')
   , mixin           = require('./mixin')
   , matchBody       = require('./match_body')
   , assert          = require('assert')
-  , url             = require('url');
+  , url             = require('url')
+  , _               = require('lodash');
 
 var noop = function() {};
 
@@ -435,9 +436,100 @@ function cleanAll() {
   return module.exports;
 }
 
+function loadDefs(path) {
+  var contents = fs.readFileSync(path);
+  return JSON.parse(contents);
+}
+
+function load(path) {
+  return define(loadDefs(path));
+}
+
+function getStatusFromDefinition(nockDef) {
+  //  Backward compatibility for when `status` was encoded as string in `reply`.
+  if(!_.isUndefined(nockDef.reply)) {
+    //  Try parsing `reply` property.
+    var parsedReply = parseInt(nockDef.reply, 10);
+    if(_.isNumber(parsedReply)) {
+      return parsedReply;
+    }
+  }
+
+  var DEFAULT_STATUS_OK = 200;
+  return nockDef.status || DEFAULT_STATUS_OK;
+}
+
+function getScopeFromDefinition(nockDef) {
+
+  //  Backward compatibility for when `port` was part of definition.
+  if(!_.isUndefined(nockDef.port)) {
+    //  Include `port` into scope if it doesn't exist.
+    var options = url.parse(nockDef.scope);
+    if(_.isNull(options.port)) {
+      return nockDef.scope + ':' + nockDef.port;
+    } else {
+      if(parseInt(options.port) !== parseInt(nockDef.port)) {
+        throw new Error('Mismatched port numbers in scope and port properties of nock definition.');
+      }
+    }
+  }
+
+  return nockDef.scope;
+}
+
+function tryJsonParse(string) {
+  try {
+    return JSON.parse(string);
+  } catch(err) {
+    return string;
+  }
+}
+
+function define(nockDefs) {
+
+  var nocks     = [];
+
+  nockDefs.forEach(function(nockDef) {
+
+    var nscope     = getScopeFromDefinition(nockDef)
+      , npath      = nockDef.path
+      , method     = nockDef.method.toLowerCase() || "get"
+      , status     = getStatusFromDefinition(nockDef)
+      //  Response is not always JSON (it could be a string or binary data)
+      , response   = nockDef.response ? tryJsonParse(nockDef.response) : ''
+      , headers    = nockDef.headers    || {}
+      , reqheaders = nockDef.reqheaders || {}
+      , body       = nockDef.body       || ''
+      , options    = nockDef.options    || {};
+
+    var nock;
+    if(body==="*") {
+      nock = startScope(nscope, options).filteringRequestBody(function() {
+        return "*";
+      })[method](nscope, "*").reply(status, response, headers);
+    } else {
+      nock = startScope(nscope, options);
+      if(reqheaders !== {}) {
+        for (var k in reqheaders) {
+          nock = nock.matchHeader(k, reqheaders[k]);
+        }
+      }
+      nock.intercept(npath, method, body).reply(status, response, headers);
+    }
+
+    nocks.push(nock);
+
+  });
+
+  return nocks;
+}
+
 module.exports = startScope;
 
 module.exports.cleanAll = cleanAll;
 module.exports.activate = globalIntercept.activate;
-module.exports.disableNetConnect = globalIntercept.disableNetConnect
-module.exports.enableNetConnect = globalIntercept.enableNetConnect
+module.exports.disableNetConnect = globalIntercept.disableNetConnect;
+module.exports.enableNetConnect = globalIntercept.enableNetConnect;
+module.exports.load = load;
+module.exports.loadDefs = loadDefs;
+module.exports.define = define;

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     },
     {
       "name": "Ivan Erceg",
+      "url": "https://github.com/ierceg",
       "email": "ivan@softwaremarbles.com"
     }
   ],
@@ -98,7 +99,8 @@
   ],
   "main": "./index",
   "dependencies": {
-    "propagate": "0.2.x"
+    "propagate": "0.2.x",
+    "lodash": "2.4.1"
   },
   "devDependencies": {
     "tap": "*",

--- a/tests/test_recorder.js
+++ b/tests/test_recorder.js
@@ -6,8 +6,7 @@ tap.test('records', function(t) {
   nock.restore();
   nock.recorder.clear();
   t.equal(nock.recorder.play().length, 0);
-  var cb1 = false
-    , options = { method: 'POST'
+  var options = { method: 'POST'
                 , host:'google.com'
                 , port:80
                 , path:'/' }
@@ -16,7 +15,6 @@ tap.test('records', function(t) {
   nock.recorder.rec(true);
   var req = http.request(options, function(res) {
     res.resume();
-    cb1 = true;
     var ret;
     res.once('end', function() {
       nock.restore();
@@ -34,8 +32,7 @@ tap.test('records objects', function(t) {
   nock.restore();
   nock.recorder.clear();
   t.equal(nock.recorder.play().length, 0);
-  var cb1 = false
-    , options = { method: 'POST'
+  var options = { method: 'POST'
                 , host:'google.com'
                 , path:'/' }
   ;
@@ -46,7 +43,6 @@ tap.test('records objects', function(t) {
   });
   var req = http.request(options, function(res) {
     res.resume();
-    cb1 = true;
     var ret;
     res.once('end', function() {
       nock.restore();
@@ -54,11 +50,10 @@ tap.test('records objects', function(t) {
       t.equal(ret.length, 1);
       var ret = ret[0];
       t.type(ret, 'object');
-      t.equal(ret.scope.indexOf("http://google.com"), 0);
-      t.equal(ret.method.indexOf("POST"), 0);
-      t.ok(typeof(ret.reply) !== 'undefined');
+      t.equal(ret.scope, "http://google.com:80");
+      t.equal(ret.method, "POST");
+      t.ok(typeof(ret.status) !== 'undefined');
       t.ok(typeof(ret.response) !== 'undefined');
-      t.ok(typeof(ret.port) === 'undefined');
       t.end();
     });
   });
@@ -84,7 +79,8 @@ tap.test('when request body is json, it goes unstringified', function(t) {
   var options = {
     method: 'POST',
     host: 'www.google.com',
-    path: '/', port: 80
+    path: '/',
+    port: 80
   };
 
   nock.restore();
@@ -99,7 +95,7 @@ tap.test('when request body is json, it goes unstringified', function(t) {
       ret = ret[1] || ret[0];
       t.equal(ret.indexOf("\nnock('http://www.google.com:80')\n  .post('/', {\"a\":1,\"b\":true})\n  .reply("), 0);
       t.end();
-    })
+    });
   });
 
   request.end(JSON.stringify(payload));
@@ -128,14 +124,13 @@ tap.test('when request body is json, it goes unstringified in objects', function
       t.ok(ret.length >= 1);
       ret = ret[1] || ret[0];
       t.type(ret, 'object');
-      t.equal(ret.scope.indexOf("http://www.google.com"), 0);
-      t.equal(ret.port, 80);
-      t.equal(ret.method.indexOf("POST"), 0);
+      t.equal(ret.scope, "http://www.google.com:80");
+      t.equal(ret.method, "POST");
       t.ok(ret.body && ret.body.a && ret.body.a === payload.a && ret.body.b && ret.body.b === payload.b);
-      t.ok(typeof(ret.reply) !== 'undefined');
+      t.ok(typeof(ret.status) !== 'undefined');
       t.ok(typeof(ret.response) !== 'undefined');
       t.end();
-    })
+    });
   });
 
   request.end(JSON.stringify(payload));
@@ -146,11 +141,12 @@ tap.test('rec() throws when reenvoked with already recorder requests', function(
   nock.recorder.clear();
   t.equal(nock.recorder.play().length, 0);
 
-  nock.recorder.rec(true);
+  nock.recorder.rec();
   try {
-    nock.recorder.rec(true);
+    nock.recorder.rec();
     //  This line should never be reached.
     t.ok(false);
+    t.end();
   } catch(e) {
     t.end();
   }


### PR DESCRIPTION
Fixed support for binary buffers
Added request headers to recorded objects
Obsoleted port and reply recorded properties but kept backward compatibility
Unified request options normalisation, buffer merging, etc. for scope and recorder
Fixed disabled net access for unfiltered requests
Fixed bad header recording for objects
Minor refactoring for clarity (e.g. renaming oldRequest to oldHttpRequest to be the same as oldHttpsRequest)

This is a bigger update but things depend on each other a bit so I decided to push it as one instead of splitting it up in 4 or 5 pull requests.
