### PR TITLE
[NockBack] Record "unmatched" requests only.

### DIFF
--- a/lib/back.js
+++ b/lib/back.js
@@ -172,15 +172,12 @@ var record = {
       throw new Error('no fs');
     }
     var context = load(fixture, options);
-
-    if( !context.isLoaded ) {
       recorder.record(_.assign({
         dont_print: true,
         output_objects: true
       }, options && options.recorder));
 
       context.isRecording = true;
-    }
 
     return context;
   },
@@ -194,11 +191,14 @@ var record = {
         outputs = options.afterRecord(outputs);
       }
 
-      outputs = JSON.stringify(outputs, null, 4);
       debug('recorder outputs:', outputs);
 
       mkdirp.sync(path.dirname(fixture));
-      fs.writeFileSync(fixture, outputs);
+      var existingOutputs = []
+      if (fs.existsSync(fixture)) {
+        existingOutputs = JSON.parse(fs.readFileSync(fixture))
+      }
+      fs.writeFileSync(fixture, JSON.stringify(existingOutputs.concat(outputs), null, 4));
     }
   }
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -113,7 +113,7 @@ var requestOverride = [];
 var overrideRequests = function(newRequest) {
   debug('overriding requests');
 
-  ['http', 'https'].forEach(function(proto) {
+var secondLayer = null
     debug('- overriding request for', proto);
 
     var moduleName = proto, // 1 to 1 match of protocol and module is fortunate :)
@@ -124,10 +124,10 @@ var overrideRequests = function(newRequest) {
         overriddenRequest = module.request,
         overriddenGet = module.get;
 
-    if(requestOverride[moduleName]) {
-      throw new Error('Module\'s request already overridden for ' + moduleName + ' protocol.');
-    }
-
+    if (requestOverride[moduleName]) {
+      debug('set recorder as second layer')
+      secondLayer = newRequest
+    } else {
     //  Store the properties of the overridden request so that it can be restored later on.
     requestOverride[moduleName] = {
       module: module,
@@ -135,17 +135,18 @@ var overrideRequests = function(newRequest) {
       get: overriddenGet
     };
 
-    module.request = function(options, callback) {
+      module.request = function (options, callback) {
       // debug('request options:', options);
-      return newRequest(proto, overriddenRequest.bind(module), options, callback);
+        return newRequest(proto, overriddenRequest.bind(module), options, callback, secondLayer);
     };
 
     if (semver.satisfies(process.version, '>=8')) {
-      module.get = function(options, callback) {
-        var req = newRequest(proto, overriddenRequest.bind(module), options, callback);
+        module.get = function (options, callback) {
+          var req = newRequest(proto, overriddenRequest.bind(module), options, callback, secondLayer);
         req.end();
         return req;
       }
+    }
     }
 
     debug('- overridden request for', proto);

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -402,7 +402,11 @@ function activate() {
     } else {
       globalEmitter.emit('no match', options);
       if (isOff() || isEnabledForNetConnect(options)) {
+        if (secondLayer) {
+          return secondLayer(proto, overriddenRequest, options, callback)
+        } else {
         return overriddenRequest(options, callback);
+        }
       } else {
         var error = new NetConnectNotAllowedError(options.host, options.path);
         return new ErroringClientRequest(error);

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -230,9 +230,9 @@ function record(rec_options) {
   //  we restore any requests that may have been overridden by other parts of nock (e.g. intercept)
   //  NOTE: This is hacky as hell but it keeps the backward compatibility *and* allows correct
   //    behavior in the face of other modules also overriding ClientRequest.
-  common.restoreOverriddenRequests();
+  // common.restoreOverriddenRequests();
   //  We restore ClientRequest as it messes with recording of modules that also override ClientRequest (e.g. xhr2)
-  intercept.restoreOverriddenClientRequest();
+  // intercept.restoreOverriddenClientRequest();
 
   //  We override the requests so that we can save information on them before executing.
   common.overrideRequests(function(proto, overriddenRequest, options, callback) {


### PR DESCRIPTION
## Reason for this PR
The **record** mode behavior does not meet the documentation:

> use recorded nocks, record new nocks
[/lib/back.js - line 309](https://github.com/nock/nock/blob/master/lib/back.js#L309:)

Related Issue: #1115

This PR corrects it, by appending newly recorded nocks to existing ones.

## Explanation of the code changes

Previously nock could wether **intercept** or **record**, but couldn't do both at the same time. 

Now the **record** method is used a _secondLayer_ during the intercept, effectively being able to do both at the same, so that when there are no interceptors for a requests, the recording mechanism takes it from there.