### PR TITLE
refactor(request_overrider): Remove dead code

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -16,30 +16,13 @@ const zlib = require('zlib')
 const timers = require('timers')
 
 function getHeader(request, name) {
-  if (!request._headers) {
-    return
-  }
-
-  const key = name.toLowerCase()
-
-  return request.getHeader ? request.getHeader(key) : request._headers[key]
+  return request.getHeader(name.toLowerCase())
 }
 
 function setHeader(request, name, value) {
   debug('setHeader', name, value)
 
-  const key = name.toLowerCase()
-
-  request._headers = request._headers || {}
-  request._headerNames = request._headerNames || {}
-  request._removedHeader = request._removedHeader || {}
-
-  if (request.setHeader) {
-    request.setHeader(key, value)
-  } else {
-    request._headers[key] = value
-    request._headerNames[key] = name
-  }
+  request.setHeader(name.toLowerCase(), value)
 
   if (name == 'expect' && value == '100-continue') {
     timers.setImmediate(function() {
@@ -283,7 +266,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
     //  We again set request headers, now for our matched interceptor.
     setRequestHeaders(req, options, interceptor)
     interceptor.req = req
-    req.headers = req.getHeaders ? req.getHeaders() : req._headers
+    req.headers = req.getHeaders()
 
     interceptor.scope.emit('request', req, interceptor, requestBody)
 
@@ -415,12 +398,10 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
 
           if (responseBody.length >= 2 && responseBody.length <= 3) {
             debug('new headers: %j', responseBody[2])
-            if (!response.headers) response.headers = {}
             _.assign(response.headers, responseBody[2] || {})
             debug('response.headers after: %j', response.headers)
             responseBody = responseBody[1]
 
-            response.rawHeaders = response.rawHeaders || []
             Object.keys(response.headers).forEach(function(key) {
               response.rawHeaders.push(key, response.headers[key])
             })


### PR DESCRIPTION
- `response.headers` was added in Node v0.1.5 and `response.rawHeaders` in v0.11.6. They are truthy.
- `_headers` was deprecated, and replaced with `getHeader()`, `getHeaders()`, and `setHeader()`: https://nodejs.org/api/deprecations.html#deprecations_dep0066_outgoingmessage_headers_outgoingmessage_headernames