### PR TITLE
refactor(intercept): Remove dead code for unreachable edge case

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -206,19 +206,13 @@ function removeInterceptor(options) {
   }
 
   if (allInterceptors[baseUrl] && allInterceptors[baseUrl].scopes.length > 0) {
-    if (key) {
-      for (let i = 0; i < allInterceptors[baseUrl].scopes.length; i++) {
-        const interceptor = allInterceptors[baseUrl].scopes[i]
-        if (interceptor._key === key) {
-          allInterceptors[baseUrl].scopes.splice(i, 1)
-          interceptor.scope.remove(key, interceptor)
-          break
-        }
+    for (let i = 0; i < allInterceptors[baseUrl].scopes.length; i++) {
+      const interceptor = allInterceptors[baseUrl].scopes[i]
+      if (interceptor._key === key) {
+        allInterceptors[baseUrl].scopes.splice(i, 1)
+        interceptor.scope.remove(key, interceptor)
+        break
       }
-    } else {
-      // TODO-coverage: This condition only seems reachable if `options` is an
-      // `Interceptor` with no `_key`. Does that ever happen?
-      allInterceptors[baseUrl].scopes.length = 0
     }
 
     return true


### PR DESCRIPTION
The only time `key` is falsy is if we've gotten an `Interceptor` and it has a falsy `_key`. `_key` is set to a truthy value in the Interceptor constructor and doesn't appear to be set anywhere else.

Also, this behavior of emptying the array made no sense to begin with.

Ref #1404 