### PR TITLE
refactor: Replace homegrown buffer compare with library method

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -36,8 +36,11 @@ const normalizeRequestOptions = function(options) {
 }
 
 /**
- * Returns true if the data contained in buffer can be reconstructed
+ * Returns false if the data contained in buffer can be reconstructed
  * from its utf8 representation.
+ *
+ * TODO: Reverse the semantics of this method and refactor calling code
+ * accordingly. We've inadvertantly gotten it flipped.
  *
  * @param  {Object} buffer - a Buffer object
  */
@@ -48,26 +51,7 @@ const isUtf8Representable = function(buffer) {
 
   const utfEncodedBuffer = buffer.toString('utf8')
   const reconstructedBuffer = Buffer.from(utfEncodedBuffer, 'utf8')
-  const compareBuffers = function(lhs, rhs) {
-    if (lhs.length !== rhs.length) {
-      return false
-    }
-
-    for (let i = 0; i < lhs.length; ++i) {
-      if (lhs[i] !== rhs[i]) {
-        // TODO: There are unit tests of this utility function in test_common.
-        // This line is not reached by those examples. It would be good to
-        // find an example that does.
-        return false
-      }
-    }
-
-    return true
-  }
-
-  //  If the buffers are *not* equal then this is a "binary buffer"
-  //  meaning that it cannot be faitfully represented in utf8.
-  return !compareBuffers(buffer, reconstructedBuffer)
+  return !reconstructedBuffer.equals(buffer)
 }
 
 /**


### PR DESCRIPTION
I found the library function we were looking for :)

We messed up on the semantics of this method in #1375. I think we should reverse the semantics of the method and started to fix that, though it's a somewhat involved diff so I decided to defer the refactor until we hit our coverage target.