### PR TITLE
refactor(common): Gently refactor headersArrayToObject

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -242,8 +242,8 @@ const headersFieldsArrayToLowerCase = function(headers) {
 }
 
 const headersArrayToObject = function(rawHeaders) {
-  if (!_.isArray(rawHeaders)) {
-    return rawHeaders
+  if (!Array.isArray(rawHeaders)) {
+    throw Error('Expected a header array')
   }
 
   const headers = {}

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -87,8 +87,10 @@ Interceptor.prototype.reply = function reply(statusCode, body, rawHeaders) {
 
   _.defaults(this.options, this.scope.scopeOptions)
 
-  // convert rawHeaders from Array to Object
-  let headers = common.headersArrayToObject(rawHeaders)
+  // If needed, convert rawHeaders from Array to Object.
+  let headers = Array.isArray(rawHeaders)
+    ? common.headersArrayToObject(rawHeaders)
+    : rawHeaders
 
   if (this.scope._defaultReplyHeaders) {
     // TODO-coverage: Remove this conditional, replacing it with a type check

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -327,5 +327,9 @@ test('headersArrayToObject', function(t) {
     ],
   })
 
+  t.throws(() => common.headersArrayToObject(123), {
+    message: 'Expected a header array',
+  })
+
   t.end()
 })


### PR DESCRIPTION
This came up while working on #1424. This code remains ugly, though it's apparent now why the `|| {}` assignment is needed.