### PR TITLE
Make nock throw error if there isn't an interceptor for a nock'ed url

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -132,6 +132,50 @@ function removeAll() {
   allInterceptors = {};
 }
 
+function hasHadInterceptors(options) {
+  var basePath,
+      isBasePathMatched,
+      isScopedMatched;
+
+  common.normalizeRequestOptions(options);
+
+  basePath = options.proto + '://' + options.host;
+
+  debug('looking for interceptors for basepath');
+
+  _.each(allInterceptors, function(interceptor, key) {
+    if (key === basePath) {
+      isBasePathMatched = true;
+
+      // false to short circuit the .each
+      return false;
+    }
+
+    _.each(interceptor, function(scope) {
+      var filteringScope = scope.__nock_scopeOptions.filteringScope;
+
+      //  If scope filtering function is defined and returns a truthy value
+      //  then we have to treat this as a match.
+      if (filteringScope && filteringScope(basePath)) {
+        debug('found matching scope interceptor');
+
+        //  Keep the filtered scope (its key) to signal the rest of the module
+        //  that this wasn't an exact but filtered match.
+        scope.__nock_filteredScope = scope.__nock_scopeKey;
+        isScopedMatched = true;
+        //  Break out of _.each for scopes.
+        return false;
+      }
+    });
+
+    //  Returning falsy value here (which will happen if we have found our matching interceptor)
+    //  will break out of _.each for all interceptors.
+    return !isScopedMatched;
+  });
+
+  return (isScopedMatched || isBasePathMatched);
+}
+
 function interceptorsFor(options) {
   var basePath;
 
@@ -226,10 +270,10 @@ function overrideClientRequest() {
   function OverriddenClientRequest(options, cb) {
     http.OutgoingMessage.call(this);
 
-    //  Filter the interceptors per request options.
-    var interceptors = interceptorsFor(options);
+    if (hasHadInterceptors(options)) {
+      //  Filter the interceptors per request options.
+      var interceptors = interceptorsFor(options);
 
-    if (interceptors.length) {
       debug('using', interceptors.length, 'interceptors');
 
       //  Use filtered interceptors to intercept requests.
@@ -299,20 +343,21 @@ function activate() {
 
     //  NOTE: overriddenRequest is already bound to its module.
 
-    var interceptors,
-        req,
+    var req,
         res;
 
     if (typeof options === 'string') {
       options = parse(options);
     }
     options.proto = proto;
-    interceptors = interceptorsFor(options);
 
-    if (isOn() && interceptors.length) {
+    if (isOn() && hasHadInterceptors(options)) {
 
-      var matches = false,
+      var interceptors,
+          matches = false,
           allowUnmocked = false;
+
+      interceptors = interceptorsFor(options);
 
       interceptors.forEach(function(interceptor) {
         if (! allowUnmocked && interceptor.options.allowUnmocked) { allowUnmocked = true; }

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -3441,3 +3441,19 @@ test('isDone() must consider repeated responses', function(t) {
 
 });
 
+test('you must setup an interceptor for each request', function(t) {
+  var scope = nock('http://www.example.com')
+     .get('/hey')
+     .reply(200, 'First match');
+
+  mikealRequest.get('http://www.example.com/hey', function(error, res, body) {
+    t.equal(res.statusCode, 200);
+    t.equal(body, 'First match', 'should match first request response body');
+
+    mikealRequest.get('http://www.example.com/hey', function(error, res, body) {
+      t.equal(error && error.toString(), 'Error: Nock: No match for request GET http://www.example.com/hey ');
+      scope.done();
+      t.end();
+    });
+  });
+});


### PR DESCRIPTION
As per this documentation: https://github.com/pgte/nock#read-this
Nock should throw an error if you don't have a matching interceptor for a url, but previously have HAD a matching interceptor.
This PR restores that behavior and fixes https://github.com/pgte/nock/issues/228
