### PR TITLE
docs: change url to match new GitHub address

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Nock
 
-[![Build Status](https://travis-ci.org/node-nock/nock.svg?branch=master)](https://travis-ci.org/node-nock/nock)
-[![Coverage Status](https://coveralls.io/repos/github/node-nock/nock/badge.svg?branch=master)](https://coveralls.io/github/node-nock/nock?branch=master)
-[![Greenkeeper](https://badges.greenkeeper.io/node-nock/nock.svg)](https://greenkeeper.io/)
+[![Build Status](https://travis-ci.org/nock/nock.svg?branch=master)](https://travis-ci.org/nock/nock)
+[![Coverage Status](https://coveralls.io/repos/github/nock/nock/badge.svg?branch=master)](https://coveralls.io/github/nock/nock?branch=master)
+[![Greenkeeper](https://badges.greenkeeper.io/nock/nock.svg)](https://greenkeeper.io/)
 
 
 Nock is an HTTP mocking and expectations library for Node.js
@@ -1430,4 +1430,4 @@ $ npm test
 
 [MIT](LICENSE)
 
-Copyright (c) 2011-2017 [Pedro Teixeira](http://about.me/pedroteixeira) and other [contributors](https://github.com/node-nock/nock/graphs/contributors).
+Copyright (c) 2011-2017 [Pedro Teixeira](http://about.me/pedroteixeira) and other [contributors](https://github.com/nock/nock/graphs/contributors).

--- a/package.json
+++ b/package.json
@@ -157,10 +157,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/node-nock/nock.git"
+    "url": "https://github.com/nock/nock.git"
   },
   "bugs": {
-    "url": "http://github.com/node-nock/nock/issues"
+    "url": "http://github.com/nock/nock/issues"
   },
   "engines": [
     "node >= 4.0"

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -2806,7 +2806,7 @@ test("allow unmocked option works with https", {skip: process.env.AIRPLANE}, fun
   }).end();
 });
 
-// TODO: remove skip as part of https://github.com/node-nock/nock/issues/1077
+// TODO: remove skip as part of https://github.com/nock/nock/issues/1077
 // test('allow unmocked post with json data', {skip: process.env.AIRPLANE}, function(t) {
 test('allow unmocked post with json data', {skip: true}, function(t) {
   nock('https://httpbin.org', { allowUnmocked: true }).
@@ -2825,7 +2825,7 @@ test('allow unmocked post with json data', {skip: true}, function(t) {
   });
 });
 
-// TODO: remove skip as part of https://github.com/node-nock/nock/issues/1077
+// TODO: remove skip as part of https://github.com/nock/nock/issues/1077
 // test('allow unmocked passthrough with mismatched bodies', {skip: process.env.AIRPLANE}, function(t) {
 test('allow unmocked passthrough with mismatched bodies', {skip: true}, function(t) {
   nock('http://httpbin.org', { allowUnmocked: true }).


### PR DESCRIPTION
The new address is now nock/nock, not node-nock/nock. hooray!