### PR TITLE
Fix browserify compatibility

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -106,7 +106,10 @@ var overrideRequests = function(newRequest) {
     debug('- overriding request for', proto);
 
     var moduleName = proto, // 1 to 1 match of protocol and module is fortunate :)
-        module = require(moduleName),
+        module = {
+          http: require('http'),
+          https: require('https')
+        }[moduleName],
         overriddenRequest = module.request;
 
     if(requestOverride[moduleName]) {

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -7,7 +7,8 @@ var EventEmitter     = require('events').EventEmitter,
     common           = require('./common'),
     Socket           = require('./socket'),
     _                = require('lodash'),
-    debug            = require('debug')('nock.request_overrider');
+    debug            = require('debug')('nock.request_overrider'),
+    timers           = require('timers');
 
 function getHeader(request, name) {
   if (!request._headers) {
@@ -428,7 +429,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
       //  Otherwise the writing to output pipe may stall invoking pause()
       //  without ever calling resume() (the observed was behavior on superagent
       //  with Node v0.10.26)
-      setImmediate(function() {
+      timers.setImmediate(function() {
         if (paused || mockEmits.length === 0 || aborted) {
           debug('mocking paused, aborted or finished');
           return;


### PR DESCRIPTION
Incompatibility was mostly related to the way browserify determines and implements required modules:
- it doesn't support dynamic require substack/node-browserify#377
- considering setImmediate not to be a part of ECMA substack/node-browserify#985
- lacks some exports expected from `http` (along with `https`) module https://github.com/substack/http-browserify/pull/75

Fixes #150
Depends on https://github.com/substack/http-browserify/pull/75
