### PR TITLE
refactor(request_overrider): Remove unreachable code

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -311,26 +311,8 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
     if (typeof interceptor.body === 'function') {
       if (requestBody && common.isJSONContent(req.headers)) {
         if (common.contentEncoding(req.headers, 'gzip')) {
-          if (typeof zlib.gunzipSync !== 'function') {
-            // TODO-coverage: This is never truthy. Remove.
-            emitError(
-              new Error(
-                'Gzip encoding is currently not supported in this version of Node.'
-              )
-            )
-            return
-          }
           requestBody = String(zlib.gunzipSync(Buffer.from(requestBody, 'hex')))
         } else if (common.contentEncoding(req.headers, 'deflate')) {
-          if (typeof zlib.deflateSync !== 'function') {
-            // TODO-coverage: This is never truthy. Remove.
-            emitError(
-              new Error(
-                'Deflate encoding is currently not supported in this version of Node.'
-              )
-            )
-            return
-          }
           requestBody = String(
             zlib.inflateSync(Buffer.from(requestBody, 'hex'))
           )

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -11,7 +11,6 @@ const common = require('./common')
 const Socket = require('./socket')
 const _ = require('lodash')
 const debug = require('debug')('nock.request_overrider')
-const ReadableStream = require('stream').Readable
 const globalEmitter = require('./global_emitter')
 const zlib = require('zlib')
 const timers = require('timers')
@@ -79,15 +78,7 @@ function setRequestHeaders(req, options, interceptor) {
 }
 
 function RequestOverrider(req, options, interceptors, remove, cb) {
-  let response
-  if (IncomingMessage) {
-    response = new IncomingMessage(new EventEmitter())
-  } else {
-    // TODO-coverage: This is unreachable because `IncomingMessage` is always
-    // truthy.
-    response = new ReadableStream()
-    response._read = function() {}
-  }
+  const response = new IncomingMessage(new EventEmitter())
 
   const requestBodyBuffers = []
   let ended


### PR DESCRIPTION
- `http.IncomingMessage` was added in Node v0.1.17. Since then it has always been truthy.
- `zlib.gunzipSync` and `zlib.deflateSync` were added in v0.11.12 and have been truthy since then.