### PR TITLE
chore(setImmediate): use global.setImmediate instead of timers.setImmediate

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -13,7 +13,6 @@ var RequestOverrider = require('./request_overrider'),
     URL              = require('url').URL,
     _                = require('lodash'),
     debug            = require('debug')('nock.intercept'),
-    timers           = require('timers'),
     EventEmitter     = require('events').EventEmitter,
     globalEmitter    = require('./global_emitter');
 
@@ -270,7 +269,7 @@ function overrideClientRequest() {
       if(isOff() || isEnabledForNetConnect(options)) {
         originalClientRequest.apply(this, arguments);
       } else {
-        timers.setImmediate(function () {
+        setImmediate(function () {
           var error = new NetConnectNotAllowedError(options.host, options.path);
           this.emit('error', error);
         }.bind(this));

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -10,7 +10,6 @@ var EventEmitter     = require('events').EventEmitter,
     Socket           = require('./socket'),
     _                = require('lodash'),
     debug            = require('debug')('nock.request_overrider'),
-    timers           = require('timers'),
     ReadableStream   = require('stream').Readable,
     globalEmitter    = require('./global_emitter'),
     zlib             = require('zlib');
@@ -42,7 +41,7 @@ function setHeader(request, name, value) {
   }
 
   if (name == 'expect' && value == '100-continue') {
-    timers.setImmediate(function() {
+    setImmediate(function() {
       debug('continue');
       request.emit('continue');
     });
@@ -143,7 +142,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
       emitError(new Error('Request aborted'));
     }
 
-    timers.setImmediate(function() {
+    setImmediate(function() {
       req.emit('drain');
     });
 
@@ -300,7 +299,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
       } else {
         error = new Error(interceptor.errorMessage);
       }
-      timers.setTimeout(emitError, interceptor.getTotalDelay(), error);
+      setTimeout(emitError, interceptor.getTotalDelay(), error);
       return;
     }
     response.statusCode = Number(interceptor.statusCode) || 200;
@@ -537,13 +536,13 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
             }
 
             // Stream the response chunks one at a time.
-            timers.setImmediate(function emitChunk() {
+            setImmediate(function emitChunk() {
               var chunk = responseBuffers.shift();
 
               if (chunk) {
                 debug('emitting response chunk');
                 response.push(chunk);
-                timers.setImmediate(emitChunk);
+                setImmediate(emitChunk);
               }
               else {
                 debug('ending response stream');


### PR DESCRIPTION
When unit testing, it is not uncommon to mock the clock. This includes controlling when setImmediate fires. By using global.setImmediate, we adhere to this expectation. This also avoids consumers having to mock the timers module.

Resolves #677