### PR TITLE
tests: Add tests for lib/recorder.getScope

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -9,7 +9,7 @@ const debug = require('debug')('nock.common')
  * @param  {Object} options - a parsed options object of the request
  */
 const normalizeRequestOptions = function(options) {
-  options.proto = options.proto || (options._https_ ? 'https' : 'http')
+  options.proto = options.proto || 'http'
   options.port = options.port || (options.proto === 'http' ? 80 : 443)
   if (options.host) {
     debug('options.host:', options.host)

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -17,7 +17,7 @@ function getScope(options) {
   common.normalizeRequestOptions(options)
 
   const scope = []
-  if (options._https_) {
+  if (options.proto === 'https') {
     scope.push('https://')
   } else {
     scope.push('http://')
@@ -25,14 +25,11 @@ function getScope(options) {
 
   scope.push(options.host)
 
-  // If a non-standard port wasn't specified in options.host, include it from
-  // options.port.
-  // TODO-coverage: Add a test of this case.
   if (
     options.host.indexOf(':') === -1 &&
     options.port &&
-    ((options._https_ && options.port.toString() !== '443') ||
-      (!options._https_ && options.port.toString() !== '80'))
+    ((options.proto && options.port.toString() !== '443') ||
+      (!options.proto && options.port.toString() !== '80'))
   ) {
     scope.push(':')
     scope.push(options.port)
@@ -386,8 +383,12 @@ function record(rec_options) {
 
       debug('finished setting up intercepting')
 
+      // We override both the http and the https modules; when we are
+      // serializing the request, we need to know which was called.
+      // By stuffing the state, we can make sure that nock records
+      // the intended protocol.
       if (proto === 'https') {
-        options._https_ = true
+        options.proto = 'https'
       }
     })
 


### PR DESCRIPTION
I also added a test to check for alternative ports.

Part of #1374.