### PR TITLE
test(Scope): Improve coverage on no-op Scope#remove test

### DIFF
--- a/tests/test_scope.js
+++ b/tests/test_scope.js
@@ -65,7 +65,6 @@ test('scope#remove() is a no-op on a persisted mock', t => {
 
 test('scope#remove() is a no-op on a nonexistent key', t => {
   const scope = nock('http://example.test')
-    .persist()
     .get('/')
     .reply(200)
   const key = 'GET http://example.test:80/'


### PR DESCRIPTION
The `persist()` is causing this to follow a different path than the one this was intended to cover.