### PR TITLE
fix: request overrider checks req.headers to parse body as json

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -313,14 +313,14 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
 
 
     if (typeof interceptor.body === 'function') {
-      if (requestBody && common.isJSONContent(options.headers)) {
-        if (requestBody && common.contentEncoding(options.headers, 'gzip')) {
+      if (requestBody && common.isJSONContent(req.headers)) {
+        if (requestBody && common.contentEncoding(req.headers, 'gzip')) {
           if (typeof zlib.gunzipSync !== 'function') {
             emitError(new Error('Gzip encoding is currently not supported in this version of Node.'));
             return;
           }
           requestBody = String(zlib.gunzipSync(new Buffer(requestBody, 'hex')), 'hex')
-        } else if (requestBody && common.contentEncoding(options.headers, 'deflate')) {
+        } else if (requestBody && common.contentEncoding(req.headers, 'deflate')) {
           if (typeof zlib.deflateSync !== 'function') {
             emitError(new Error('Deflate encoding is currently not supported in this version of Node.'));
             return;


### PR DESCRIPTION
fixes https://github.com/nock/nock/issues/1156

Request overrider was using headers from options.
But some library don't set headers via options.

Use req.headers (retreived before in the same function) to ensure body is parse as JSON when header Content-Type=application/json