### PR TITLE
Allow matching header with a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,19 @@ var scope = nock('http://api.myservice.com')
                 })
 ```
 
+You can also use a function for the header body.
+
+```js
+var scope = nock('http://api.myservice.com')
+                .matchHeader('content-length', function (val) {
+                  return val >= 1000;
+                })
+                .get('/')
+                .reply(200, {
+                  data: 'hello world'
+                })
+```
+
 ## Allow __unmocked__ requests on a mocked hostname
 
 If you need some request on the same host name to be mocked and some others to **really** go through the HTTP stack, you can use the `allowUnmocked` option like this:

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -138,6 +138,9 @@ function startScope(basePath, options) {
       }
 
       var checkHeaders = function(header) {
+        if (typeof header.value === 'function') {
+          return header.value(options.getHeader(header.name));
+        }
         return matchStringOrRegexp(options.getHeader(header.name), header.value);
       };
 

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -535,6 +535,36 @@ test("match headers with regexp", function(t) {
 
 });
 
+test("match headers with function", function(t) {
+  var scope = nock('http://www.headier.com')
+     .get('/')
+     .matchHeader('x-my-headers', function (val) {
+        return val > 123;
+     })
+     .reply(200, "Hello World!");
+
+  http.get({
+     host: "www.headier.com"
+    , method: 'GET'
+    , path: '/'
+    , port: 80
+    , headers: {'X-My-Headers': 456}
+  }, function(res) {
+    res.setEncoding('utf8');
+    t.equal(res.statusCode, 200);
+
+    res.on('data', function(data) {
+      t.equal(data, 'Hello World!');
+    });
+
+    res.on('end', function() {
+      scope.done();
+      t.end();
+    });
+  });
+
+});
+
 test("match all headers", function(t) {
   var scope = nock('http://api.headdy.com')
      .matchHeader('accept', 'application/json')


### PR DESCRIPTION
e.g.:

``` js
var scope = nock('http://api.myservice.com')
                .matchHeader('content-length', function (val) {
                  return val >= 1000;
                })
                .get('/')
                .reply(200, {
                  data: 'hello world'
                })
```
