### PR TITLE
feat: encode an expected buffer the same way when matching as the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,13 +183,21 @@ var scope = nock('http://www.example.com')
 
 ### Specifying request body
 
-You can specify the request body to be matched as the second argument to the `get`, `post`, `put` or `delete` specifications. There are four types of second argument allowed:
+You can specify the request body to be matched as the second argument to the `get`, `post`, `put` or `delete` specifications. There are five types of second argument allowed:
 
 **String**: nock will exact match the stringified request body with the provided string
 
 ```js
 nock('http://www.example.com')
   .post('/login', 'username=pgte&password=123456')
+  .reply(200, { id: '123ABC' });
+```
+
+**Buffer**: nock will exact match the stringified request body with the provided buffer
+
+```js
+nock('http://www.example.com')
+  .post('/login', Buffer.from([0xff, 0x11]))
   .reply(200, { id: '123ABC' });
 ```
 

--- a/lib/match_body.js
+++ b/lib/match_body.js
@@ -3,6 +3,7 @@
 var deepEqual = require('deep-equal');
 var qs = require('qs');
 var _ = require('lodash')
+var common = require('./common');
 
 module.exports =
 function matchBody(spec, body) {
@@ -13,6 +14,14 @@ function matchBody(spec, body) {
 
   if (Buffer.isBuffer(body)) {
     body = body.toString();
+  }
+
+  if (Buffer.isBuffer(spec)) {
+    if (common.isBinaryBuffer(spec)) {
+      spec = spec.toString('hex');
+    } else {
+      spec = spec.toString('utf8');
+    }
   }
 
   var contentType = (

--- a/tests/test_body_match.js
+++ b/tests/test_body_match.js
@@ -220,3 +220,109 @@ test('urlencoded form posts are matched with regexp', function(t) {
     t.end();
   });
 });
+
+test('match utf-8 buffer body with utf-8 buffer', function(t) {
+
+  nock('http://encodingsareus.com')
+      .post('/', Buffer.from('hello'))
+      .reply(200);
+
+  mikealRequest({
+    url: 'http://encodingsareus.com/',
+    method: 'post',
+    encoding: null,
+    body: Buffer.from('hello')
+  }, function(err, res) {
+    if (err) throw err;
+    assert.equal(res.statusCode, 200);
+    t.end();
+  });
+});
+
+test('doesn\'t match utf-8 buffer body with mismatching utf-8 buffer', function(t) {
+
+  nock('http://encodingsareus.com')
+      .post('/', Buffer.from('goodbye'))
+      .reply(200);
+
+  mikealRequest({
+    url: 'http://encodingsareus.com/',
+    method: 'post',
+    encoding: null,
+    body: Buffer.from('hello')
+  }, function(err) {
+    assert.ok(err);
+    t.end();
+  });
+});
+
+test('match binary buffer body with binary buffer', function(t) {
+
+  nock('http://encodingsareus.com')
+      .post('/', Buffer.from([0xff, 0xff, 0xff]))
+      .reply(200);
+
+  mikealRequest({
+    url: 'http://encodingsareus.com/',
+    method: 'post',
+    encoding: null,
+    body: Buffer.from([0xff, 0xff, 0xff])
+  }, function(err, res) {
+    if (err) throw err;
+    assert.equal(res.statusCode, 200);
+    t.end();
+  });
+});
+
+test('doesn\'t match binary buffer body with mismatching binary buffer', function(t) {
+
+  nock('http://encodingsareus.com')
+      .post('/', Buffer.from([0xff, 0xff, 0xfa]))
+      .reply(200);
+
+  mikealRequest({
+    url: 'http://encodingsareus.com/',
+    method: 'post',
+    encoding: null,
+    body: Buffer.from([0xff, 0xff, 0xff])
+  }, function(err) {
+    assert.ok(err);
+    t.end();
+  });
+});
+
+// for the next two tests, keeping the same urls causes them to interfere with another.
+
+test('doesn\'t match binary buffer body with mismatching utf-8 buffer', function(t) {
+
+  nock('http://encodingsareus-1.com')
+      .post('/', Buffer.from([0xff, 0xff, 0xff]))
+      .reply(200);
+
+  mikealRequest({
+    url: 'http://encodingsareus-1.com/',
+    method: 'post',
+    encoding: null,
+    body: Buffer.from('hello')
+  }, function(err) {
+    assert.ok(err);
+    t.end();
+  });
+});
+
+test('doesn\'t match utf-8 buffer body with mismatching binary buffer', function(t) {
+
+  nock('http://encodingsareus-2.com')
+      .post('/', Buffer.from('hello'))
+      .reply(200);
+
+  mikealRequest({
+    url: 'http://encodingsareus-2.com/',
+    method: 'post',
+    encoding: null,
+    body: Buffer.from([0xff, 0xff, 0xff])
+  }, function(err) {
+    assert.ok(err);
+    t.end();
+  });
+});


### PR DESCRIPTION
When creating a mock, you can also pass in a buffer for an expected body.

The buffers are encoded as utf8 strings if applicable (if `common.isBinaryBuffer(...)` returns `false`), and otherwise, are hex encoded as they are on the [request client side](https://github.com/nock/nock/blob/f81fb6d/lib/request_overrider.js#L238).

This allows for matching against expected binary content like for Protobuf-based APIs, and goes along with the existing replies with buffers.

```js
// Example with compiled protobuf.js output.
const messages = require('./messages');

let incoming = messages.IncomingMessage.create({
  foo: 1,
  bar: 'test'
}).encode().finish();

let outgoing = messages.OutgoingMessage.create({
  message: 'success!'
}).encode().finish();

nock('http://proto-service.io')
  .post('/api/cool-endpoint', incoming)
  .reply(200, outgoing);

// Using buffers directly.
nock('http://buffer-api.io')
  .put('/api/thing/2', Buffer.from('Hello'))
  .reply(200, Buffer.from('Goodbye'));
```