### PR TITLE
Avoid hoisting function decls

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -85,143 +85,14 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
     response._read = function() {}
   }
 
-  const requestBodyBuffers = []
-  let ended
-  let headers
-
-  //  We may be changing the options object and we don't want those
-  //  changes affecting the user so we use a clone of the object.
-  options = _.clone(options) || {}
-
-  response.req = req
-
-  if (options.headers) {
-    //  We use lower-case header field names throught Nock.
-    options.headers = common.headersFieldNamesToLowerCase(options.headers)
-
-    headers = options.headers
-    _.forOwn(headers, function(val, key) {
-      setHeader(req, key, val)
-    })
-  }
-
-  /// options.auth
-  if (options.auth && (!options.headers || !options.headers.authorization)) {
-    setHeader(
-      req,
-      'Authorization',
-      `Basic ${Buffer.from(options.auth).toString('base64')}`
-    )
-  }
-
-  if (!req.connection) {
-    req.connection = new EventEmitter()
-  }
-
-  req.path = options.path
-
-  options.getHeader = function(name) {
-    return getHeader(req, name)
-  }
-
-  req.socket = response.socket = Socket({ proto: options.proto })
-
-  req.write = function(buffer, encoding, callback) {
-    debug('write', arguments)
-    if (!req.aborted) {
-      if (buffer) {
-        if (!Buffer.isBuffer(buffer)) {
-          buffer = Buffer.from(buffer, encoding)
-        }
-        requestBodyBuffers.push(buffer)
-      }
-      if (typeof callback === 'function') {
-        callback()
-      }
-    } else {
-      emitError(new Error('Request aborted'))
-    }
-
-    setImmediate(function() {
-      req.emit('drain')
-    })
-
-    return false
-  }
-
-  req.end = function(buffer, encoding, callback) {
-    debug('req.end')
-    if (!req.aborted && !ended) {
-      req.write(buffer, encoding, function() {
-        if (typeof callback === 'function') {
-          callback()
-        }
-        end(cb)
-        req.emit('finish')
-        req.emit('end')
-      })
-    }
-    if (req.aborted) {
-      emitError(new Error('Request aborted'))
-    }
-  }
-
-  req.flushHeaders = function() {
-    debug('req.flushHeaders')
-    if (!req.aborted && !ended) {
-      end(cb)
-    }
-    if (req.aborted) {
-      emitError(new Error('Request aborted'))
-    }
-  }
-
-  req.abort = function() {
-    if (req.aborted) {
-      return
-    }
-    debug('req.abort')
-    req.aborted = Date.now()
-    if (!ended) {
-      end()
-    }
-    const err = new Error()
-    err.code = 'aborted'
-    response.emit('close', err)
-
-    req.socket.destroy()
-
-    req.emit('abort')
-
-    const connResetError = new Error('socket hang up')
-    connResetError.code = 'ECONNRESET'
-    emitError(connResetError)
-  }
-
-  // restify listens for a 'socket' event to
-  // be emitted before calling end(), which causes
-  // nock to hang with restify. The following logic
-  // fakes the socket behavior for restify,
-  // Fixes: https://github.com/pgte/nock/issues/79
-  req.once = req.on = function(event, listener) {
-    // emit a fake socket.
-    if (event == 'socket') {
-      listener.call(req, req.socket)
-      req.socket.emit('connect', req.socket)
-      req.socket.emit('secureConnect', req.socket)
-    }
-
-    EventEmitter.prototype.on.call(this, event, listener)
-    return this
-  }
-
-  const emitError = function(error) {
+  function emitError(error) {
     process.nextTick(function() {
       req.emit('error', error)
     })
   }
 
-  const end = function(cb) {
+  let ended
+  function end(cb) {
     debug('ending')
     ended = true
     let requestBody, responseBody, responseBuffers, interceptor
@@ -596,6 +467,135 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
         }
       }
     }
+  }
+
+  const requestBodyBuffers = []
+  let headers
+
+  //  We may be changing the options object and we don't want those
+  //  changes affecting the user so we use a clone of the object.
+  options = _.clone(options) || {}
+
+  response.req = req
+
+  if (options.headers) {
+    //  We use lower-case header field names throught Nock.
+    options.headers = common.headersFieldNamesToLowerCase(options.headers)
+
+    headers = options.headers
+    _.forOwn(headers, function(val, key) {
+      setHeader(req, key, val)
+    })
+  }
+
+  /// options.auth
+  if (options.auth && (!options.headers || !options.headers.authorization)) {
+    setHeader(
+      req,
+      'Authorization',
+      `Basic ${Buffer.from(options.auth).toString('base64')}`
+    )
+  }
+
+  if (!req.connection) {
+    req.connection = new EventEmitter()
+  }
+
+  req.path = options.path
+
+  options.getHeader = function(name) {
+    return getHeader(req, name)
+  }
+
+  req.socket = response.socket = Socket({ proto: options.proto })
+
+  req.write = function(buffer, encoding, callback) {
+    debug('write', arguments)
+    if (!req.aborted) {
+      if (buffer) {
+        if (!Buffer.isBuffer(buffer)) {
+          buffer = Buffer.from(buffer, encoding)
+        }
+        requestBodyBuffers.push(buffer)
+      }
+      if (typeof callback === 'function') {
+        callback()
+      }
+    } else {
+      emitError(new Error('Request aborted'))
+    }
+
+    setImmediate(function() {
+      req.emit('drain')
+    })
+
+    return false
+  }
+
+  req.end = function(buffer, encoding, callback) {
+    debug('req.end')
+    if (!req.aborted && !ended) {
+      req.write(buffer, encoding, function() {
+        if (typeof callback === 'function') {
+          callback()
+        }
+        end(cb)
+        req.emit('finish')
+        req.emit('end')
+      })
+    }
+    if (req.aborted) {
+      emitError(new Error('Request aborted'))
+    }
+  }
+
+  req.flushHeaders = function() {
+    debug('req.flushHeaders')
+    if (!req.aborted && !ended) {
+      end(cb)
+    }
+    if (req.aborted) {
+      emitError(new Error('Request aborted'))
+    }
+  }
+
+  req.abort = function() {
+    if (req.aborted) {
+      return
+    }
+    debug('req.abort')
+    req.aborted = Date.now()
+    if (!ended) {
+      end()
+    }
+    const err = new Error()
+    err.code = 'aborted'
+    response.emit('close', err)
+
+    req.socket.destroy()
+
+    req.emit('abort')
+
+    const connResetError = new Error('socket hang up')
+    connResetError.code = 'ECONNRESET'
+    emitError(connResetError)
+  }
+
+  // restify listens for a 'socket' event to
+  // be emitted before calling end(), which causes
+  // nock to hang with restify. The following logic
+  // fakes the socket behavior for restify,
+  // Fixes: https://github.com/pgte/nock/issues/79
+  req.once = req.on = function(event, listener) {
+    // emit a fake socket.
+    if (event == 'socket') {
+      listener.call(req, req.socket)
+      req.socket.emit('connect', req.socket)
+      req.socket.emit('secureConnect', req.socket)
+    }
+
+    EventEmitter.prototype.on.call(this, event, listener)
+    return this
   }
 
   return req


### PR DESCRIPTION
Hoping this will improve the stack traces when tests fail.

https://github.com/nock/nock/issues/1305#issuecomment-451055287

As I read this I'm not sure it would actually affect whether or not these are hoisted, nor whether changing the order, or changing from function expressions to function declarations, would affect either the line numbers, or whether hoisting takes place.

I do think this makes the code clearer. However I'm not sure this is helping with those oddball line numbers, and just as puzzled by them as before.