### PR TITLE
enable object to be used in place of status code in reply api

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -55,9 +55,24 @@ Interceptor.prototype.reply = function reply(statusCode, body, headers) {
     if (arguments.length <= 2 && _.isFunction(statusCode)) {
         body = statusCode;
         statusCode = 200;
-    }
 
-    this.statusCode = statusCode;
+        this.statusCode = statusCode;
+    }
+    else if (_.isObject(statusCode)) {
+        var statusObject = {}
+        for (var prop in statusCode) {
+            if (prop === 'statusCode') {
+                this.statusCode = statusCode[prop]
+            }
+            else {
+                statusObject[prop] = statusCode[prop]
+            }
+        }
+        this.statusObject = statusObject
+    }
+    else {
+        this.statusCode = statusCode;
+    }
 
     //  We use lower-case headers throughout Nock.
     headers = common.headersFieldNamesToLowerCase(headers);

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -287,6 +287,12 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
     }
     response.statusCode = Number(interceptor.statusCode) || 200;
 
+    if (interceptor.statusObject) {
+      for (var prop in interceptor.statusObject) {
+          response[prop] = interceptor.statusObject[prop]
+      }
+    }
+
     // Clone headers/rawHeaders to not override them when evaluating later
     response.headers = _.extend({}, interceptor.headers);
     response.rawHeaders = (interceptor.rawHeaders || []).slice();


### PR DESCRIPTION
I am using nock to mock a request using

```
nock(url)
   .post(path, data)
   .reply(200, replyData)
```

Now I want to have a **statusText** property in the response as well and want to do something like
`reply({ statusCode: 200, statusText: 'OK'})`

So, I was tracing the flow of execution for this and it seems this is the way _reply_ is called..

lib/interceptor: reply
lib/scope: add
lib/intercept: OverriddenClientRequest
lib/request_override: RequestOverrider

However, I am yet to get the `statusText` property in the final response.
Would like some help here. @pgte @ssbrewster ?
