### PR TITLE
fix: package.engines is supposed to be an object

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   "bugs": {
     "url": "http://github.com/nock/nock/issues"
   },
-  "engines": [
-    "node >= 8.0"
-  ],
+  "engines": {
+    "node": ">= 8.0"
+  },
   "main": "./index",
   "dependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
See https://docs.npmjs.com/files/package.json#engines

This is causing a validation error in Shields:

![](https://img.shields.io/npm/l/nock.svg)
https://img.shields.io/npm/l/nock.svg