### PR TITLE
Comprehensive cleanup after each test

### DIFF
--- a/tests/cleanup_after_each.js
+++ b/tests/cleanup_after_each.js
@@ -3,7 +3,7 @@
 const { afterEach } = require('tap')
 const nock = require('..')
 
-module.exports = function registerCleanupHook() {
+module.exports = function cleanupAfterEach() {
   // After each test, clean up all of nock's global state. Since tap creates a
   // separate process for each test module, this function must be called at
   // the top of each one.

--- a/tests/cleanup_hook.js
+++ b/tests/cleanup_hook.js
@@ -1,0 +1,15 @@
+const { afterEach } = require('tap')
+const nock = require('..')
+
+module.exports = function registerCleanupHook() {
+  // After each test, clean up all of nock's global state. Since tap creates a
+  // separate process for each test module, this function must be called at
+  // the top of each one.
+  afterEach(done => {
+    nock.restore()
+    nock.cleanAll()
+    nock.enableNetConnect()
+    nock.activate()
+    done()
+  })
+}

--- a/tests/cleanup_hook.js
+++ b/tests/cleanup_hook.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { afterEach } = require('tap')
 const nock = require('..')
 

--- a/tests/test_abort.js
+++ b/tests/test_abort.js
@@ -4,7 +4,7 @@ const nock = require('..')
 const http = require('http')
 const { test } = require('tap')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('[actual] req.abort() should cause "abort" and "error" to be emitted', t => {
   nock('http://localhost:16829')

--- a/tests/test_abort.js
+++ b/tests/test_abort.js
@@ -1,8 +1,10 @@
 'use strict'
 
-const nock = require('../.')
+const nock = require('..')
 const http = require('http')
 const { test } = require('tap')
+
+require('./cleanup_hook')()
 
 test('[actual] req.abort() should cause "abort" and "error" to be emitted', t => {
   nock('http://localhost:16829')

--- a/tests/test_allow_unmocked.js
+++ b/tests/test_allow_unmocked.js
@@ -5,7 +5,9 @@ const url = require('url')
 const got = require('got')
 const mikealRequest = require('request')
 const { test } = require('tap')
-const nock = require('../.')
+const nock = require('..')
+
+require('./cleanup_hook')()
 
 test('with allowUnmocked, mocked request still works', async t => {
   const scope = nock('http://example.com', { allowUnmocked: true })
@@ -231,8 +233,6 @@ test('match hostname using regexp with allowUnmocked (issue-1076)', t => {
 
 // https://github.com/nock/nock/issues/835
 test('match multiple paths to domain using regexp with allowUnmocked', async t => {
-  nock.cleanAll()
-
   const server = http.createServer((request, response) => {
     response.write('live')
     response.end()
@@ -258,7 +258,6 @@ test('match multiple paths to domain using regexp with allowUnmocked', async t =
 })
 
 test('match domain and path using regexp with query params and allowUnmocked', t => {
-  nock.cleanAll()
   const imgResponse = 'Matched Images Page'
   const opts = { allowUnmocked: true }
 
@@ -281,8 +280,6 @@ test('match domain and path using regexp with query params and allowUnmocked', t
 
 // https://github.com/nock/nock/issues/490
 test('match when query is specified with allowUnmocked', async t => {
-  nock.cleanAll()
-
   const server = http.createServer((request, response) => {
     response.write('live')
     response.end()

--- a/tests/test_allow_unmocked.js
+++ b/tests/test_allow_unmocked.js
@@ -7,7 +7,7 @@ const mikealRequest = require('request')
 const { test } = require('tap')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('with allowUnmocked, mocked request still works', async t => {
   const scope = nock('http://example.com', { allowUnmocked: true })

--- a/tests/test_allow_unmocked_https.js
+++ b/tests/test_allow_unmocked_https.js
@@ -7,7 +7,7 @@ const nock = require('..')
 const ssl = require('./ssl')
 const got = require('got')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('Nock with allowUnmocked and an url match', async t => {
   const options = {

--- a/tests/test_allow_unmocked_https.js
+++ b/tests/test_allow_unmocked_https.js
@@ -3,11 +3,11 @@
 const { test } = require('tap')
 const fs = require('fs')
 const https = require('https')
-const nock = require('../')
+const nock = require('..')
 const ssl = require('./ssl')
 const got = require('got')
 
-nock.enableNetConnect()
+require('./cleanup_hook')()
 
 test('Nock with allowUnmocked and an url match', async t => {
   const options = {
@@ -39,8 +39,6 @@ test('Nock with allowUnmocked and an url match', async t => {
 })
 
 test('Nock with allowUnmocked, url match and query false', async t => {
-  nock.cleanAll()
-
   const options = {
     key: fs.readFileSync('tests/ssl/ca.key'),
     cert: fs.readFileSync('tests/ssl/ca.crt'),

--- a/tests/test_back.js
+++ b/tests/test_back.js
@@ -4,7 +4,7 @@ const http = require('http')
 const fs = require('fs')
 const { test } = require('tap')
 const proxyquire = require('proxyquire').noPreserveCache()
-const nock = require('../.')
+const nock = require('..')
 
 const nockBack = nock.back
 const exists = fs.existsSync

--- a/tests/test_back_2.js
+++ b/tests/test_back_2.js
@@ -11,7 +11,7 @@ const nockBack = nock.back
 let originalMode
 let fixture
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 function rimrafOnEnd(t) {
   t.once('end', () => rimraf.sync(fixture))

--- a/tests/test_back_2.js
+++ b/tests/test_back_2.js
@@ -4,12 +4,14 @@ const http = require('http')
 const fs = require('fs')
 const { test } = require('tap')
 const rimraf = require('rimraf')
-const nock = require('../')
+const nock = require('..')
 
 const nockBack = nock.back
 
 let originalMode
 let fixture
+
+require('./cleanup_hook')()
 
 function rimrafOnEnd(t) {
   t.once('end', () => rimraf.sync(fixture))
@@ -18,7 +20,6 @@ function rimrafOnEnd(t) {
 test('setup', t => {
   originalMode = nockBack.currentMode
 
-  nock.enableNetConnect()
   nockBack.fixtures = `${__dirname}/fixtures`
   fixture = `${nockBack.fixtures}/recording_test.json`
   rimraf.sync(fixture)

--- a/tests/test_basic_auth.js
+++ b/tests/test_basic_auth.js
@@ -12,7 +12,7 @@ test('basic auth with username and password', async t => {
       .get('/test')
       .basicAuth({ user: 'foo', pass: 'bar' })
       .reply(200, 'Here is the content')
-      done()
+    done()
   })
 
   await t.test('succeeds when it matches', async tt => {

--- a/tests/test_basic_auth.js
+++ b/tests/test_basic_auth.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const got = require('got')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('basic auth with username and password', async t => {
   t.beforeEach(done => {

--- a/tests/test_basic_auth.js
+++ b/tests/test_basic_auth.js
@@ -2,13 +2,18 @@
 
 const { test } = require('tap')
 const got = require('got')
-const nock = require('../')
+const nock = require('..')
+
+require('./cleanup_hook')()
 
 test('basic auth with username and password', async t => {
-  nock('http://example.test')
-    .get('/test')
-    .basicAuth({ user: 'foo', pass: 'bar' })
-    .reply(200, 'Here is the content')
+  t.beforeEach(done => {
+    nock('http://example.test')
+      .get('/test')
+      .basicAuth({ user: 'foo', pass: 'bar' })
+      .reply(200, 'Here is the content')
+      done()
+  })
 
   await t.test('succeeds when it matches', async tt => {
     const response = await got('http://example.test/test', {
@@ -26,10 +31,13 @@ test('basic auth with username and password', async t => {
 })
 
 test('basic auth with username only', async t => {
-  nock('http://example.test')
-    .get('/test')
-    .basicAuth({ user: 'foo' })
-    .reply(200, 'Here is the content')
+  t.beforeEach(done => {
+    nock('http://example.test')
+      .get('/test')
+      .basicAuth({ user: 'foo' })
+      .reply(200, 'Here is the content')
+    done()
+  })
 
   await t.test('succeeds when it matches', async tt => {
     const response = await got('http://example.test/test', { auth: 'foo:' })

--- a/tests/test_body_match.js
+++ b/tests/test_body_match.js
@@ -5,7 +5,7 @@ const { test } = require('tap')
 const mikealRequest = require('request')
 const assert = require('assert')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('match body is regex trying to match string', function(t) {
   nock('http://example.test')

--- a/tests/test_body_match.js
+++ b/tests/test_body_match.js
@@ -5,6 +5,8 @@ const { test } = require('tap')
 const mikealRequest = require('request')
 const assert = require('assert')
 
+require('./cleanup_hook')()
+
 test('match body is regex trying to match string', function(t) {
   nock('http://example.test')
     .post('/', new RegExp('a.+'))

--- a/tests/test_clientrequest.js
+++ b/tests/test_clientrequest.js
@@ -4,7 +4,7 @@ const http = require('http')
 const { test } = require('tap')
 const nock = require('../.')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 // This test seems to need `http`.
 test('can use ClientRequest using GET', t => {

--- a/tests/test_clientrequest.js
+++ b/tests/test_clientrequest.js
@@ -4,6 +4,8 @@ const http = require('http')
 const { test } = require('tap')
 const nock = require('../.')
 
+require('./cleanup_hook')()
+
 // This test seems to need `http`.
 test('can use ClientRequest using GET', t => {
   let dataCalled = false

--- a/tests/test_clientrequest.js
+++ b/tests/test_clientrequest.js
@@ -71,9 +71,6 @@ test('can use ClientRequest using POST', t => {
 })
 
 test('creating ClientRequest with empty options throws expected error', t => {
-  // Confidence check.
-  t.ok(nock.isActive())
-
   t.throws(() => new http.ClientRequest(), {
     message:
       'Creating a client request with empty `options` is not supported in Nock',
@@ -83,12 +80,6 @@ test('creating ClientRequest with empty options throws expected error', t => {
 })
 
 test('when no interceptors and net connect is allowed, request via ClientRequest goes through', t => {
-  nock.cleanAll()
-  nock.enableNetConnect()
-
-  // Confidence check. We need nock enabled to test the desired path.
-  t.ok(nock.isActive())
-
   const server = http.createServer((request, response) => {
     response.writeHead(201)
     response.end()
@@ -107,8 +98,6 @@ test('when no interceptors and net connect is allowed, request via ClientRequest
 
 test('when no interceptors and net connect is disallowed, receive via ClientRequest emits the expected error', t => {
   nock.disableNetConnect()
-  t.once('end', () => nock.enableNetConnect())
-
   new http.ClientRequest({ port: 12345, path: '/' }).on('error', err => {
     t.equal(err.message, 'Nock: Disallowed net connect for "localhost:12345/"')
     t.end()

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -5,7 +5,7 @@ const common = require('../lib/common')
 const matchBody = require('../lib/match_body')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('matchBody ignores new line characters from strings', t => {
   t.true(

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -3,6 +3,9 @@
 const { test } = require('tap')
 const common = require('../lib/common')
 const matchBody = require('../lib/match_body')
+const nock = require('..')
+
+require('./cleanup_hook')()
 
 test('matchBody ignores new line characters from strings', t => {
   t.true(
@@ -231,6 +234,7 @@ test('matchStringOrRegexp', function(t) {
 
 test('overrideRequests', t => {
   t.on('end', () => common.restoreOverriddenRequests())
+  nock.restore()
   common.overrideRequests()
   // Second call throws.
   t.throws(() => common.overrideRequests(), {

--- a/tests/test_complex_querystring.js
+++ b/tests/test_complex_querystring.js
@@ -5,7 +5,7 @@ const qs = require('qs')
 const got = require('got')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 const exampleText = 'it worked!'
 

--- a/tests/test_complex_querystring.js
+++ b/tests/test_complex_querystring.js
@@ -3,7 +3,9 @@
 const { test } = require('tap')
 const qs = require('qs')
 const got = require('got')
-const nock = require('../.')
+const nock = require('..')
+
+require('./cleanup_hook')()
 
 const exampleText = 'it worked!'
 

--- a/tests/test_content_encoding.js
+++ b/tests/test_content_encoding.js
@@ -5,7 +5,7 @@ const { test } = require('tap')
 const got = require('got')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('accepts gzipped content', async t => {
   const message = 'Lorem ipsum dolor sit amet'

--- a/tests/test_content_encoding.js
+++ b/tests/test_content_encoding.js
@@ -3,7 +3,9 @@
 const zlib = require('zlib')
 const { test } = require('tap')
 const got = require('got')
-const nock = require('../.')
+const nock = require('..')
+
+require('./cleanup_hook')()
 
 test('accepts gzipped content', async t => {
   const message = 'Lorem ipsum dolor sit amet'

--- a/tests/test_default_reply_headers.js
+++ b/tests/test_default_reply_headers.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const nock = require('..')
 const got = require('got')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('when no headers are specified on the request, default reply headers work', async t => {
   nock('http://example.test')

--- a/tests/test_default_reply_headers.js
+++ b/tests/test_default_reply_headers.js
@@ -1,8 +1,10 @@
 'use strict'
 
 const { test } = require('tap')
-const nock = require('../.')
+const nock = require('..')
 const got = require('got')
+
+require('./cleanup_hook')()
 
 test('when no headers are specified on the request, default reply headers work', async t => {
   nock('http://example.test')

--- a/tests/test_define.js
+++ b/tests/test_define.js
@@ -5,6 +5,8 @@ const { test } = require('tap')
 const got = require('got')
 const nock = require('..')
 
+require('./cleanup_hook')()
+
 test('define() is backward compatible', t => {
   t.ok(
     nock.define([

--- a/tests/test_define.js
+++ b/tests/test_define.js
@@ -5,7 +5,7 @@ const { test } = require('tap')
 const got = require('got')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('define() is backward compatible', t => {
   t.ok(

--- a/tests/test_delay.js
+++ b/tests/test_delay.js
@@ -7,7 +7,9 @@ const stream = require('stream')
 const got = require('got')
 const mikealRequest = require('request')
 const { test } = require('tap')
-const nock = require('../.')
+const nock = require('..')
+
+require('./cleanup_hook')()
 
 const textFile = path.join(__dirname, '..', 'assets', 'reply_file_1.txt')
 

--- a/tests/test_delay.js
+++ b/tests/test_delay.js
@@ -9,7 +9,7 @@ const mikealRequest = require('request')
 const { test } = require('tap')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 const textFile = path.join(__dirname, '..', 'assets', 'reply_file_1.txt')
 

--- a/tests/test_dynamic_mock.js
+++ b/tests/test_dynamic_mock.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const request = require('request')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('one function returning the body defines a full mock', function(t) {
   nock('http://example.test')

--- a/tests/test_dynamic_mock.js
+++ b/tests/test_dynamic_mock.js
@@ -1,8 +1,10 @@
 'use strict'
 
 const { test } = require('tap')
-const nock = require('../.')
 const request = require('request')
+const nock = require('..')
+
+require('./cleanup_hook')()
 
 test('one function returning the body defines a full mock', function(t) {
   nock('http://example.test')

--- a/tests/test_encode_querystring.js
+++ b/tests/test_encode_querystring.js
@@ -4,7 +4,7 @@ const request = require('request')
 const { test } = require('tap')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('encode query string', t => {
   const query1 = { q: '(nodejs)' }

--- a/tests/test_encode_querystring.js
+++ b/tests/test_encode_querystring.js
@@ -1,10 +1,12 @@
 'use strict'
 
-const nock = require('../.')
 const request = require('request')
 const { test } = require('tap')
+const nock = require('..')
 
-test('encode query string', function(t) {
+require('./cleanup_hook')()
+
+test('encode query string', t => {
   const query1 = { q: '(nodejs)' }
 
   nock('https://example.test')

--- a/tests/test_events.js
+++ b/tests/test_events.js
@@ -5,7 +5,7 @@ const querystring = require('querystring')
 const { test } = require('tap')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('emits request and replied events', function(t) {
   const scope = nock('http://example.test')

--- a/tests/test_events.js
+++ b/tests/test_events.js
@@ -1,9 +1,11 @@
 'use strict'
 
-const nock = require('../.')
 const http = require('http')
 const querystring = require('querystring')
 const { test } = require('tap')
+const nock = require('..')
+
+require('./cleanup_hook')()
 
 test('emits request and replied events', function(t) {
   const scope = nock('http://example.test')

--- a/tests/test_events.js
+++ b/tests/test_events.js
@@ -89,7 +89,6 @@ test('emits no match when netConnect is disabled', function(t) {
   nock.emitter.on('no match', function(req) {
     t.equal(req.hostname, 'google.com')
     nock.emitter.removeAllListeners('no match')
-    nock.enableNetConnect()
     t.end()
   })
   http.get('http://google.com').once('error', ignore)

--- a/tests/test_fake_timer.js
+++ b/tests/test_fake_timer.js
@@ -1,12 +1,14 @@
 'use strict'
 
-const nock = require('../.')
 const { test } = require('tap')
 const request = require('request')
 const lolex = require('lolex')
+const nock = require('..')
+
+require('./cleanup_hook')()
 
 // https://github.com/nock/nock/issues/1334
-test('one function returns successfully when fake timer is enabled', function(t) {
+test('one function returns successfully when fake timer is enabled', t => {
   const clock = lolex.install()
   nock('http://example.test')
     .get('/')

--- a/tests/test_fake_timer.js
+++ b/tests/test_fake_timer.js
@@ -5,7 +5,7 @@ const request = require('request')
 const lolex = require('lolex')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 // https://github.com/nock/nock/issues/1334
 test('one function returns successfully when fake timer is enabled', t => {

--- a/tests/test_gzip_request.js
+++ b/tests/test_gzip_request.js
@@ -5,7 +5,7 @@ const http = require('http')
 const zlib = require('zlib')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('accepts and decodes gzip encoded application/json', t => {
   const message = {

--- a/tests/test_gzip_request.js
+++ b/tests/test_gzip_request.js
@@ -1,72 +1,70 @@
 'use strict'
 
-const nock = require('../')
 const { test } = require('tap')
 const http = require('http')
 const zlib = require('zlib')
+const nock = require('..')
 
-if (zlib.gzipSync && zlib.gunzipSync) {
-  test('accepts and decodes gzip encoded application/json', function(t) {
-    const message = {
-      my: 'contents',
-    }
+require('./cleanup_hook')()
 
-    t.plan(1)
+test('accepts and decodes gzip encoded application/json', t => {
+  const message = {
+    my: 'contents',
+  }
 
-    nock('http://example.test')
-      .post('/')
-      .reply(function(url, actual) {
-        t.same(actual, message)
-        t.end()
-        return 200
-      })
+  t.plan(1)
 
-    const req = http.request({
-      hostname: 'example.test',
-      path: '/',
-      method: 'POST',
-      headers: {
-        'content-encoding': 'gzip',
-        'content-type': 'application/json',
-      },
+  nock('http://example.test')
+    .post('/')
+    .reply(function(url, actual) {
+      t.same(actual, message)
+      t.end()
+      return 200
     })
 
-    const compressedMessage = zlib.gzipSync(JSON.stringify(message))
-
-    req.write(compressedMessage)
-    req.end()
+  const req = http.request({
+    hostname: 'example.test',
+    path: '/',
+    method: 'POST',
+    headers: {
+      'content-encoding': 'gzip',
+      'content-type': 'application/json',
+    },
   })
-}
 
-if (zlib.deflateSync && zlib.inflateSync) {
-  test('accepts and decodes deflate encoded application/json', function(t) {
-    const message = {
-      my: 'contents',
-    }
+  const compressedMessage = zlib.gzipSync(JSON.stringify(message))
 
-    t.plan(1)
+  req.write(compressedMessage)
+  req.end()
+})
 
-    nock('http://example.test')
-      .post('/')
-      .reply(function(url, actual) {
-        t.same(actual, message)
-        t.end()
-        return 200
-      })
+test('accepts and decodes deflate encoded application/json', t => {
+  const message = {
+    my: 'contents',
+  }
 
-    const req = http.request({
-      hostname: 'example.test',
-      path: '/',
-      method: 'POST',
-      headers: {
-        'content-encoding': 'deflate',
-        'content-type': 'application/json',
-      },
+  t.plan(1)
+
+  nock('http://example.test')
+    .post('/')
+    .reply(function(url, actual) {
+      t.same(actual, message)
+      t.end()
+      return 200
     })
 
-    const compressedMessage = zlib.deflateSync(JSON.stringify(message))
-
-    req.write(compressedMessage)
-    req.end()
+  const req = http.request({
+    hostname: 'example.test',
+    path: '/',
+    method: 'POST',
+    headers: {
+      'content-encoding': 'deflate',
+      'content-type': 'application/json',
+    },
   })
-}
+
+  const compressedMessage = zlib.deflateSync(JSON.stringify(message))
+
+  req.write(compressedMessage)
+  req.end()
+})

--- a/tests/test_header_matching.js
+++ b/tests/test_header_matching.js
@@ -7,7 +7,7 @@ const got = require('got')
 const mikealRequest = require('request')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('match headers', async t => {
   const scope = nock('http://example.test')

--- a/tests/test_header_matching.js
+++ b/tests/test_header_matching.js
@@ -7,6 +7,8 @@ const got = require('got')
 const mikealRequest = require('request')
 const nock = require('..')
 
+require('./cleanup_hook')()
+
 test('match headers', async t => {
   const scope = nock('http://example.test')
     .get('/')

--- a/tests/test_header_matching.js
+++ b/tests/test_header_matching.js
@@ -426,8 +426,6 @@ test('match basic authentication header', t => {
 })
 
 test('multiple interceptors override headers from unrelated request', t => {
-  nock.cleanAll()
-
   nock.define([
     {
       scope: 'https://example.test:443',

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -12,7 +12,7 @@ const hyperquest = require('hyperquest')
 const got = require('got')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 const globalCount = Object.keys(global).length
 const acceptableLeaks = [

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -12,7 +12,7 @@ const hyperquest = require('hyperquest')
 const got = require('got')
 const nock = require('..')
 
-nock.enableNetConnect()
+require('./cleanup_hook')()
 
 const globalCount = Object.keys(global).length
 const acceptableLeaks = [
@@ -578,8 +578,6 @@ test('scopes are independent', async t => {
 
   t.true(scope1.isDone())
   t.false(scope2.isDone())
-
-  nock.cleanAll()
 })
 
 test('two scopes with the same request are consumed', async t => {
@@ -1443,7 +1441,6 @@ test('match domain using regexp', t => {
 })
 
 test('match domain using regexp with path as callback (issue-1137)', t => {
-  nock.cleanAll()
   nock(/.*/)
     .get(() => true)
     .reply(200, 'Match regex')
@@ -1457,7 +1454,6 @@ test('match domain using regexp with path as callback (issue-1137)', t => {
 })
 
 test('match multiple interceptors with regexp domain (issue-508)', t => {
-  nock.cleanAll()
   nock(/chainregex/)
     .get('/')
     .reply(200, 'Match regex')
@@ -1649,7 +1645,6 @@ test('no content type provided', t => {
 
 // https://github.com/nock/nock/issues/835
 test('match domain and path using regexp', t => {
-  nock.cleanAll()
   const imgResponse = 'Matched Images Page'
 
   const scope = nock(/example/)
@@ -1671,8 +1666,6 @@ test('match domain and path using regexp', t => {
 
 // https://github.com/nock/nock/issues/1003
 test('correctly parse request without specified path', t => {
-  nock.cleanAll()
-
   const scope1 = nock('https://example.test')
     .get('')
     .reply(200)
@@ -1690,8 +1683,6 @@ test('correctly parse request without specified path', t => {
 })
 
 test('data is sent with flushHeaders', t => {
-  nock.cleanAll()
-
   const scope1 = nock('https://example.test')
     .get('')
     .reply(200, 'this is data')

--- a/tests/test_ipv6.js
+++ b/tests/test_ipv6.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const http = require('http')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('IPV6 URL in http.get get gets mocked', function(t) {
   let dataCalled = false

--- a/tests/test_ipv6.js
+++ b/tests/test_ipv6.js
@@ -1,8 +1,10 @@
 'use strict'
 
-const nock = require('../')
 const { test } = require('tap')
 const http = require('http')
+const nock = require('..')
+
+require('./cleanup_hook')()
 
 test('IPV6 URL in http.get get gets mocked', function(t) {
   let dataCalled = false

--- a/tests/test_isomorphic_fetch.js
+++ b/tests/test_isomorphic_fetch.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const fetch = require('isomorphic-fetch')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('basic match works', function(t) {
   const scope = nock('http://example.test')

--- a/tests/test_isomorphic_fetch.js
+++ b/tests/test_isomorphic_fetch.js
@@ -1,8 +1,10 @@
 'use strict'
 
-const nock = require('../')
 const { test } = require('tap')
 const fetch = require('isomorphic-fetch')
+const nock = require('..')
+
+require('./cleanup_hook')()
 
 test('basic match works', function(t) {
   const scope = nock('http://example.test')

--- a/tests/test_logging.js
+++ b/tests/test_logging.js
@@ -6,6 +6,8 @@ const sinon = require('sinon')
 const { test } = require('tap')
 const nock = require('..')
 
+require('./cleanup_hook')()
+
 test('match debugging works', async t => {
   const log = sinon.stub(debug, 'log')
   debug.enable('nock.interceptor')

--- a/tests/test_logging.js
+++ b/tests/test_logging.js
@@ -6,7 +6,7 @@ const sinon = require('sinon')
 const { test } = require('tap')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('match debugging works', async t => {
   const log = sinon.stub(debug, 'log')

--- a/tests/test_net_connect.js
+++ b/tests/test_net_connect.js
@@ -11,6 +11,7 @@ require('./cleanup_hook')()
 
 test('disable net connect is default', function(t) {
   nock.disableNetConnect()
+
   nock('http://example.test')
     .get('/')
     .reply(200)
@@ -26,9 +27,7 @@ test('disable net connect is default', function(t) {
 })
 
 test('when net connect is disabled, throws the expected error ', async t => {
-  nock.cleanAll()
   nock.disableNetConnect()
-  t.once('end', () => nock.enableNetConnect())
 
   try {
     await got('http://example.test')
@@ -53,7 +52,6 @@ test('enable real HTTP request only for specified domain, via string', t => {
   t.once('end', () => server.close())
 
   nock.enableNetConnect('localhost')
-  t.once('end', () => nock.enableNetConnect())
 
   server.listen(() =>
     mikealRequest(`http://localhost:${server.address().port}/`)
@@ -62,7 +60,6 @@ test('enable real HTTP request only for specified domain, via string', t => {
 
 test('disallow request for other domains, via string', t => {
   nock.enableNetConnect('localhost')
-  t.once('end', () => nock.enableNetConnect())
 
   http
     .get('http://www.amazon.com', function(res) {
@@ -89,7 +86,6 @@ test('enable real HTTP request only for specified domain, via regexp', t => {
   t.once('end', () => server.close())
 
   nock.enableNetConnect(/ocalhos/)
-  t.once('end', () => nock.enableNetConnect())
 
   server.listen(() =>
     mikealRequest(`http://localhost:${server.address().port}/`)
@@ -98,7 +94,6 @@ test('enable real HTTP request only for specified domain, via regexp', t => {
 
 test('disallow request for other domains, via regexp', t => {
   nock.enableNetConnect(/ocalhos/)
-  t.once('end', () => nock.enableNetConnect())
 
   http
     .get('http://www.amazon.com', function(res) {

--- a/tests/test_net_connect.js
+++ b/tests/test_net_connect.js
@@ -7,7 +7,7 @@ const mikealRequest = require('request')
 const { test } = require('tap')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('disable net connect is default', function(t) {
   nock.disableNetConnect()

--- a/tests/test_net_connect.js
+++ b/tests/test_net_connect.js
@@ -7,6 +7,8 @@ const mikealRequest = require('request')
 const { test } = require('tap')
 const nock = require('..')
 
+require('./cleanup_hook')()
+
 test('disable net connect is default', function(t) {
   nock.disableNetConnect()
   nock('http://example.test')

--- a/tests/test_nock_lifecycle.js
+++ b/tests/test_nock_lifecycle.js
@@ -6,6 +6,8 @@ const { test } = require('tap')
 const got = require('got')
 const nock = require('..')
 
+require('./cleanup_hook')()
+
 test('double activation throws exception', t => {
   nock.restore()
   t.false(nock.isActive())

--- a/tests/test_nock_lifecycle.js
+++ b/tests/test_nock_lifecycle.js
@@ -6,7 +6,7 @@ const { test } = require('tap')
 const got = require('got')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('double activation throws exception', t => {
   nock.restore()

--- a/tests/test_nock_off.js
+++ b/tests/test_nock_off.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const mikealRequest = require('request')
 const ssl = require('./ssl')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('NOCK_OFF=true works for https', t => {
   const original = process.env.NOCK_OFF

--- a/tests/test_nock_off.js
+++ b/tests/test_nock_off.js
@@ -2,10 +2,11 @@
 
 const { test } = require('tap')
 const mikealRequest = require('request')
-
 const ssl = require('./ssl')
 
-test('NOCK_OFF=true works for https', function(t) {
+require('./cleanup_hook')()
+
+test('NOCK_OFF=true works for https', t => {
   const original = process.env.NOCK_OFF
   process.env.NOCK_OFF = 'true'
   const nock = require('../')

--- a/tests/test_persist_optionally.js
+++ b/tests/test_persist_optionally.js
@@ -9,7 +9,7 @@ const got = require('got')
 const { test } = require('tap')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 const textFile = path.join(__dirname, '..', 'assets', 'reply_file_1.txt')
 

--- a/tests/test_persist_optionally.js
+++ b/tests/test_persist_optionally.js
@@ -7,7 +7,9 @@ const http = require('http')
 const path = require('path')
 const got = require('got')
 const { test } = require('tap')
-const nock = require('../.')
+const nock = require('..')
+
+require('./cleanup_hook')()
 
 const textFile = path.join(__dirname, '..', 'assets', 'reply_file_1.txt')
 
@@ -38,7 +40,6 @@ test('calling optionally(false) on a mock leaves it as required', t => {
     .reply(200)
 
   t.notEqual(nock.pendingMocks(), [])
-  nock.cleanAll()
   t.end()
 })
 
@@ -107,7 +108,6 @@ test('optional repeated mocks execute repeatedly, but never appear as pending', 
 })
 
 test("activeMocks returns optional mocks only before they're completed", t => {
-  nock.cleanAll()
   nock('http://example.test')
     .get('/optional')
     .optionally()
@@ -121,8 +121,6 @@ test("activeMocks returns optional mocks only before they're completed", t => {
 })
 
 test('activeMocks always returns persisted mocks', async t => {
-  nock.cleanAll()
-
   const scope = nock('http://example.test')
     .get('/persisted')
     .reply(200)
@@ -135,7 +133,6 @@ test('activeMocks always returns persisted mocks', async t => {
   t.deepEqual(nock.activeMocks(), ['GET http://example.test:80/persisted'])
 
   scope.done()
-  nock.cleanAll()
 })
 
 test('persists interceptors', async t => {
@@ -153,8 +150,6 @@ test('persists interceptors', async t => {
   await got('http://example.test/')
 
   t.true(scope.isDone())
-
-  nock.cleanAll()
 })
 
 test('Persisted interceptors are in pendingMocks initially', async t => {
@@ -164,8 +159,6 @@ test('Persisted interceptors are in pendingMocks initially', async t => {
     .persist()
 
   t.deepEqual(scope.pendingMocks(), ['GET http://example.test:80/abc'])
-
-  nock.cleanAll()
 })
 
 test('Persisted interceptors are not in pendingMocks after the first request', async t => {
@@ -177,8 +170,6 @@ test('Persisted interceptors are not in pendingMocks after the first request', a
   await got('http://example.test/def')
 
   t.deepEqual(scope.pendingMocks(), [])
-
-  nock.cleanAll()
 })
 
 test('persist reply with file', async t => {
@@ -194,13 +185,9 @@ test('persist reply with file', async t => {
     t.equal(statusCode, 200)
     t.equal(body, 'Hello from the file!')
   }
-
-  nock.cleanAll()
 })
 
 test('stop persisting a persistent nock', async t => {
-  nock.cleanAll()
-
   const scope = nock('http://example.test')
     .persist(true)
     .get('/')

--- a/tests/test_query.js
+++ b/tests/test_query.js
@@ -2,7 +2,9 @@
 
 const mikealRequest = require('request')
 const { test } = require('tap')
-const nock = require('../.')
+const nock = require('..')
+
+require('./cleanup_hook')()
 
 test('query() matches a query string of the same name=value', t => {
   nock('http://example.test')

--- a/tests/test_query.js
+++ b/tests/test_query.js
@@ -4,7 +4,7 @@ const mikealRequest = require('request')
 const { test } = require('tap')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('query() matches a query string of the same name=value', t => {
   nock('http://example.test')

--- a/tests/test_recorder.js
+++ b/tests/test_recorder.js
@@ -10,7 +10,7 @@ const mikealRequest = require('request')
 const superagent = require('superagent')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 let globalCount
 

--- a/tests/test_recorder.js
+++ b/tests/test_recorder.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const nock = require('../.')
 const { test } = require('tap')
 const http = require('http')
 const https = require('https')
@@ -9,6 +8,9 @@ const zlib = require('zlib')
 const got = require('got')
 const mikealRequest = require('request')
 const superagent = require('superagent')
+const nock = require('..')
+
+require('./cleanup_hook')()
 
 let globalCount
 

--- a/tests/test_redirects.js
+++ b/tests/test_redirects.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const got = require('got')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('follows redirects', async t => {
   const scope = nock('http://example.test')

--- a/tests/test_redirects.js
+++ b/tests/test_redirects.js
@@ -2,7 +2,9 @@
 
 const { test } = require('tap')
 const got = require('got')
-const nock = require('../')
+const nock = require('..')
+
+require('./cleanup_hook')()
 
 test('follows redirects', async t => {
   const scope = nock('http://example.test')

--- a/tests/test_remove_interceptor.js
+++ b/tests/test_remove_interceptor.js
@@ -188,7 +188,5 @@ test('does not remove unmatched interceptors', t => {
   t.deepEqual(scope1.pendingMocks(), ['GET http://example.test:80/somepath'])
   t.deepEqual(scope2.pendingMocks(), [])
 
-  nock.cleanAll()
-
   t.end()
 })

--- a/tests/test_remove_interceptor.js
+++ b/tests/test_remove_interceptor.js
@@ -4,6 +4,8 @@ const { test } = require('tap')
 const got = require('got')
 const nock = require('..')
 
+require('./cleanup_hook')()
+
 test('remove interceptor for GET resource', async t => {
   nock('http://example.test')
     .get('/somepath')

--- a/tests/test_remove_interceptor.js
+++ b/tests/test_remove_interceptor.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const got = require('got')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('remove interceptor for GET resource', async t => {
   nock('http://example.test')

--- a/tests/test_repeating.js
+++ b/tests/test_repeating.js
@@ -5,6 +5,8 @@ const async = require('async')
 const { test } = require('tap')
 const nock = require('..')
 
+require('./cleanup_hook')()
+
 test('repeating once', t => {
   nock.disableNetConnect()
 
@@ -17,10 +19,6 @@ test('repeating once', t => {
     t.equal(200, res.statusCode, 'first request')
     t.end()
   })
-
-  nock.cleanAll()
-
-  nock.enableNetConnect()
 })
 
 test('repeating twice', t => {

--- a/tests/test_repeating.js
+++ b/tests/test_repeating.js
@@ -5,7 +5,7 @@ const async = require('async')
 const { test } = require('tap')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('repeating once', t => {
   nock.disableNetConnect()

--- a/tests/test_replies.js
+++ b/tests/test_replies.js
@@ -9,6 +9,8 @@ const lolex = require('lolex')
 const proxyquire = require('proxyquire').noPreserveCache()
 const nock = require('..')
 
+require('./cleanup_hook')()
+
 const textFile = path.join(__dirname, '..', 'assets', 'reply_file_1.txt')
 const binaryFile = path.join(__dirname, '..', 'assets', 'reply_file_2.txt.gz')
 

--- a/tests/test_replies.js
+++ b/tests/test_replies.js
@@ -9,7 +9,7 @@ const lolex = require('lolex')
 const proxyquire = require('proxyquire').noPreserveCache()
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 const textFile = path.join(__dirname, '..', 'assets', 'reply_file_1.txt')
 const binaryFile = path.join(__dirname, '..', 'assets', 'reply_file_2.txt.gz')

--- a/tests/test_request_promise.js
+++ b/tests/test_request_promise.js
@@ -1,10 +1,12 @@
 'use strict'
 
-const nock = require('../')
 const { test } = require('tap')
 const rp = require('request-promise')
+const nock = require('..')
 
-test('IPV6 URL in request-promise get gets mocked', function(t) {
+require('./cleanup_hook')()
+
+test('IPV6 URL in request-promise get gets mocked', t => {
   const payload = 'somedata'
   const target = 'http://[2607:f0d0:1002:51::4]:8080'
 

--- a/tests/test_request_promise.js
+++ b/tests/test_request_promise.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const rp = require('request-promise')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('IPV6 URL in request-promise get gets mocked', t => {
   const payload = 'somedata'

--- a/tests/test_s3.js
+++ b/tests/test_s3.js
@@ -12,7 +12,7 @@ const AWS = require('aws-sdk')
 const { test } = require('tap')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('works with s3, body < 1024 ^ 2', function(t) {
   const REGION = 'us-east-1'

--- a/tests/test_s3.js
+++ b/tests/test_s3.js
@@ -8,9 +8,11 @@
 //
 // Do not create new tests in this style.
 
-const nock = require('../')
 const AWS = require('aws-sdk')
 const { test } = require('tap')
+const nock = require('..')
+
+require('./cleanup_hook')()
 
 test('works with s3, body < 1024 ^ 2', function(t) {
   const REGION = 'us-east-1'

--- a/tests/test_scope.js
+++ b/tests/test_scope.js
@@ -6,7 +6,7 @@ const proxyquire = require('proxyquire').noPreserveCache()
 const Interceptor = require('../lib/interceptor')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('scope exposes interceptors', t => {
   const scopes = nock.load(path.join(__dirname, 'fixtures', 'goodRequest.json'))

--- a/tests/test_scope.js
+++ b/tests/test_scope.js
@@ -1,10 +1,12 @@
 'use strict'
 
 const path = require('path')
-const nock = require('../')
-const Interceptor = require('../lib/interceptor')
 const { test } = require('tap')
 const proxyquire = require('proxyquire').noPreserveCache()
+const Interceptor = require('../lib/interceptor')
+const nock = require('..')
+
+require('./cleanup_hook')()
 
 test('scope exposes interceptors', t => {
   const scopes = nock.load(path.join(__dirname, 'fixtures', 'goodRequest.json'))

--- a/tests/test_scope.js
+++ b/tests/test_scope.js
@@ -21,7 +21,6 @@ test('scope exposes interceptors', t => {
     })
   })
 
-  nock.cleanAll()
   t.end()
 })
 
@@ -40,8 +39,6 @@ test('scope#remove() works', t => {
   // Assert.
   t.deepEqual(scope.activeMocks(), [])
 
-  // Clean up.
-  nock.cleanAll()
   t.end()
 })
 
@@ -61,8 +58,6 @@ test('scope#remove() is a no-op on a persisted mock', t => {
   // Assert.
   t.deepEqual(scope.activeMocks(), [key])
 
-  // Clean up.
-  nock.cleanAll()
   t.end()
 })
 
@@ -81,8 +76,6 @@ test('scope#remove() is a no-op on a nonexistent key', t => {
   // Assert.
   t.deepEqual(scope.activeMocks(), [key])
 
-  // Clean up.
-  nock.cleanAll()
   t.end()
 })
 

--- a/tests/test_socketdelay.js
+++ b/tests/test_socketdelay.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const http = require('http')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('socketDelay', function(t) {
   let timeouted = false

--- a/tests/test_socketdelay.js
+++ b/tests/test_socketdelay.js
@@ -2,7 +2,9 @@
 
 const { test } = require('tap')
 const http = require('http')
-const nock = require('../.')
+const nock = require('..')
+
+require('./cleanup_hook')()
 
 test('socketDelay', function(t) {
   let timeouted = false

--- a/tests/test_stream.js
+++ b/tests/test_stream.js
@@ -6,9 +6,10 @@ const path = require('path')
 const stream = require('stream')
 const util = require('util')
 const { test } = require('tap')
-const nock = require('../.')
 const got = require('got')
-const { Stream } = require('stream')
+const nock = require('..')
+
+require('./cleanup_hook')()
 
 const textFile = path.join(__dirname, '..', 'assets', 'reply_file_1.txt')
 
@@ -24,7 +25,7 @@ test('reply with file and pipe response', t => {
   })
 
   let text = ''
-  const fakeStream = new Stream()
+  const fakeStream = new stream.Stream()
   fakeStream.writable = true
   fakeStream.write = d => {
     text += d

--- a/tests/test_stream.js
+++ b/tests/test_stream.js
@@ -9,7 +9,7 @@ const { test } = require('tap')
 const got = require('got')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 const textFile = path.join(__dirname, '..', 'assets', 'reply_file_1.txt')
 

--- a/tests/test_url_encoding.js
+++ b/tests/test_url_encoding.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const mikealRequest = require('request')
 const nock = require('..')
 
-require('./cleanup_hook')()
+require('./cleanup_after_each')()
 
 test('url encoding', t => {
   nock('http://example.test')

--- a/tests/test_url_encoding.js
+++ b/tests/test_url_encoding.js
@@ -1,18 +1,19 @@
 'use strict'
 
-const nock = require('../')
 const { test } = require('tap')
 const mikealRequest = require('request')
-const assert = require('assert')
+const nock = require('..')
 
-test('url encoding', function(t) {
+require('./cleanup_hook')()
+
+test('url encoding', t => {
   nock('http://example.test')
     .get('/key?a=[1]')
     .reply(200)
 
   mikealRequest('http://example.test/key?a=[1]', function(err, res) {
     if (err) throw err
-    assert.equal(res.statusCode, 200)
+    t.equal(res.statusCode, 200)
     t.end()
   })
 })


### PR DESCRIPTION
This adds a global `afterEach` hook that resets nock global state to the condition it's in when it's initially `require`d. It's worth noting that there isn't a single function for doing this; I've got four function calls here to accomplish that. It's worth taking a moment here to validate that this is indeed the correct sequence of calls. See #1441 for some discussion on that.

It removes most or all of the one-off global-state cleanup code that's sprinkled among the tests.

- Tests may now assume that, at the time they're invoked, that nock's initial state will match the state it has when it has just been `require`d.
- Tests are not responsible for restoring that state afterward.
- If tests need nock in a _different_ starting state, it's up to them to set it.
- If tests create _other_ state, such as starting a server, it's up to them to clean it up.

I've included some miscellaneous adjacent style cleanup.

I've deferred the various `test_back*` suites because they are all intertwingled, and require a bit more focused effort to unravel.