### PR TITLE
Throw error when leading slash is not present in path

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -18,8 +18,9 @@ try {
 module.exports = Interceptor
 
 function Interceptor(scope, uri, method, requestBody, interceptorOptions) {
-  // Adds a leading slash if required
-  if (typeof uri === 'string' && !['', '*', '/'].includes(uri.charAt(0))) {
+  // Adds a leading slash if required. Uri can be either a string or a regexp, but
+  // we only need to check strings.
+  if (typeof uri === 'string' && /^[^/*]/.test(uri)) {
     uri = `/${uri}`
   }
 

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -18,6 +18,11 @@ try {
 module.exports = Interceptor
 
 function Interceptor(scope, uri, method, requestBody, interceptorOptions) {
+  // Adds a leading slash if required
+  if (typeof uri === 'string' && !['', '*', '/'].includes(uri.charAt(0))) {
+    uri = `/${uri}`
+  }
+
   this.scope = scope
   this.interceptorMatchHeaders = []
 

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -18,10 +18,12 @@ try {
 module.exports = Interceptor
 
 function Interceptor(scope, uri, method, requestBody, interceptorOptions) {
-  // Adds a leading slash if required. Uri can be either a string or a regexp, but
+  // Check for leading slash. Uri can be either a string or a regexp, but
   // we only need to check strings.
   if (typeof uri === 'string' && /^[^/*]/.test(uri)) {
-    uri = `/${uri}`
+    throw Error(
+      "Non-wildcard URL path strings must begin with a slash (otherwise they won't match anything)"
+    )
   }
 
   this.scope = scope

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -106,26 +106,9 @@ test("when request's content-type is json: reply callback's requestBody should a
   scope.done()
 })
 
-test("adds a leading slash when the path doesn't include one", function(t) {
+test("when the path doesn't include a leading slash it raises an error", function(t) {
   t.plan(1)
-
-  const scope = nock('http://example.test')
-    .get('no-leading-slash')
-    .reply((path, requestBody) => 200)
-
-  http
-    .request(
-      {
-        host: 'example.test',
-        path: '/no-leading-slash',
-        port: 80,
-      },
-      res => {
-        t.equal(res.statusCode, 200, 'intercepts the request')
-        res.on('end', () => scope.done())
-      }
-    )
-    .end()
+  t.throws(() => nock('http://example.test').get('no-leading-slash'))
 })
 
 test("when request has no content-type header: reply callback's requestBody should not automatically parse to JSON", async t => {

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -106,6 +106,28 @@ test("when request's content-type is json: reply callback's requestBody should a
   scope.done()
 })
 
+test("adds a leading slash when the path doesn't include one", function(t) {
+  t.plan(1)
+
+  const scope = nock('http://example.test')
+    .get('no-leading-slash')
+    .reply((path, requestBody) => 200)
+
+  http
+    .request(
+      {
+        host: 'example.test',
+        path: '/no-leading-slash',
+        port: 80,
+      },
+      res => {
+        t.equal(res.statusCode, 200, 'intercepts the request')
+        res.on('end', () => scope.done())
+      }
+    )
+    .end()
+})
+
 test("when request has no content-type header: reply callback's requestBody should not automatically parse to JSON", async t => {
   const requestBodyFixture = {
     id: 1,


### PR DESCRIPTION
~Previously, whenever you intercept a path with no leading slash nock will not resolve the URL correctly. This fixes the issue by adding a leading slash if required while creating an `Interceptor`.~

Given https://github.com/nock/nock/pull/1391#discussion_r250725610, we decided to make nock raise an error whenever the user forgets to add a leading slash into the intercepted path, instead of adding it itself.

Fixes #1259. 