### PR TITLE
Add TODO comment to remove request to example.com

### DIFF
--- a/tests/test_recorder.js
+++ b/tests/test_recorder.js
@@ -626,6 +626,7 @@ test("doesn't record request headers by default", t => {
       output_objects: true,
     })
 
+    // TODO: replace request to www.example.com with local server
     http
       .request(
         {


### PR DESCRIPTION
I just had a built fail because of it:
https://travis-ci.org/nock/nock/jobs/496683359#L2610