### PR TITLE
chore: Only run coverage in latest Node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
       node_js: lts/*
       env: semantic-release
       script: npm run semantic-release
-    - node_js: lts/*
+    - node_js: 10
       env: coverage
       script:
         - npm run test


### PR DESCRIPTION
Try to fix issue where coverage reporting on PRs seems wrong:

- https://github.com/nock/nock/pull/1286#issuecomment-447696329
- https://github.com/nock/nock/pull/1283#issuecomment-447685920