### PR TITLE
test: Install missing dev dependency for linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "semver": "^5.5.0"
   },
   "devDependencies": {
+    "acorn": "^6.0.4",
     "async": "^2.6.0",
     "aws-sdk": "^2.202.0",
     "coveralls": "^3.0.0",


### PR DESCRIPTION
Without this change:

```
> nock@0.0.0-development pretest /Users/pnm/code/nock
> npm run -s lint

internal/modules/cjs/loader.js:582
    throw err;
    ^

Error: Cannot find module 'acorn'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:580:15)
    at Function.Module._load (internal/modules/cjs/loader.js:506:25)
    at Module.require (internal/modules/cjs/loader.js:636:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous> (/Users/pnm/code/nock/node_modules/acorn-jsx/index.js:8:15)
    at Module._compile (internal/modules/cjs/loader.js:688:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:699:10)
    at Module.load (internal/modules/cjs/loader.js:598:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:537:12)
    at Function.Module._load (internal/modules/cjs/loader.js:529:3)
```