### PR TITLE
Fixes NOCK_OFF='true' not working for some cases.

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -272,7 +272,8 @@ function overrideClientRequest() {
   function OverriddenClientRequest(options, cb) {
     http.OutgoingMessage.call(this);
 
-    if (hasHadInterceptors(options)) {
+    if (isOn() && hasHadInterceptors(options)) {
+
       //  Filter the interceptors per request options.
       var interceptors = interceptorsFor(options);
 

--- a/tests/test_nock_off.js
+++ b/tests/test_nock_off.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var test          = require('tap').test;
+var mikealRequest = require('request');
+
+test('NOCK_OFF=true works for https', function(t) {
+  var original = process.env.NOCK_OFF;
+  process.env.NOCK_OFF = 'true';
+  var nock = require('../');
+  var scope = nock('https://www.google.com')
+  .get('/')
+  .reply(200, {foo: 'bar'});
+
+  var options = {
+    method: 'GET',
+    uri: 'https://www.google.com'
+  };
+
+  mikealRequest(options, function(err, resp, body) {
+    t.notOk(err);
+    t.notDeepEqual(body, '{"foo":"bar"}');
+    scope.done();
+    t.end();
+    process.env.NOCK_OFF = original;
+    return console.log(resp.statusCode, 'body length: ', body.length);
+  });
+});
+
+


### PR DESCRIPTION
This PR fixes #222 and adds a unit test to prove that the bug really exists :). You can try using the old `lib/intercept.js` without the modification and running the tests and it will fail. Thanks in advance!
