### PR TITLE
Report request errors through the error event

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -78,6 +78,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
       requestBodyBuffers = [],
       originalInterceptors = interceptors,
       aborted,
+      emitError,
       end,
       ended,
       headers,
@@ -176,6 +177,12 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
 
     req.on(method, cb);
   };
+    
+  emitError = function(error) {
+    process.nextTick(function () {
+      req.emit('error', error);
+    });
+  };
 
   end = function(cb) {
     ended = true;
@@ -222,7 +229,9 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
           return;
         }
       }
-      throw new Error("Nock: No match for request " + common.stringifyRequest(options, requestBody));
+        
+      emitError(new Error("Nock: No match for request " + common.stringifyRequest(options, requestBody)));
+      return;
     }
 
     debug('interceptor identified, starting mocking');
@@ -248,12 +257,14 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
       if(common.isContentEncoded(response.headers)) {
 
         if (interceptor.delayInMs) {
-          throw new Error('Response delay is currently not supported with content-encoded responses.');
+          emitError(new Error('Response delay is currently not supported with content-encoded responses.'));
+          return;
         }
 
         var buffers = interceptor.body;
         if(!_.isArray(buffers)) {
-          throw new Error('content-encoded response must be an array of binary buffers and not ' + typeof(buffers));
+          emitError(new Error('content-encoded response must be an array of binary buffers and not ' + typeof(buffers)));
+          return;
         }
 
         responseBuffers = _.map(buffers, function(buffer) {

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -1392,26 +1392,28 @@ test("can use https", function(t) {
   req.end();
 });
 
-test("complaints if https route is missing", function(t) {
+test("emits error if https route is missing", function(t) {
   var dataCalled = false
 
   var scope = nock('https://google.com')
     .get('/')
     .reply(200, "Hello World!");
 
-  try {
-    var req = https.request({
-        host: "google.com"
-      , path: '/abcdef892932'
-    }, function(res) {
-      throw new Error('should not come here!');
-    }).end();
-  } catch (err) {
-    t.ok(err.message.match(/No match for request GET https:\/\/google.com\/abcdef892932/));
-    t.end();
-  }
+  var req = https.request({
+      host: "google.com"
+    , path: '/abcdef892932'
+  }, function(res) {
+    throw new Error('should not come here!');
+  });
+        
+  req.end();
 
-
+  // This listener is intentionally after the end call so make sure that
+  // listeners added after the end will catch the error
+  req.on('error', function (err) {
+      t.ok(err.message.match(/No match for request GET https:\/\/google.com\/abcdef892932/));
+      t.end();
+  });
 });
 
 test("can use ClientRequest using GET", function(t) {


### PR DESCRIPTION
This issue is very similar to #205 which I previously summitted a pull request for.  This new pull request catches more cases where errors are thrown rather than emitting an error.  Here is the justification for the change, for anybody who doesn't want to read the previous pull request:

The [documentation for http.request](http://nodejs.org/api/http.html#http_http_request_options_callback) says:

> If any error is encountered during the request (be that with DNS resolution, TCP level errors, or actual HTTP parse errors) an 'error' event is emitted on the returned request object.

I think that access to the host being blocked would fall into that situation and libraries designed to use the error event will not expect the error to be thrown.  The https://github.com/mikeal/request library is one such library, the one that caused me to find this problem.

Another example of the expectation of error reporting is in the [example code for the http.get](http://nodejs.org/api/http.html#http_http_get_options_callback) call:

``` javascript
http.get("http://www.google.com/index.html", function(res) {
  console.log("Got response: " + res.statusCode);
}).on('error', function(e) {
  console.log("Got error: " + e.message);
});
```

With these changes, the testcases checking for errors now matches the example code from the http documentation.
