### PR TITLE
bug fixes in removeInterceptor

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -220,12 +220,14 @@ function interceptorsFor(options) {
 }
 
 function removeInterceptor(options) {
-  var baseUrl, key, method;
+  var baseUrl, key, method, proto;
+
+  proto = options.proto ? options.proto : 'http';
 
   common.normalizeRequestOptions(options);
-  baseUrl = options.proto + '://' + options.host;
+  baseUrl = proto + '://' + options.host;
 
-  if (allInterceptors[baseUrl].length > 0) {
+  if (allInterceptors[baseUrl] && allInterceptors[baseUrl].length > 0) {
     if (options.path) {
       method = options.method && options.method.toUpperCase() || 'GET';
       key = method + ' ' + baseUrl + (options.path || '/');
@@ -245,7 +247,6 @@ function removeInterceptor(options) {
 
   return false;
 }
-
 //  Variable where we keep the ClientRequest we have overridden
 //  (which might or might not be node's original http.ClientRequest)
 var originalClientRequest;


### PR DESCRIPTION
- if "proto" was not defined in options, no default value was used, thus producing invalid urls in the most common 'http' case
- if there was no interceptor for the baseUrl, exception was thrown (length of undefined)
