### PR TITLE
Improve matching of regexp domains

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -350,8 +350,17 @@ Interceptor.prototype.matchIndependentOfBody = function matchIndependentOfBody(o
         return false;
     }
 
-    var matchKey = method + ' ' + proto + '://' + options.host + path;
-    return this._key === matchKey;
+    var matched;
+    if (this.scope.basePath instanceof RegExp) {
+        matched = this.method === method &&
+            common.matchStringOrRegexp(proto + '://' + options.host, this.scope.basePath ) &&
+            this.uri === path;
+    } else {
+        var matchKey = method + ' ' + proto + '://' + options.host + path;
+        matched = this._key === matchKey;
+    }
+
+    return matched;
 };
 
 Interceptor.prototype.filteringPath = function filteringPath() {

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -4192,6 +4192,20 @@ test('match domain using regexp', function (t) {
   });
 });
 
+test('match full domain using regexp', function (t) {
+  var scope = nock(/^http:\/\/.*\.fulldomainexample\.com:80$/, { allowUnmocked: true })
+    .get('/resources')
+    .reply(200, 'Match www');
+
+  mikealRequest.get('http://www.fulldomainexample.com/resources', function(err, res, body) {
+    t.type(err, 'null');
+    t.equal(res.statusCode, 200);
+    t.equal(body, 'Match www');
+
+    t.end();
+  });
+});
+
 test('match multiple interceptors with regexp domain (issue-508)', function (t) {
   var scope = nock(/chainregex/)
     .get('/')


### PR DESCRIPTION
I need to do partial matching on domains for ignoring the subdomain-part. This was not working and I discovered that the reason was the matchIndependentOfBody method which did simple string-matching regardless of basePath being a regular expression.

I have fixed that and included a test-case that only passes when the changes are included.
