### PR TITLE
setTimeout 0 never fires, under certain circumstances

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -364,7 +364,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
       //  Otherwise the writing to output pipe may stall invoking pause()
       //  without ever calling resume() (the observed was behavior on superagent
       //  with Node v0.10.26)
-      setTimeout(function() {
+      setImmediate(function() {
         if (paused || mockEmits.length === 0 || aborted) {
           debug('mocking paused, aborted or finished');
           return;
@@ -375,7 +375,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
 
         //  Recursively invoke to mock the next emit after the last one was handled.
         mockNextEmit();
-      }, 0);
+      });
     }
 
     debug('mocking', mockEmits.length, 'emits');


### PR DESCRIPTION
There was a regression in 0.31.1 (commit af16109) which causes my test suite to hang at a certain point. I traced the issue to `lib/request_overrider.js` line 367: the callback passed to `setTimeout` is never run under some circumstances. This happens deep into my test suite, after many successful uses of `nock` (i.e. the `setTimeout` works as intended earlier in the suite). Indeed, if I run just the offending part of the suite, in isolation, then it passes. I am fairly confident that this isn't just the result of poorly written/fragile tests: I tried skipping the file and subsequent parts of the suite hangs in the same manner. Unfortunately, I don't have a simple test case to share, and I can't share my suite of tests. My guess is that this has something to do with accumulated state in `nock`, or a limitation on concurrent timers in node.js.

I noticed that changing `setTimeout 0` to `setImmediate` (or `process.nextTick`) resolves the issue in my case, but I don't have a deeper understanding of why that is or whether it's a general fix. @ierceg please review when you have a chance.
