### PR TITLE
Add URI of nocked call to logger output

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -321,7 +321,7 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
         this.scope.logger('matching ' + matchKey + ( path || "" )+ '?' + queryString + ' to ' + this._key +
         ' with query(' + stringify(this.queries) + '): ' + matches);
     } else {
-        this.scope.logger('matching ' + matchKey + ( (path) ? path : "") + ' to ' + this._key + ': ' + matches);
+        this.scope.logger('matching ' + matchKey + ( path || "" ) + ' to ' + this._key + ': ' + matches);
     }
 
     if (matches) {

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -24,8 +24,7 @@ function Interceptor(scope, uri, method, requestBody, interceptorOptions) {
     this.interceptorMatchHeaders = [];
     this.method = method.toUpperCase();
     this.uri = uri;
-    this._key = this.method + ' ' + scope.basePath + scope.basePathname + (typeof uri === 'string' ? '' : '/') +
-                (typeof uri === "function" ? " function()":uri);
+    this._key = this.method + ' ' + scope.basePath + scope.basePathname + (typeof uri === 'string' ? '' : '/') + uri;
     this.basePath = this.scope.basePath;
     this.path = (typeof uri === 'string') ? scope.basePathname + uri : uri;
 
@@ -319,7 +318,7 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
 
     // special logger for query()
     if (queryIndex !== -1) {
-        this.scope.logger('matching ' + matchKey + ( (path) ? path : "")+ '?' + queryString + ' to ' + this._key +
+        this.scope.logger('matching ' + matchKey + ( path || "" )+ '?' + queryString + ' to ' + this._key +
         ' with query(' + stringify(this.queries) + '): ' + matches);
     } else {
         this.scope.logger('matching ' + matchKey + ( (path) ? path : "") + ' to ' + this._key + ': ' + matches);

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -318,10 +318,10 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
 
     // special logger for query()
     if (queryIndex !== -1) {
-        this.scope.logger('matching ' + matchKey + '?' + queryString + ' to ' + this._key +
+        this.scope.logger('matching ' + matchKey + ( (path) ? path : "")+ '?' + queryString + ' to ' + this._key +
         ' with query(' + stringify(this.queries) + '): ' + matches);
     } else {
-        this.scope.logger('matching ' + matchKey + ' to ' + this._key + ': ' + matches);
+        this.scope.logger('matching ' + matchKey + ( (path) ? path : "") + ' to ' + this._key + ': ' + matches);
     }
 
     if (matches) {

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -24,7 +24,8 @@ function Interceptor(scope, uri, method, requestBody, interceptorOptions) {
     this.interceptorMatchHeaders = [];
     this.method = method.toUpperCase();
     this.uri = uri;
-    this._key = this.method + ' ' + scope.basePath + scope.basePathname + (typeof uri === 'string' ? '' : '/') + uri;
+    this._key = this.method + ' ' + scope.basePath + scope.basePathname + (typeof uri === 'string' ? '' : '/') +
+                (typeof uri === "function" ? " function()":uri);
     this.basePath = this.scope.basePath;
     this.path = (typeof uri === 'string') ? scope.basePathname + uri : uri;
 

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -16,7 +16,6 @@ var domain  = require('domain');
 var hyperquest = require('hyperquest');
 var _ = require('lodash');
 var async = require('async');
-var stream = require('stream');
 
 var globalCount;
 

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -988,7 +988,7 @@ test("log different request types", function(t) {
     if (step===0) t.equal(s,"matching http://api.headdy.com:80/one to GET http://api.headdy.com:80/one: true");
     if (step===1) t.equal(s,"matching http://api.headdy.com:80/two to GET http://api.headdy.com:80//tw./: true");
     if (step===2) t.equal(s,"matching http://api.headdy.com:80/three to GET http://api.headdy.com:80/ function(): true");
-    if (step===3) t.equal(s,"matching http://api.headdy.com:80/matchmiss to GET http://api.headdy.com:80/missmatch: false");
+    if (step===3) t.equal(s,"matching http://api.headdy.com:80/matchmiss to GET http://api.headdy.com:80/mismatch: false");
     step = step +1;
   }
   var scope = nock('http://api.headdy.com')
@@ -1060,7 +1060,7 @@ test("log different request types", function(t) {
 });
 
 
-test('log a missmatch', function(t) {
+test('log a mismatch', function(t) {
   function log(text) {
     t.equal(text,"matching http://example.com:80/superpowers to POST http://example.com:80/resource: false");
   }

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -987,7 +987,7 @@ test("log different request types", function(t) {
   function expect(s) {
     if (step===0) t.equal(s,"matching http://api.headdy.com:80/one to GET http://api.headdy.com:80/one: true");
     if (step===1) t.equal(s,"matching http://api.headdy.com:80/two to GET http://api.headdy.com:80//tw./: true");
-    if (step===2) t.equal(s,"matching http://api.headdy.com:80/three to GET http://api.headdy.com:80/ function(): true");
+    if (step===2) t.equal(s,'matching http://api.headdy.com:80/three to GET http://api.headdy.com:80/function (uri) { return uri.indexOf("three")>=0; }: true');
     if (step===3) t.equal(s,"matching http://api.headdy.com:80/matchmiss to GET http://api.headdy.com:80/mismatch: false");
     step = step +1;
   }

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -979,28 +979,32 @@ test("match all headers", function(t) {
 
 
 
-test("match all headers with log", function(t) {
+test("log different request types", function(t) {
 
   // Create a very simple expect function, to
   // compare the results of the two log calls in this test
   let step = 0;
   function expect(s) {
     if (step===0) t.equal(s,"matching http://api.headdy.com:80/one to GET http://api.headdy.com:80/one: true");
-    if (step===1) t.equal(s,"matching http://api.headdy.com:80/two to GET http://api.headdy.com:80/two: true");
+    if (step===1) t.equal(s,"matching http://api.headdy.com:80/two to GET http://api.headdy.com:80//tw./: true");
+    if (step===2) t.equal(s,"matching http://api.headdy.com:80/three to GET http://api.headdy.com:80/ function(): true");
+    if (step===3) t.equal(s,"matching http://api.headdy.com:80/matchmiss to GET http://api.headdy.com:80/missmatch: false");
     step = step +1;
   }
   var scope = nock('http://api.headdy.com')
     .matchHeader('accept', 'application/json')
     .get('/one')
     .reply(200, { hello: "world" })
-    .get('/two')
+    .get(/tw./)
     .reply(200, { a: 1, b: 2, c: 3 })
+    .get(function(uri) { return uri.indexOf("three")>=0; })
+    .reply(200,{c:1})
     .log(expect);
 
   var ended = 0;
   function callback() {
     ended += 1;
-    if (ended === 2) {
+    if (ended === 3) {
       scope.done();
       t.end();
     }
@@ -1035,10 +1039,54 @@ test("match all headers with log", function(t) {
       t.equal(data, '{"a":1,"b":2,"c":3}');
     });
 
+
+
     res.on('end', callback);
   });
+  http.get({
+    host: "api.headdy.com"
+    , path: '/three'
+    , port: 80
+    , headers: {'accept': 'application/json'}
+  }, function(res) {
+    res.setEncoding('utf8');
+    t.equal(res.statusCode, 200);
 
+    res.on('data', function(data) {
+      t.equal(data, '{"c":1}');
+    });
+    res.on('end', callback);
+  });
 });
+
+
+test('log a missmatch', function(t) {
+  function log(text) {
+    t.equal(text,"matching http://example.com:80/superpowers to POST http://example.com:80/resource: false");
+  }
+  var scope = nock('http://example.com')
+    .post('/resource')
+    .reply(200, { status: "ok" })
+    .log(log);
+
+  var d = domain.create();
+
+  d.run(function() {
+    mikealRequest({
+      method: 'POST',
+      uri: 'http://example.com/superpowers'
+    });
+  });
+
+  d.once('error', function(err) {
+    t.ok(err.message.match(/No match/));
+    // Disable logger, as scope is still existing, as call failed
+    scope.log(function(){});
+
+    t.end();
+  });
+});
+
 
 test("header manipulation", function(t) {
   var scope = nock('http://example.com')


### PR DESCRIPTION
The current logger only writes the complete URI of the inceptor, but not the complete called URI.


Previous Output:
```
matching http://example.com:80 to POST http://example.com:80/resource: false
```
Output after apply of this change request

```
matching http://example.com:80/superpowers to POST http://example.com:80/resource: false
```
As this has lead to a longer search for a mistake in my code, I decided to create this change requests.

As a result, now the called URI and the interceptor URI is logged.

Other Changes:

a) **interceptor._key** was changed not to contain the complete filter function. Typical filter functions can be small, but I suggest only to log the information " function()"
I did not find any test, that fails because of this change.

b) Logging was expanded

c) wrote 2 test
One containing different types (Function, String and Regex) of successful nock logs and one that is testing logging of a fail.

I hope I met your coding guidelines.

In the test "log a mismatch" I had the problem, that the nock wasn't used, and i did not know, how to disable this single scope.

But the scope affects the next test, which is obvious a very bad style. May be you know how to remove a single scope. (nock.clearAll()) leads many test to a fail.
For now i only disable the "logger" via an empty function call.