### PR TITLE
Adding test to prove that a header value can be an array (e.g. for Set-Cookie)

### DIFF
--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -690,6 +690,33 @@ test("headers work", function(t) {
 
 });
 
+test("headers as arrays work", function(t) {
+
+  var scope = nock('http://www.headdy.com')
+     .get('/')
+     .reply(200, "Hello World!", {'Set-Cookie': ['cookie1=foo', 'cookie2=bar']});
+
+  var req = http.request({
+     host: "www.headdy.com"
+    , method: 'GET'
+    , path: '/'
+    , port: 80
+  }, function(res) {
+   t.equal(res.statusCode, 200);
+   res.on('end', function() {
+     t.equivalent(res.headers, {'set-cookie': ['cookie1=foo', 'cookie2=bar']});
+     scope.done();
+     t.end();
+   });
+   // Streams start in 'paused' mode and must be started.
+   // See https://nodejs.org/api/stream.html#stream_class_stream_readable
+   res.resume();
+  });
+
+  req.end();
+
+});
+
 test("reply headers work with function", function(t) {
 
   var scope = nock('http://replyheadersworkwithfunction.xxx')


### PR DESCRIPTION
My use case for nock involved setting cookies, and the documentation makes no mention of how to do this. In particular, the Set-Cookie header can appear multiple times in a response to set multiple cookies. There was also no mention in the documentation that setting a header value to an array is a valid syntax.

However, looking at the code, it uses Array.push() so this works fine. I have added a test case to prove that this works. No code change otherwise.
