### PR TITLE
Fixes the behavior of isDone() when called on a repeated interceptor.

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -105,8 +105,8 @@ function remove(interceptor) {
     return;
   }
 
-  if (interceptor.counter > 1) {
-    interceptor.counter -= 1;
+  interceptor.counter -= 1;
+  if (interceptor.counter > 0) {
     return;
   }
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -252,7 +252,7 @@ function startScope(basePath, options) {
         this.body.pause();
       }
 
-      if (! persist) {
+      if (!persist && this.counter < 1) {
         remove(this._key, this);
       }
     }


### PR DESCRIPTION
When an interceptor was repeated with a call to times(), isDone() was returning true after the first request.
This commit fixes this wrong behavior, and a a test.

Please, let me know if you want I change something.
