### PR TITLE
docs: Add CHANGELOG file pointing to GitHub releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+Nock’s changelog can be found directly in the [GitHub release notes](https://github.com/nock/nock/releases). These are automatically created by [semantic-release](https://github.com/semantic-release/semantic-release) based on their [commit message conventions](https://semantic-release.gitbook.io/semantic-release#commit-message-format).


### PR DESCRIPTION
It was not immediately clear to me that the CHANGELOG was part of the GitHub releases. Adding this file will clear up that. However, it does add an extra file. We could include this in the CONTRIBUTING, or better, in the README, instead, if you like. I am suggesting this here as the CHANGELOG file is what I would naturally look for when I am looking for a CHANGELOG. However, I may be out of touch with modern development practices and this may be overoptimizing. What do we think?