### PR TITLE
fix(mixin): Remove dead code

### DIFF
--- a/lib/mixin.js
+++ b/lib/mixin.js
@@ -2,8 +2,6 @@
 var _ = require("lodash");
 
 function mixin(a, b) {
-	if (! a) { a = {}; }
-	if (! b) {b = {}; }
 	a = _.cloneDeep(a);
 	for(var prop in b) {
 		a[prop] = b[prop];


### PR DESCRIPTION
These two lines are not covered by code coverage. The function is called in one place, where it always has truthy arguments, so it seems simplest to remove this behavior.