### PR TITLE
refactor(intercept): Remove dead code

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -238,11 +238,6 @@ inherits(ErroringClientRequest, http.ClientRequest)
 function overrideClientRequest() {
   debug('Overriding ClientRequest')
 
-  if (originalClientRequest) {
-    // TODO-coverage: Add a test that covers this case.
-    throw new Error('Nock already overrode http.ClientRequest')
-  }
-
   // ----- Extending http.ClientRequest
 
   //  Define the overriding client request that nock uses internally.


### PR DESCRIPTION
This function is exported from this module, though it doesn't appear to be part of the public interface, and is only invoked here, from `activate()`. Activate makes the same check before calling this function.