### PR TITLE
Fix stack trace not captured when throwing error

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -22,8 +22,12 @@ var RequestOverrider = require('./request_overrider'),
  * // throw NetConnectNotAllowedError
  */
 function NetConnectNotAllowedError(host) {
-  this.message = 'Nock: Not allow net connect for "' + host + '"';
+  Error.call(this);
+
   this.name    = 'NetConnectNotAllowedError';
+  this.message = 'Nock: Not allow net connect for "' + host + '"';
+
+  Error.captureStackTrace(this, this.constructor);
 }
 
 inherits(NetConnectNotAllowedError, Error);

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -2019,6 +2019,36 @@ test('disabled real HTTP request', function(t) {
   nock.enableNetConnect();
 });
 
+test('NetConnectNotAllowedError is instance of Error', function(t) {
+  nock.disableNetConnect();
+
+  try {
+    http.get('http://www.amazon.com', function(res) {
+      throw "should not request this";
+    });
+  } catch(err) {
+    t.type(err, 'Error');
+    t.end();
+  }
+
+  nock.enableNetConnect();
+});
+
+test('NetConnectNotAllowedError exposes the stack', function(t) {
+  nock.disableNetConnect();
+
+  try {
+    http.get('http://www.amazon.com', function(res) {
+      throw "should not request this";
+    });
+  } catch(err) {
+    t.notEqual(err.stack, undefined);
+    t.end();
+  }
+
+  nock.enableNetConnect();
+});
+
 test('enable real HTTP request only for google.com, via string', function(t) {
   nock.enableNetConnect('google.com');
 


### PR DESCRIPTION
The stack trace was not being captured for the NetConnectNotAllowedError. I also took the opportunity to add tests for the Error instance.
