### PR TITLE
Updated the scope.request event emitter to include the request body

### DIFF
--- a/README.md
+++ b/README.md
@@ -1236,7 +1236,7 @@ nock.removeInterceptor(interceptor);
 
 A scope emits the following events:
 
-* `emit('request', function(req, interceptor))`;
+* `emit('request', function(req, interceptor, body))`;
 * `emit('replied', function(req, interceptor))`;
 
 ## Global no match event

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -288,7 +288,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
     interceptor.req = req;
     req.headers = req.getHeaders ? req.getHeaders() : req._headers;
 
-    interceptor.scope.emit('request', req, interceptor);
+    interceptor.scope.emit('request', req, interceptor, requestBody);
 
     if (typeof interceptor.errorMessage !== 'undefined') {
       interceptor.interceptionCounter++;


### PR DESCRIPTION
I am working on a testing scenario where I am running a method that then makes several requests. In the tests, I needed to later inspect the request body, but it did not appear to include a simple way to get the request body. If there is another way to do this, no worries, but this was helpful for me.

Example:

```javascript
const twitter = nock(/twitter\.com/).persist().post(/media\/upload/).reply(200);
const methods = {
  'INIT': [],
  'APPEND': [],
  'FINALIZE': [],
  'STATUS': []
};

twitter.on('request', (req, interceptor, body) => {
  const parsed = querystring.parse(body);
  if (parsed.command) {
    methods[parsed.command].push(body);
  }
});

return myMethod().then(() => {
  expect(methods.INIT).to.have.lengthOf(1);
  // ...
})
```

Not sure if this would be helpful (or better?) in the `replied` event? Essentially I wanted to spy on which interceptors had been called.

And thanks for this package, it is extremely helpful in tests! 👍 