### PR TITLE
Added alterResponse callback to nock.back.

### DIFF
--- a/lib/back.js
+++ b/lib/back.js
@@ -157,7 +157,8 @@ var record = {
     if( !context.isLoaded ) {
       recorder.record(_.assign({
         dont_print: true,
-        output_objects: true
+        output_objects: true,
+        alter_response: options.alterResponse
       }, options && options.recorder));
 
       context.isRecording = true;

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -201,6 +201,7 @@ function record(rec_options) {
   if (optionsIsObject && _.has(rec_options, 'use_separator')) {
     use_separator = rec_options.use_separator;
   }
+  var alterResponse = optionsIsObject && rec_options.alter_response || function(){};
 
   debug(thisRecordingId, 'restoring overridden requests before new overrides');
   //  To preserve backward compatibility (starting recording wasn't throwing if nock was already active)
@@ -234,6 +235,10 @@ function record(rec_options) {
     options._recording = true;
 
     var req = overriddenRequest(options, function(res) {
+      var newRes = alterResponse(res);
+      if(newRes){
+        res = newRes;
+      }
 
       debug(thisRecordingId, 'intercepting', proto, 'request to record');
 


### PR DESCRIPTION
I needed a callback that would let me alter responses so that I can simulate various edge cases that may not occur with live data. I also needed this callback to run after each request, since in my app code the requests performed are determined by the output of earlier requests (so `afterRecord` wouldn't work).

WIP: Still doesn't do what I need it to, which is allow both the original and saved mock to be altered.