### PR TITLE
fix: Fix `.matchHeader()` with `allowUnmocked`

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -173,7 +173,7 @@ function interceptorsFor(options) {
         matchingInterceptor = [
           {
             options: { allowUnmocked: true },
-            matchIndependentOfBody: function() {
+            matchAddress() {
               return false
             },
           },
@@ -396,7 +396,7 @@ function activate() {
       let allowUnmocked = false
 
       matches = !!_.find(interceptors, function(interceptor) {
-        return interceptor.matchIndependentOfBody(options)
+        return interceptor.matchAddress(options)
       })
 
       allowUnmocked = !!_.find(interceptors, function(interceptor) {

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -388,17 +388,7 @@ function activate() {
       options = urlParse(options.toString())
     }
     options.proto = proto
-    if (!options.getHeader) {
-      if (options.headers) {
-        options.getHeader = function(key) {
-          return this.headers[key.toLowerCase()]
-        }
-      } else {
-        options.getHeader = function(key) {
-          return undefined
-        }
-      }
-    }
+
     const interceptors = interceptorsFor(options)
 
     if (isOn() && interceptors) {

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -388,7 +388,17 @@ function activate() {
       options = urlParse(options.toString())
     }
     options.proto = proto
-
+    if (!options.getHeader) {
+      if (options.headers) {
+        options.getHeader = function(key) {
+          return this.headers[key.toLowerCase()]
+        }
+      } else {
+        options.getHeader = function(key) {
+          return undefined
+        }
+      }
+    }
     const interceptors = interceptorsFor(options)
 
     if (isOn() && interceptors) {

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -227,7 +227,7 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
     body = this.scope.transformRequestBodyFunction(body, this._requestBody)
   }
 
-  const matchesFilter = ({ name, value: predicate }) => {
+  const requestMatchesFilter = ({ name, value: predicate }) => {
     const headerValue = options.getHeader(name)
     if (typeof predicate === 'function') {
       return predicate(headerValue)
@@ -237,8 +237,8 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
   }
 
   if (
-    !this.scope.matchHeaders.every(matchesFilter) ||
-    !this.interceptorMatchHeaders.every(filterMatches)
+    !this.scope.matchHeaders.every(requestMatchesFilter) ||
+    !this.interceptorMatchHeaders.every(requestMatchesFilter)
   ) {
     this.scope.logger("headers don't match")
     return false

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -227,13 +227,15 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
     body = this.scope.transformRequestBodyFunction(body, this._requestBody)
   }
 
-  const checkHeaders = function(header) {
-    if (_.isFunction(header.value)) {
-      return header.value(options.getHeader(header.name))
+  const checkHeaders = function(filter) {
+    let headerKey = filter.name
+    let headerValue = options.getHeader !== undefined ? options.getHeader(headerKey) : options.headers[headerKey]
+    if (_.isFunction(filter.value)) {
+      return filter.value(headerValue)
     }
     return common.matchStringOrRegexp(
-      options.getHeader(header.name),
-      header.value
+      headerValue,
+      filter.value
     )
   }
 
@@ -394,10 +396,15 @@ Interceptor.prototype.matchIndependentOfBody = function matchIndependentOfBody(
     path = this.scope.transformPathFunction(path)
   }
 
-  const checkHeaders = function(header) {
-    return (
-      options.getHeader &&
-      common.matchStringOrRegexp(options.getHeader(header.name), header.value)
+  const checkHeaders = function(filter) {
+    let headerKey = filter.name
+    let headerValue = options.getHeader !== undefined ? options.getHeader(headerKey) : options.headers[headerKey]
+    if (_.isFunction(filter.value)) {
+      return filter.value(headerValue)
+    }
+    return common.matchStringOrRegexp(
+      headerValue,
+      filter.value
     )
   }
 

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -165,6 +165,31 @@ Interceptor.prototype.replyWithFile = function replyWithFile(
   return this.reply(statusCode, readStream, headers)
 }
 
+/**
+ * Test to see if the headers match a filter. If the function cannot determin where the headers are
+ * it returns false.
+ * @name filterMatches
+ * @param {Object} filter - A filter object containing the header name we want to filter on and the
+ *                          filter value which can be a string, regex, or predicate.
+ * @param {Object} obj - A object containing the headers we wish to check. This is either the
+ *                       request options or the outgoing request
+ * @returns {boolean} True if the headers contain a value that matches the filter.
+ */
+function filterMatches(filter, obj) {
+  let headerValue
+  if (obj.getHeader) {
+    headerValue = obj.getHeader(filter.name)
+  } else if (obj.headers) {
+    headerValue = obj.headers[filter.name]
+  } else {
+    return false
+  }
+  if (_.isFunction(filter.value)) {
+    return filter.value(headerValue)
+  }
+  return common.matchStringOrRegexp(headerValue, filter.value)
+}
+
 // Also match request headers
 // https://github.com/pgte/nock/issues/163
 Interceptor.prototype.reqheaderMatches = function reqheaderMatches(
@@ -227,14 +252,8 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
     body = this.scope.transformRequestBodyFunction(body, this._requestBody)
   }
 
-  const checkHeaders = function(header) {
-    if (_.isFunction(header.value)) {
-      return header.value(options.getHeader(header.name))
-    }
-    return common.matchStringOrRegexp(
-      options.getHeader(header.name),
-      header.value
-    )
+  const checkHeaders = function(filter) {
+    return filterMatches(filter, options)
   }
 
   if (
@@ -393,15 +412,8 @@ Interceptor.prototype.matchIndependentOfBody = function matchIndependentOfBody(
   if (this.scope.transformPathFunction) {
     path = this.scope.transformPathFunction(path)
   }
-
-  const checkHeaders = function(header) {
-    if (_.isFunction(header.value)) {
-      return header.value(options.getHeader(header.name))
-    }
-    return common.matchStringOrRegexp(
-      options.getHeader(header.name),
-      header.value
-    )
+  const checkHeaders = function(filter) {
+    return filterMatches(filter, options)
   }
 
   if (

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -252,13 +252,11 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
     body = this.scope.transformRequestBodyFunction(body, this._requestBody)
   }
 
-  const checkHeaders = function(filter) {
-    return filterMatches(filter, options)
-  }
-
   if (
-    !this.scope.matchHeaders.every(checkHeaders) ||
-    !this.interceptorMatchHeaders.every(checkHeaders)
+    !this.scope.matchHeaders.every(filter => filterMatches(filter, options)) ||
+    !this.interceptorMatchHeaders.every(filter =>
+      filterMatches(filter, options)
+    )
   ) {
     this.scope.logger("headers don't match")
     return false

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -384,9 +384,11 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
   return matches
 }
 
-Interceptor.prototype.matchIndependentOfBody = function matchIndependentOfBody(
-  options
-) {
+/**
+ * Return true when the interceptor's method, protocol, host, port, and path
+ * match the provided options.
+ */
+Interceptor.prototype.matchAddress = function matchAddress(options) {
   const isRegex = _.isRegExp(this.path)
   const isRegexBasePath = _.isRegExp(this.scope.basePath)
 

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -165,31 +165,6 @@ Interceptor.prototype.replyWithFile = function replyWithFile(
   return this.reply(statusCode, readStream, headers)
 }
 
-/**
- * Test to see if the headers match a filter. If the function cannot determin where the headers are
- * it returns false.
- * @name filterMatches
- * @param {Object} filter - A filter object containing the header name we want to filter on and the
- *                          filter value which can be a string, regex, or predicate.
- * @param {Object} obj - An object containing the headers we wish to check. This is either the
- *                       request options or the outgoing request.
- * @returns {boolean} True if the headers contain a value that matches the filter.
- */
-function filterMatches(filter, obj) {
-  let headerValue
-  if (obj.getHeader) {
-    headerValue = obj.getHeader(filter.name)
-  } else if (obj.headers) {
-    headerValue = obj.headers[filter.name]
-  } else {
-    return false
-  }
-  if (_.isFunction(filter.value)) {
-    return filter.value(headerValue)
-  }
-  return common.matchStringOrRegexp(headerValue, filter.value)
-}
-
 // Also match request headers
 // https://github.com/pgte/nock/issues/163
 Interceptor.prototype.reqheaderMatches = function reqheaderMatches(
@@ -225,6 +200,23 @@ Interceptor.prototype.reqheaderMatches = function reqheaderMatches(
 
   debug("request header field doesn't match:", key, header, reqHeader)
   return false
+}
+
+/**
+ * Test to see if the headers match a filter.
+ * @name filterMatches
+ * @param {Object} filter - A filter object containing the header name we want to filter on and the
+ *                          filter value which can be a string, regex, or predicate.
+ * @param {Object} obj - An object containing the headers we wish to check. This is either the
+ *                       request options or the outgoing request.
+ * @returns {boolean} True if the headers contain a value that matches the filter.
+ */
+function filterMatches(filter, obj) {
+  const headerValue = obj.getHeader(filter.name)
+  if (typeof filter.value === 'function') {
+    return filter.value(headerValue)
+  }
+  return common.matchStringOrRegexp(headerValue, filter.value)
 }
 
 Interceptor.prototype.match = function match(options, body, hostNameOnly) {

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -228,8 +228,8 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
   }
 
   const checkHeaders = function(filter) {
-    let headerKey = filter.name
-    let headerValue = options.getHeader !== undefined ? options.getHeader(headerKey) : options.headers[headerKey]
+    const headerKey = filter.name
+    const headerValue = options.getHeader !== undefined ? options.getHeader(headerKey) : options.headers[headerKey]
     if (_.isFunction(filter.value)) {
       return filter.value(headerValue)
     }
@@ -397,8 +397,8 @@ Interceptor.prototype.matchIndependentOfBody = function matchIndependentOfBody(
   }
 
   const checkHeaders = function(filter) {
-    let headerKey = filter.name
-    let headerValue = options.getHeader !== undefined ? options.getHeader(headerKey) : options.headers[headerKey]
+    const headerKey = filter.name
+    const headerValue = options.getHeader !== undefined ? options.getHeader(headerKey) : options.headers[headerKey]
     if (_.isFunction(filter.value)) {
       return filter.value(headerValue)
     }

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -229,14 +229,18 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
 
   const checkHeaders = function(filter) {
     const headerKey = filter.name
-    const headerValue = options.getHeader !== undefined ? options.getHeader(headerKey) : options.headers[headerKey]
+    let headerValue
+    if (options.getHeader) {
+      headerValue = options.getHeader(headerKey)
+    } else if (options.headers) {
+      headerValue = options.headers[headerKey]
+    } else {
+      return false
+    }
     if (_.isFunction(filter.value)) {
       return filter.value(headerValue)
     }
-    return common.matchStringOrRegexp(
-      headerValue,
-      filter.value
-    )
+    return common.matchStringOrRegexp(headerValue, filter.value)
   }
 
   if (
@@ -398,14 +402,18 @@ Interceptor.prototype.matchIndependentOfBody = function matchIndependentOfBody(
 
   const checkHeaders = function(filter) {
     const headerKey = filter.name
-    const headerValue = options.getHeader !== undefined ? options.getHeader(headerKey) : options.headers[headerKey]
+    let headerValue
+    if (options.getHeader) {
+      headerValue = options.getHeader(headerKey)
+    } else if (options.headers) {
+      headerValue = options.headers[headerKey]
+    } else {
+      return false
+    }
     if (_.isFunction(filter.value)) {
       return filter.value(headerValue)
     }
-    return common.matchStringOrRegexp(
-      headerValue,
-      filter.value
-    )
+    return common.matchStringOrRegexp(headerValue, filter.value)
   }
 
   if (

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -412,17 +412,6 @@ Interceptor.prototype.matchIndependentOfBody = function matchIndependentOfBody(
   if (this.scope.transformPathFunction) {
     path = this.scope.transformPathFunction(path)
   }
-  const checkHeaders = function(filter) {
-    return filterMatches(filter, options)
-  }
-
-  if (
-    !this.scope.matchHeaders.every(checkHeaders) ||
-    !this.interceptorMatchHeaders.every(checkHeaders)
-  ) {
-    return false
-  }
-
   const comparisonKey = isRegex ? this.__nock_scopeKey : this._key
   const matchKey = `${method} ${proto}://${options.host}${path}`
 

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -202,23 +202,6 @@ Interceptor.prototype.reqheaderMatches = function reqheaderMatches(
   return false
 }
 
-/**
- * Test to see if the headers match a filter.
- * @name filterMatches
- * @param {Object} filter - A filter object containing the header name we want to filter on and the
- *                          filter value which can be a string, regex, or predicate.
- * @param {Object} obj - An object containing the headers we wish to check. This is either the
- *                       request options or the outgoing request.
- * @returns {boolean} True if the headers contain a value that matches the filter.
- */
-function filterMatches(filter, obj) {
-  const headerValue = obj.getHeader(filter.name)
-  if (typeof filter.value === 'function') {
-    return filter.value(headerValue)
-  }
-  return common.matchStringOrRegexp(headerValue, filter.value)
-}
-
 Interceptor.prototype.match = function match(options, body, hostNameOnly) {
   if (debug.enabled) {
     debug('match %s, body = %s', stringify(options), stringify(body))
@@ -244,11 +227,18 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
     body = this.scope.transformRequestBodyFunction(body, this._requestBody)
   }
 
+  const matchesFilter = ({ name, value: predicate }) => {
+    const headerValue = options.getHeader(name)
+    if (typeof predicate === 'function') {
+      return predicate(headerValue)
+    } else {
+      return common.matchStringOrRegexp(headerValue, predicate)
+    }
+  }
+
   if (
-    !this.scope.matchHeaders.every(filter => filterMatches(filter, options)) ||
-    !this.interceptorMatchHeaders.every(filter =>
-      filterMatches(filter, options)
-    )
+    !this.scope.matchHeaders.every(matchesFilter) ||
+    !this.interceptorMatchHeaders.every(filterMatches)
   ) {
     this.scope.logger("headers don't match")
     return false

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -171,8 +171,8 @@ Interceptor.prototype.replyWithFile = function replyWithFile(
  * @name filterMatches
  * @param {Object} filter - A filter object containing the header name we want to filter on and the
  *                          filter value which can be a string, regex, or predicate.
- * @param {Object} obj - A object containing the headers we wish to check. This is either the
- *                       request options or the outgoing request
+ * @param {Object} obj - An object containing the headers we wish to check. This is either the
+ *                       request options or the outgoing request.
  * @returns {boolean} True if the headers contain a value that matches the filter.
  */
 function filterMatches(filter, obj) {

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -227,20 +227,14 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
     body = this.scope.transformRequestBodyFunction(body, this._requestBody)
   }
 
-  const checkHeaders = function(filter) {
-    const headerKey = filter.name
-    let headerValue
-    if (options.getHeader) {
-      headerValue = options.getHeader(headerKey)
-    } else if (options.headers) {
-      headerValue = options.headers[headerKey]
-    } else {
-      return false
+  const checkHeaders = function(header) {
+    if (_.isFunction(header.value)) {
+      return header.value(options.getHeader(header.name))
     }
-    if (_.isFunction(filter.value)) {
-      return filter.value(headerValue)
-    }
-    return common.matchStringOrRegexp(headerValue, filter.value)
+    return common.matchStringOrRegexp(
+      options.getHeader(header.name),
+      header.value
+    )
   }
 
   if (
@@ -400,20 +394,14 @@ Interceptor.prototype.matchIndependentOfBody = function matchIndependentOfBody(
     path = this.scope.transformPathFunction(path)
   }
 
-  const checkHeaders = function(filter) {
-    const headerKey = filter.name
-    let headerValue
-    if (options.getHeader) {
-      headerValue = options.getHeader(headerKey)
-    } else if (options.headers) {
-      headerValue = options.headers[headerKey]
-    } else {
-      return false
+  const checkHeaders = function(header) {
+    if (_.isFunction(header.value)) {
+      return header.value(options.getHeader(header.name))
     }
-    if (_.isFunction(filter.value)) {
-      return filter.value(headerValue)
-    }
-    return common.matchStringOrRegexp(headerValue, filter.value)
+    return common.matchStringOrRegexp(
+      options.getHeader(header.name),
+      header.value
+    )
   }
 
   if (

--- a/tests/test_header_matching.js
+++ b/tests/test_header_matching.js
@@ -82,7 +82,7 @@ test('match headers on number with regexp', async t => {
 })
 
 test('match header on scope with function: gets the expected argument', async t => {
-  t.plan(3)
+  t.plan(4) // The check in matchHeader should run twice
 
   const scope = nock('http://example.test')
     .get('/')
@@ -105,6 +105,21 @@ test('match header on scope with function: gets the expected argument', async t 
 
 test('match header on scope with function: matches when match accepted', async t => {
   const scope = nock('http://example.test')
+    .get('/')
+    .matchHeader('x-my-headers', val => true)
+    .reply(200, 'Hello World!')
+
+  const { statusCode, body } = await got('http://example.test/', {
+    headers: { 'X-My-Headers': 456 },
+  })
+
+  t.equal(statusCode, 200)
+  t.equal(body, 'Hello World!')
+  scope.done()
+})
+
+test('match header on scope with function and allow unmocked: matches when match accepted', async t => {
+  const scope = nock('http://example.test', { allowUnmocked: true })
     .get('/')
     .matchHeader('x-my-headers', val => true)
     .reply(200, 'Hello World!')
@@ -152,7 +167,7 @@ test('match header on scope with function: does not consume mock request when ma
 })
 
 test('match header on intercept with function: gets the expected argument', async t => {
-  t.plan(3)
+  t.plan(4) // The check in matchHeader should run twice
 
   const scope = nock('http://example.test')
     .matchHeader('x-my-headers', val => {
@@ -177,6 +192,23 @@ test('match header on intercept with function: gets the expected argument', asyn
 
 test('match header on interceptor with function: matches when match accepted', async t => {
   const scope = nock('http://example.test')
+    .matchHeader('x-my-headers', val => true)
+    // `.matchHeader()` is called on the interceptor. It precedes the call to
+    // `.get()`.
+    .get('/')
+    .reply(200, 'Hello World!')
+
+  const { statusCode, body } = await got('http://example.test/', {
+    headers: { 'X-My-Headers': 456 },
+  })
+
+  t.equal(statusCode, 200)
+  t.equal(body, 'Hello World!')
+  scope.done()
+})
+
+test('match header on interceptor with function: matches when match accepted', async t => {
+  const scope = nock('http://example.test', { allowUnmocked: true })
     .matchHeader('x-my-headers', val => true)
     // `.matchHeader()` is called on the interceptor. It precedes the call to
     // `.get()`.

--- a/tests/test_header_matching.js
+++ b/tests/test_header_matching.js
@@ -82,7 +82,7 @@ test('match headers on number with regexp', async t => {
 })
 
 test('match header on scope with function: gets the expected argument', async t => {
-  t.plan(4) // The check in matchHeader should run twice
+  t.plan(3)
 
   const scope = nock('http://example.test')
     .get('/')
@@ -167,7 +167,7 @@ test('match header on scope with function: does not consume mock request when ma
 })
 
 test('match header on intercept with function: gets the expected argument', async t => {
-  t.plan(4) // The check in matchHeader should run twice
+  t.plan(3)
 
   const scope = nock('http://example.test')
     .matchHeader('x-my-headers', val => {


### PR DESCRIPTION
Currently, the header filter fails if there is not a `getHeader` method present on the `options` object. This sometimes appears to be the case. This is a simple node program written that should work as a repo
```typescript
import httpProxy from 'http-proxy';
import nock from 'nock';

nock('http://example.com')
  .matchHeader('any-string', val => true)
  .get('/hello'),
  reply(200, 'goodbye');

let proxyServer = httpProxy.createProxyServer({
	changeOrigin: true,
	selfHandleResponse: false,
	target: 'http://example.com',
  });
proxyServer.listen(8080);

```
```bash
curl -X GET http://localhost:8080/hello
```

This change also makes the two checkHeader methods consistent. Where one previously respected functions and the other did not.