### PR TITLE
Fixed response not resuming on drain

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -60,6 +60,7 @@ function setRequestHeaders(req, options, interceptor) {
 }
 
 function RequestOverrider(req, options, interceptors, remove, cb) {
+
   var response = new OutgoingMessage(new EventEmitter()),
       requestBodyBuffers = [],
       originalInterceptors = interceptors,
@@ -178,6 +179,8 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
       throw new Error("Nock: No match for request " + common.stringifyRequest(options, requestBody));
     }
 
+    debug('interceptor identified, starting mocking');
+
     interceptor = interceptors.shift();
 
     response.statusCode = interceptor.statusCode || 200;
@@ -237,6 +240,8 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
 
     //  Transform the response body if it exists (it may not exist if we have `responseBuffers` instead)
     if(responseBody) {
+      debug('transform the response body');
+
       if (!Buffer.isBuffer(responseBody) && !isStream(responseBody)) {
         if (typeof responseBody === 'string') {
           responseBody = new Buffer(responseBody);
@@ -246,10 +251,12 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
       }
 
       if (interceptor.delayInMs) {
+        debug('delaying the response for', interceptor.delayInMs, 'milliseconds');
         responseBody = new DelayedBody(interceptor.delayInMs, responseBody);
       }
 
       if (isStream(responseBody)) {
+        debug('response body is a stream');
         responseBody.pause();
         responseBody.on('data', function(d) {
           response.emit('data', d);
@@ -270,15 +277,17 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
       }
     }
 
-    response.setEncoding = function(newEncoding) {
-      encoding = newEncoding;
-    };
     remove(interceptor);
     interceptor.discard();
 
     if (aborted) { return; }
 
+    response.setEncoding = function(newEncoding) {
+      encoding = newEncoding;
+    };
+
     response.pause = function() {
+      debug('pausing mocking');
       paused = true;
       if (isStream(responseBody)) {
         responseBody.pause();
@@ -286,6 +295,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
     };
 
     response.resume = function() {
+      debug('resuming mocking');
       paused = false;
       if (isStream(responseBody)) {
         responseBody.resume();
@@ -295,6 +305,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
 
     var read = false;
     response.read = function() {
+      debug('reading response body');
       if (isStream(responseBody) && responseBody.read) {
         return responseBody.read();
       } else if (! read) {
@@ -302,6 +313,13 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
         return responseBody;
       }
     };
+
+    //  HACK: Flag our response object as readable so that it can be automatically
+    //    resumed by Node when drain happens. This enables working with some agents
+    //    that behave differently than built-in agent (e.g. needle, superagent).
+    //    The correct way to implement this would be to use IncomingMessage instead
+    //    of OutgoingMessage class to mock responses.
+    response.readable = true;
 
     //  `mockEmits` is an array of emits to be performed during mocking.
     if (typeof responseBody !== "undefined") {
@@ -333,11 +351,14 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
 
     if (!isStream(responseBody)) {
       mockEmits.push(function() {
+        debug('emitting end');
         response.emit('end');
       });
     }
 
     function mockNextEmit() {
+      debug('mocking next emit');
+
       //  We don't use `process.nextTick` because we *want* (very much so!)
       //  for I/O to happen before the next `emit` since we are precisely mocking I/O.
       //  Otherwise the writing to output pipe may stall invoking pause()
@@ -345,6 +366,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
       //  with Node v0.10.26)
       setTimeout(function() {
         if (paused || mockEmits.length === 0 || aborted) {
+          debug('mocking paused, aborted or finished');
           return;
         }
 
@@ -356,21 +378,30 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
       }, 0);
     }
 
+    debug('mocking', mockEmits.length, 'emits');
+
     process.nextTick(function() {
-      var respond = function(){
+      var respond = function() {
+        debug('emitting response');
+
         if (typeof cb === 'function') {
+          debug('callback with response');
           cb(response);
         }
+
         req.emit('response', response);
+
         if (isStream(responseBody)) {
+          debug('resuming response stream');
           responseBody.resume();
         }
+
         mockNextEmit();
       };
 
       if (interceptor.delayConnectionInMs && interceptor.delayConnectionInMs > 0) {
         setTimeout(respond, interceptor.delayConnectionInMs);
-      }else{
+      } else {
         respond();
       }
     });

--- a/package.json
+++ b/package.json
@@ -106,7 +106,8 @@
   "devDependencies": {
     "tap": "*",
     "request": "*",
-    "superagent": "~0.15.7"
+    "superagent": "~0.15.7",
+    "needle": "^0.7.1"
   },
   "scripts": {
     "test": "node node_modules/tap/bin/tap.js --dd tests"

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -1,3 +1,4 @@
+
 var fs      = require('fs');
 var nock    = require('../.');
 var http    = require('http');
@@ -9,6 +10,7 @@ var test    = require('tap').test;
 var mikealRequest = require('request');
 var superagent = require('superagent');
 var _       = require('lodash');
+var needle  = require("needle");
 
 test("double activation throws exception", function(t) {
   nock.restore();
@@ -2664,4 +2666,22 @@ test('sending binary and receiving JSON should work ', function(t) {
       t.end();
     }
   );
+});
+
+test('fix #146 - resume() is automatically invoked when the response is drained', function(t) {
+  var replyLength = 1024 * 1024;
+  var replyBuffer = new Buffer((new Array(replyLength + 1)).join("."));
+  t.equal(replyBuffer.length, replyLength);
+
+  nock("http://www.abc.com")
+    .get("/abc")
+    .reply(200, replyBuffer);
+
+  needle.get("http://www.abc.com/abc", function(err, res, buffer) {
+    t.notOk(err);
+    t.ok(res);
+    t.ok(buffer);
+    t.equal(buffer, replyBuffer);
+    t.end();
+  });
 });


### PR DESCRIPTION
This fixes #146 by marking `OutgoingMessage` (a writable stream) as readable allowing resuming of mocking by Node itself (deep in its streams library) when drained. This is a hack obviously but it works. I think that the proper way to actually solve this is to make `response` be a `IncomingMessage` (as that's what we are mocking - incoming messages) but I got all sorts of errors when I started down that path so I let it be for now.
