### PR TITLE
test: Remove a pointless test

### DIFF
--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -516,37 +516,6 @@ test('isDone', async t => {
   scope.done()
 })
 
-test('request headers exposed', t => {
-  const scope = nock('http://example.com')
-    .get('/')
-    .reply(200, 'Hello World!', { 'X-My-Headers': 'My Header value' })
-
-  // Testing that the req is augmented, so using `http`.
-  const req = http.get(
-    {
-      host: 'example.com',
-      method: 'GET',
-      path: '/',
-      port: 80,
-      headers: { 'X-My-Headers': 'My custom Header value' },
-    },
-    res => {
-      res.on('end', () => {
-        scope.done()
-        t.end()
-      })
-      // Streams start in 'paused' mode and must be started.
-      // See https://nodejs.org/api/stream.html#stream_class_stream_readable
-      res.resume()
-    }
-  )
-
-  t.equivalent(req._headers, {
-    'x-my-headers': 'My custom Header value',
-    host: 'example.com',
-  })
-})
-
 test('headers work', async t => {
   const scope = nock('http://example.com')
     .get('/')


### PR DESCRIPTION
This test was added in https://github.com/nock/nock/commit/1b5849ac391e81c464938e22d7577b8b3f23b724 which set `_headers` on an intercepted `req` object.

Presumably subsequently, `_headers` became a property on `http.OutgoingMessage`.

It was later deprecated:
https://nodejs.org/api/deprecations.html#deprecations_dep0066_outgoingmessage_headers_outgoingmessage_headernames

Suffice it to say that:

1. The assertion passes when run _without_ nock.
2. This test does not seem to any longer exercise any code from `nock`.