### PR TITLE
Correctly detect protocol when normalizing request options. Fixes #210.

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -8,7 +8,7 @@ var debug = require('debug')('nock.common');
  * @param  {Object} options - a parsed options object of the request
  */
 var normalizeRequestOptions = function(options) {
-  options.proto = options.proto || 'http';
+  options.proto = options.proto || (options._https_ ? 'https': 'http');
   options.port = options.port || ((options.proto === 'http') ? 80 : 443);
   if (options.host) {
     options.hostname = options.hostname || options.host.split(':')[0];

--- a/tests/test_recorder.js
+++ b/tests/test_recorder.js
@@ -254,7 +254,7 @@ tap.test('records https correctly', function(t) {
       t.equal(ret.length, 1);
       ret = ret[0];
       t.type(ret, 'object');
-      t.equal(ret.scope, "https://google.com:80");
+      t.equal(ret.scope, "https://google.com:443");
       t.equal(ret.method, "POST");
       t.ok(typeof(ret.status) !== 'undefined');
       t.ok(typeof(ret.response) !== 'undefined');


### PR DESCRIPTION
See issue #210 for discussion. The recorder incorrectly captures HTTPS scopes as https://foo.com:80, when they should be https://foo.com:443.
