### PR TITLE
fix: Replaced util._extend with Object.assign due to deprecation

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -9,7 +9,6 @@ var globalIntercept = require('./intercept')
   , _               = require('lodash')
   , debug           = require('debug')('nock.scope')
   , EventEmitter    = require('events').EventEmitter
-  , extend          = require('util')._extend
   , globalEmitter   = require('./global_emitter')
   , util            = require('util')
   , Interceptor     = require('./interceptor') ;
@@ -346,7 +345,7 @@ function define(nockDefs) {
   return nocks;
 }
 
-module.exports = extend(startScope, {
+module.exports = Object.assign(startScope, {
   cleanAll: cleanAll,
   activate: globalIntercept.activate,
   isActive: globalIntercept.isActive,


### PR DESCRIPTION
While going through the source code I noticed that the package 'util' provided by Node - the method _extend was used. This is deprecated since node v.6 and was never intended for the public API.

I replaced it with Object.assign instead as per the recommendation of Node.

[Deprecation notice](https://nodejs.org/api/util.html#util_util_extend_target_source)