### PR TITLE
Set socket connecting state to always be false

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -125,7 +125,6 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
   };
 
   req.socket = response.socket = Socket({ proto: options.proto });
-  req.socket.connecting = true;
 
   req.write = function(buffer, encoding, callback) {
     debug('write', arguments);

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -22,6 +22,7 @@ function Socket(options) {
   this.writable = true;
   this.readable = true;
   this.destroyed = false;
+  this.connecting = false;
 
   this.setNoDelay = noop;
   this.setKeepAlive = noop;


### PR DESCRIPTION
### Background

I recently encountered the `socketDelay` bug noted in https://github.com/nock/nock/issues/1174 (at least, fairly sure).  More specifically, I observed breakage running my test suite on node versions `>=10.7.0`. 

https://github.com/nodejs/node/pull/21204 looks like an extremely likely upstream cause of the behavior I'm experiencing with nock.  It was [released](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md) in node `v10.7.0` so the timing fits as well. 

Notably, before that change, if a request's socket attribute was truthy and writeable, `req.setTimeout` would invoke `socket.setTimeout` without inspecting any connection state, like `socket.connecting` ([ref](https://github.com/nodejs/node/pull/21204/files#diff-e3bc37430eb078ccbafe3aa3b570c91aL720)).  Now, `req.setTimeout` always checks the current state of the socket ([ref](https://github.com/nodejs/node/pull/21204/files#diff-e3bc37430eb078ccbafe3aa3b570c91aR742)):

* If a socket is currently connecting, we defer registering the timeout until after the socket emits the `'connect'` event. 
* If a socket is not currently connecting, we immediately register a timeout. 

I'm not *super* well versed in nock's guiding philosophy, but poking around the code it didn't seem like the mock socket implementation was particularly full featured or attempted to accurately model real socket behavior.  For instance, `socket.connecting` is set to `true` [here](https://github.com/nock/nock/blob/master/lib/request_overrider.js#L128), but is never set to `false`.  Further, the only time it looks like the `'connect'` event will be emitted is as a side-effect of registering the `'socket'` event on `req` ([ref](https://github.com/nock/nock/blob/master/lib/request_overrider.js#L208)), which is a bit weird (and fails to set `socket.connecting` to `false` even though it ought to be given the [docs](https://nodejs.org/api/net.html#net_socket_connecting))

### Suggested Fix

Because the life-cycle of a socket isn't really modeled in nock, my suggested fix is to simply pretend as if the socket is already connected at the time of issuing the request.  At least, this fixes the issues I'm experiencing. 

A few tests appear to be broken on `master`, but this patch doesn't appear to introduce any testing regressions, and fixes a handful in fact.  There looks to a cert expiration issue effecting some of the tests, I'll post back with any thoughts as I dig a bit more into it. 

Happy to discuss alternative ideas!

edit: looks like the CA expiration was already tackled in https://github.com/nock/nock/pull/1181/files !