### PR TITLE
test(test_back): Cover both of the ‘no fs’ code paths

### DIFF
--- a/tests/test_back.js
+++ b/tests/test_back.js
@@ -255,19 +255,6 @@ tap.test('nockBack dryrun tests', nw => {
 tap.test('nockBack record tests', nw => {
   nockBack.setMode('record');
 
-  nw.test('nockBack record throws an exception when fs is not available', t => {
-    const nockBackWithoutFs = proxyquire('../lib/back', {fs: null});
-    setOriginalModeOnEnd(t, nockBackWithoutFs);
-
-    nockBackWithoutFs.fixtures = __dirname + '/fixtures';
-
-    t.throws(
-      () => nockBackWithoutFs('goodRequest.json'),
-      {message: 'no fs'});
-
-    t.end();
-  });
-
   nw.test('it records when configured correctly', t => {
     t.plan(4)
 
@@ -448,4 +435,27 @@ tap.test('nockBack lockdown tests', nw => {
   });
 
   nw.end();
+});
+
+tap.test('nockBack dryrun throws the expected exception when fs is not available', t => {
+  const nockBackWithoutFs = proxyquire('../lib/back', {fs: null});
+
+  nockBackWithoutFs.fixtures = __dirname + '/fixtures';
+  t.throws(
+    () => nockBackWithoutFs('goodRequest.json'),
+    {message: 'no fs'});
+
+  t.end();
+});
+
+tap.test('nockBack record mode throws the expected exception when fs is not available', t => {
+  const nockBackWithoutFs = proxyquire('../lib/back', {fs: null});
+  nockBackWithoutFs.setMode('record')
+  setOriginalModeOnEnd(t, nockBackWithoutFs);
+
+  nockBackWithoutFs.fixtures = __dirname + '/fixtures';
+  t.throws(
+    () => nockBackWithoutFs('goodRequest.json'),
+    {message: 'no fs'});
+  t.end();
 });


### PR DESCRIPTION
Ref https://github.com/nock/nock/pull/1298#issuecomment-448392497