### PR TITLE
Added nock.isActive()

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -229,6 +229,14 @@ function restoreOverriddenClientRequest() {
   }
 }
 
+function isActive() {
+
+  //  If ClientRequest has been overwritten by Nock then originalClientRequest is not undefined.
+  //  This means that Nock has been activated.
+  return !_.isUndefined(originalClientRequest);
+
+}
+
 function activate() {
 
   if(originalClientRequest) {
@@ -293,6 +301,7 @@ module.exports = add;
 module.exports.removeAll = removeAll;
 module.exports.isOn = isOn;
 module.exports.activate = activate;
+module.exports.isActive = isActive;
 module.exports.enableNetConnect = enableNetConnect;
 module.exports.disableNetConnect = disableNetConnect;
 module.exports.overrideClientRequest = overrideClientRequest;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -566,6 +566,7 @@ module.exports = startScope;
 
 module.exports.cleanAll = cleanAll;
 module.exports.activate = globalIntercept.activate;
+module.exports.isActive = globalIntercept.isActive;
 module.exports.disableNetConnect = globalIntercept.disableNetConnect;
 module.exports.enableNetConnect = globalIntercept.enableNetConnect;
 module.exports.load = load;

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -12,14 +12,17 @@ var _       = require('lodash');
 
 test("double activation throws exception", function(t) {
   nock.restore();
+  t.false(nock.isActive());
   try {
     nock.activate();
+    t.true(nock.isActive());
     nock.activate();
     //  This line should never be reached.
     t.false(true);
   } catch(e) {
     t.equal(e.toString(), 'Error: Nock already active');
   }
+  t.true(nock.isActive());
   t.end();
 });
 
@@ -1820,6 +1823,7 @@ test('(re-)activate after restore', function(t) {
     .reply(200, 'Hello, World!');
 
   nock.restore();
+  t.false(nock.isActive());
 
   http.get('http://google.com/', function(res) {
     res.resume();
@@ -1827,6 +1831,7 @@ test('(re-)activate after restore', function(t) {
       t.ok(!scope.isDone());
 
       nock.activate();
+      t.true(nock.isActive());
       http.get('http://google.com', function(res) {
         res.resume();
         res.on('end', function() {

--- a/tests/test_recorder.js
+++ b/tests/test_recorder.js
@@ -8,12 +8,15 @@ tap.test('recording turns off nock interception (backward compatibility behavior
 
   //  We ensure that there are no overrides.
   nock.restore();
+  t.false(nock.isActive());
   //  We active the nock overriding - as it's done by merely loading nock.
   nock.activate();
+  t.true(nock.isActive());
   //  We start recording.
   nock.recorder.rec();
-  //  Nothing happens - which was the original behavior.
-  t.ok(true);
+  //  Nothing happens (nothing has been thrown) - which was the original behavior -
+  //  and mocking has been deactivated.
+  t.false(nock.isActive());
 
   t.end();
 


### PR DESCRIPTION
`nock.isActive()` returns `true` when mocking is active, `false` after `restore()`. Since recording turns off mocking, it will also return `false` during and after recording.
