### PR TITLE
fix(intercept): Improve error message when `new ClientMessage()` is invoked with no options

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -260,6 +260,7 @@ function overrideClientRequest() {
       // In principle, there is no reason we couldn't support this. However it
       // doesn't work, and fixing it seems low priority. Giving an explicit
       // error seems nicer than crashing with a weird stack trace.
+      // https://github.com/nock/nock/pull/1386
       throw Error(
         'Creating a client request with empty `options` is not supported in Nock'
       )

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -256,6 +256,15 @@ function overrideClientRequest() {
 
   //  Define the overriding client request that nock uses internally.
   function OverriddenClientRequest(options, cb) {
+    if (!options) {
+      // In principle, there is no reason we couldn't support this. However it
+      // doesn't work, and fixing it seems low priority. Giving an explicit
+      // error seems nicer than crashing with a weird stack trace.
+      throw Error(
+        'Creating a client request with empty `options` is not supported in Nock'
+      )
+    }
+
     // TODO-coverage: Remove this conditional, as it is always true in Node 8+.
     if (http.OutgoingMessage) http.OutgoingMessage.call(this)
 

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -86,7 +86,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
 
   //  We may be changing the options object and we don't want those
   //  changes affecting the user so we use a clone of the object.
-  options = _.clone(options) || {}
+  options = _.clone(options)
 
   response.req = req
 


### PR DESCRIPTION
In Node, it’s valid to invoke `new ClientMessage()` with no options. However, in Nock, this causes a crash:

```
Cannot read property 'proto' of undefined
    stack: |
      Object.normalizeRequestOptions (lib/common.js:12:27)
      interceptorsFor (lib/intercept.js:139:10)
      new OverriddenClientRequest (lib/intercept.js:263:26)
      Test.t (tests/test_request_overrider.js:20:8)
```

Fixing that does not seem like a high priority, so this provides a better error message, while also removing related unreachable code.