### PR TITLE
docs(CODE_OF_CONDUCT.md): Change maintainer support email

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at nock+coc@martynus.net or richard@maintainer.io. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at nock+coc@martynus.net or coc+nock@maintainer.io. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 


### PR DESCRIPTION
I have changed the maintainer.io support email from `richard@maintainer.io` to `coc+nock@maintainer.io` in an attempt to make it more applicable in other CoCs, less tied to my own namespace, and to point out that emails which go to this email do not necessarily go to me, but to my team, which may at times include more than just a single perceived cis white male. Hopefully, this change will make it easier to email Maintainer as a third party in disputes.