### PR TITLE
chore: ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage
 .nyc_output/
 tests/browserify-public/browserify-bundle.js
 .vscode/
+package-lock.json


### PR DESCRIPTION
We have ignored the `package-lock.json` file from PRs before (see #1155 and #965), so it makes sense to me for this tobe ignored altogether.