### PR TITLE
NetConnectNotAllowedErrors should be reported through the 'error' event, not thrown

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -177,6 +177,15 @@ function interceptorsFor(options) {
 //  (which might or might not be node's original http.ClientRequest)
 var originalClientRequest;
 
+function ErroringClientRequest(error) {
+  http.OutgoingMessage.call(this);
+  process.nextTick(function() {
+     this.emit('error', error);
+  }.bind(this));
+}
+
+inherits(ErroringClientRequest, http.ClientRequest);
+
 function overrideClientRequest() {
   debug('Overriding ClientRequest');
 
@@ -210,7 +219,10 @@ function overrideClientRequest() {
       if(isOff() || isEnabledForNetConnect(options)) {
         originalClientRequest.apply(this, arguments);
       } else {
-        throw new NetConnectNotAllowedError(options.host);
+        process.nextTick(function () {
+          var error = new NetConnectNotAllowedError(options.host);
+          this.emit('error', error);
+        }.bind(this));
       }
     }
   }
@@ -297,7 +309,8 @@ function activate() {
       if (isOff() || isEnabledForNetConnect(options)) {
         return overriddenRequest(options, callback);
       } else {
-        throw new NetConnectNotAllowedError(options.host);
+        var error = new NetConnectNotAllowedError(options.host);
+        return new ErroringClientRequest(error);
       }
     }
   });

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -2066,14 +2066,12 @@ test('has a req property on the response', function(t) {
 test('disabled real HTTP request', function(t) {
   nock.disableNetConnect();
 
-  try {
-    http.get('http://www.amazon.com', function(res) {
-      throw "should not request this";
-    });
-  } catch(err) {
+  http.get('http://www.amazon.com', function(res) {
+    throw "should not request this";
+  }).on('error', function(err) {
     t.equal(err.message, 'Nock: Not allow net connect for "www.amazon.com:80"');
     t.end();
-  }
+  });
 
   nock.enableNetConnect();
 });
@@ -2081,14 +2079,12 @@ test('disabled real HTTP request', function(t) {
 test('NetConnectNotAllowedError is instance of Error', function(t) {
   nock.disableNetConnect();
 
-  try {
-    http.get('http://www.amazon.com', function(res) {
-      throw "should not request this";
-    });
-  } catch(err) {
+  http.get('http://www.amazon.com', function(res) {
+    throw "should not request this";
+  }).on('error', function (err) {
     t.type(err, 'Error');
     t.end();
-  }
+  });
 
   nock.enableNetConnect();
 });
@@ -2096,14 +2092,12 @@ test('NetConnectNotAllowedError is instance of Error', function(t) {
 test('NetConnectNotAllowedError exposes the stack', function(t) {
   nock.disableNetConnect();
 
-  try {
-    http.get('http://www.amazon.com', function(res) {
-      throw "should not request this";
-    });
-  } catch(err) {
+  http.get('http://www.amazon.com', function(res) {
+    throw "should not request this";
+  }).on('error', function (err) {
     t.notEqual(err.stack, undefined);
     t.end();
-  }
+  });
 
   nock.enableNetConnect();
 });
@@ -2111,17 +2105,15 @@ test('NetConnectNotAllowedError exposes the stack', function(t) {
 test('enable real HTTP request only for google.com, via string', function(t) {
   nock.enableNetConnect('google.com');
 
-  try {
-    http.get('http://google.com.br/').on('error', function(err) {
-      throw err;
-    });
+  http.get('http://google.com.br/').on('error', function(err) {
+    throw err;
+  });
 
-    http.get('http://www.amazon.com', function(res) {
-      throw "should not deliver this request"
-    })
-  } catch(err) {
+  http.get('http://www.amazon.com', function(res) {
+    throw "should not deliver this request"
+  }).on('error', function (err) {
     t.equal(err.message, 'Nock: Not allow net connect for "www.amazon.com:80"');
-  }
+  });
 
   t.end();
   nock.enableNetConnect();
@@ -2130,18 +2122,16 @@ test('enable real HTTP request only for google.com, via string', function(t) {
 test('enable real HTTP request only for google.com, via regexp', function(t) {
   nock.enableNetConnect(/google\.com/);
 
-  try {
-    http.get('http://google.com.br/').on('error', function(err) {
-      throw err;
-    });
+  http.get('http://google.com.br/').on('error', function(err) {
+    throw err;
+  });
 
-    http.get('http://www.amazon.com', function(res) {
-      throw "should not request this";
-    });
-  } catch(err) {
+  http.get('http://www.amazon.com', function(res) {
+    throw "should not request this";
+  }).on('error', function (err) {
     t.equal(err.message, 'Nock: Not allow net connect for "www.amazon.com:80"');
     t.end();
-  }
+  });
 
   nock.enableNetConnect();
 });


### PR DESCRIPTION
The [documentation for http.request](http://nodejs.org/api/http.html#http_http_request_options_callback) says:

> If any error is encountered during the request (be that with DNS resolution, TCP level errors, or actual HTTP parse errors) an 'error' event is emitted on the returned request object.

I think that access to the host being blocked would fall into that situation and libraries designed to use the error event will not expect the error to be thrown.  The AWS SDK is one such library, the one that caused me to find this problem.

Another example of the expectation of error reporting is in the [example code for the http.get](http://nodejs.org/api/http.html#http_http_get_options_callback) call:

``` javascript
http.get("http://www.google.com/index.html", function(res) {
  console.log("Got response: " + res.statusCode);
}).on('error', function(e) {
  console.log("Got error: " + e.message);
});
```

With these changes, the testcases checking for errors now matches the example code from the http documentation.
