### PR TITLE
refactor(common): Remove unreachable code in mergeChunks

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -54,29 +54,6 @@ const isUtf8Representable = function(buffer) {
   return !reconstructedBuffer.equals(buffer)
 }
 
-/**
- * If the chunks are Buffer objects then it returns a single Buffer object with the data from all the chunks.
- * If the chunks are strings then it returns a single string value with data from all the chunks.
- *
- * @param  {Array} chunks - an array of Buffer objects or strings
- */
-const mergeChunks = function(chunks) {
-  if (_.isEmpty(chunks)) {
-    return Buffer.alloc(0)
-  }
-
-  // We assume that all chunks are Buffer objects if the first is buffer object.
-  const areBuffers = Buffer.isBuffer(_.first(chunks))
-
-  if (!areBuffers) {
-    // TODO-coverage: In reality is this ever called with strings instead of
-    // buffers? Either add a functional test or remove this.
-    return chunks.join('')
-  }
-
-  return Buffer.concat(chunks)
-}
-
 //  Array where all information about all the overridden requests are held.
 let requestOverride = []
 
@@ -410,7 +387,6 @@ function isStream(obj) {
 
 exports.normalizeRequestOptions = normalizeRequestOptions
 exports.isUtf8Representable = isUtf8Representable
-exports.mergeChunks = mergeChunks
 exports.overrideRequests = overrideRequests
 exports.restoreOverriddenRequests = restoreOverriddenRequests
 exports.stringifyRequest = stringifyRequest

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -66,7 +66,7 @@ const getBodyFromChunks = function(chunks, headers) {
     }
   }
 
-  const mergedBuffer = common.mergeChunks(chunks)
+  const mergedBuffer = Buffer.concat(chunks)
 
   //  The merged buffer can be one of three things:
   //    1.  A binary buffer which then has to be recorded as a hex string.

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -212,7 +212,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
     let continued = false
 
     //  When request body is a binary buffer we internally use in its hexadecimal representation.
-    const requestBodyBuffer = common.mergeChunks(requestBodyBuffers)
+    const requestBodyBuffer = Buffer.concat(requestBodyBuffers)
     const isBinaryRequestBodyBuffer = common.isUtf8Representable(
       requestBodyBuffer
     )


### PR DESCRIPTION
- Only buffers are ever put into the `chunks` and `requestBodyBuffers` arrays
- `Buffer.concat([])` already returns a Buffer

Ref #1404