### PR TITLE
bump semantic-release to v16 beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "request-promise": "^4.2.2",
     "restify-clients": "^2.2.0",
     "rimraf": "^2.6.2",
-    "semantic-release": "^15.0.0",
+    "semantic-release": "^16.0.0-beta.10",
     "superagent": "^4.0.0",
     "tap": "^12.0.0"
   },


### PR DESCRIPTION
we’ll need this for pre- and maintenance releases. Follow up for https://github.com/nock/nock/issues/1285