### PR TITLE
adds warning about restore() and points to cleanAll()

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ You can restore the HTTP interceptor to the normal unmocked behaviour by calling
 ```js
 nock.restore();
 ```
+**note**: restore does not clear the interceptor list. Use [nock.cleanAll()](#cleanall) if you expect the interceptor list to be empty.
 
 # Turning Nock Off (experimental!)
 


### PR DESCRIPTION
This little bit of docs would have saved me a few hours today. Hopefully it can save someone else. 
