### PR TITLE
refactor(scope): Remove unreachable code in Scope constructor

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -26,11 +26,6 @@ function startScope(basePath, options) {
 }
 
 function Scope(basePath, options) {
-  if (!(this instanceof Scope)) {
-    // TODO-coverage: Add a simple test to cover this line.
-    return new Scope(basePath, options)
-  }
-
   EventEmitter.apply(this)
   this.keyedInterceptors = {}
   this.interceptors = []


### PR DESCRIPTION
The `Scope` constructor is not exported, so this code is unreachable.