### PR TITLE
nock.setAllowUnmock(<bool>)

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -40,7 +40,12 @@ function NetConnectNotAllowedError(host, path) {
 inherits(NetConnectNotAllowedError, Error);
 
 var allInterceptors = {},
-    allowNetConnect;
+    allowNetConnect,
+    globalAllowUnmocked;
+
+function setAllowUnmocked(bool) {
+  globalAllowUnmocked = bool;
+}
 
 /**
  * Enabled real request.
@@ -356,8 +361,8 @@ function activate() {
       allowUnmocked = !! _.find(interceptors, function(interceptor) {
         return interceptor.options.allowUnmocked;
       });
-
-      if (! matches && allowUnmocked) {
+      
+      if (! matches && (allowUnmocked || globalAllowUnmocked)) {
         if (proto === 'https') {
           var ClientRequest = http.ClientRequest;
           http.ClientRequest = originalClientRequest;
@@ -395,6 +400,7 @@ function activate() {
 activate();
 
 module.exports = add;
+module.exports.setAllowUnmocked = setAllowUnmocked;
 module.exports.removeAll = removeAll;
 module.exports.removeInterceptor = removeInterceptor;
 module.exports.isOn = isOn;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -351,7 +351,7 @@ module.exports = extend(startScope, {
   removeInterceptor: globalIntercept.removeInterceptor,
   disableNetConnect: globalIntercept.disableNetConnect,
   enableNetConnect: globalIntercept.enableNetConnect,
-  setAllowUmocked: globalIntercept.setAllowUnmocked,
+  setAllowUnmocked: globalIntercept.setAllowUnmocked,
   load: load,
   loadDefs: loadDefs,
   define: define,

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -351,6 +351,7 @@ module.exports = extend(startScope, {
   removeInterceptor: globalIntercept.removeInterceptor,
   disableNetConnect: globalIntercept.disableNetConnect,
   enableNetConnect: globalIntercept.enableNetConnect,
+  setAllowUmocked: globalIntercept.setAllowUnmocked,
   load: load,
   loadDefs: loadDefs,
   define: define,

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -4988,3 +4988,22 @@ test("teardown", function(t) {
   t.deepEqual(leaks, [], 'No leaks');
   t.end();
 });
+
+test('setAllowUnmocked', function(t){
+
+  nock('http://bob.com/')
+    .get('/')
+    .reply(404);
+
+  nock.setAllowUnmocked(true);
+
+  mikealRequest('http://bob.com', function(err, res) {
+    t.equals(404, res.statusCode);
+  });
+
+  mikealRequest('http://bob.com', function(err, res) {
+    t.equals(200, res.statusCode);
+    t.end();
+  });
+
+});


### PR DESCRIPTION
I'm trying to update another open source library that uses Nock. Unfortunately, they're still on version __0.47__. The one code change that prevents them from moving forward to the latest is the change from way back in nock 0.48 https://github.com/node-nock/nock/commit/9670b94a84aadfdeae987afcd6d5ca33015e8613 which enables a failure mode when a request is made to a no longer (but once formerly) mocked url. 

I'd like to add a feature, `nock.setAllowUnmocked(<bool>)` that will basically turn off this failure mode when enabled. By default its off and works as the library does today. It's a useful feature for cases when you are mocking some calls with nock, and then making http requests to the same url. I tried using `enableNetConnections` but it doesn't quite work the same way. Setting allowUnmocked on each individual nock also does not work. Setting allowUnmocked to true (on a global sense) is what I'm looking for.

Feedback appreciated.

```
function setAllowUnmocked(bool) {
  globalAllowUnmocked = bool;
}		
```

```
      allowUnmocked = !! _.find(interceptors, function(interceptor) {
        return interceptor.options.allowUnmocked;
      });
      
      if (! matches && (allowUnmocked || globalAllowUnmocked)) {
        if (proto === 'https') {
          var ClientRequest = http.ClientRequest;
          http.ClientRequest = originalClientRequest;
          req = overriddenRequest(options, callback);
          http.ClientRequest = ClientRequest;
        } else {
          req = overriddenRequest(options, callback);
        }
        globalEmitter.emit('no match', req);
        return req;
      }
```