### PR TITLE
Change NetConnectNotAllowedError to inherit Error

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -26,6 +26,8 @@ function NetConnectNotAllowedError(host) {
   this.name    = 'NetConnectNotAllowedError';
 }
 
+inherits(NetConnectNotAllowedError, Error);
+
 var allInterceptors = {},
     allowNetConnect = /.*/;
 


### PR DESCRIPTION
The NetConnectNotAllowedError did not inherit from an actual Error class.

This came up while integrating nock with our generator-based test suite.
