### PR TITLE
fixes #1265

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -21,6 +21,10 @@ module.exports = Interceptor;
 function Interceptor(scope, uri, method, requestBody, interceptorOptions) {
     this.scope = scope;
     this.interceptorMatchHeaders = [];
+
+    if (typeof method === 'undefined' || !method) {
+        throw new Error('The "method" parameter is required for an intercept call.');
+    }
     this.method = method.toUpperCase();
     this.uri = uri;
     this._key = this.method + ' ' + scope.basePath + scope.basePathname + (typeof uri === 'string' ? '' : '/') + uri;

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -29,6 +29,17 @@ var acceptableLeaks = [
   '_key', '__core-js_shared__', 'fetch', 'Response', 'Headers', 'Request'];
 
 
+test("invalid or missing method parameter throws an exception", function(t) {
+  try {
+    nock("https://example.com").
+      intercept("/somepath");
+    t.false(true);
+  } catch(error) {
+    t.equal(error.toString(), 'Error: The "method" parameter is required for an intercept call.');
+  }
+  t.end();
+});
+
 test("double activation throws exception", function(t) {
   nock.restore();
   t.false(nock.isActive());


### PR DESCRIPTION
## Description
As mentioned in #1265, the `.intercept(...)` call errors out with no useful error message when the second argument (the method) is not mentioned. 

This pull request fixes this by adding a small check to `lib/interceptor.js` and throwing an error if the provided value is either `undefined` or `null`. It would be, however, much better if a static type-check is also performed. 

## Related Issue
#1265 

## How Has This Been Tested?
A singleton test case in `tests/test_interceptor.js` invokes `.intercept(...)` with the `scope` as the first argument; the second -- or the "method" parameter -- is left out (thereby setting it to `undefined`). 

The test case makes sure that the error is thrown and that the message matches the message specified.