### PR TITLE
test: Improve tests for header matching with function; adopt new promise-rejection assertion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -461,7 +461,7 @@
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
@@ -578,6 +578,15 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
+    },
+    "assert-rejects": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-rejects/-/assert-rejects-1.0.0.tgz",
+      "integrity": "sha512-xSmDqs5YxfrHUQBhVfrP/5+UoEvMBTY2+oRDoLfY9zsTA1hnW0KiKYcXKyeVWSgb0UpsQ4gyeBuKlXKzKUobZA==",
+      "dev": true,
+      "requires": {
+        "is-regexp": "^1.0.0"
+      }
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -1037,7 +1046,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
     },
     "class-utils": {
@@ -1159,12 +1168,12 @@
     "color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "integrity": "sha1-k4NDeaHMmgxh+C9S8NBDIiUb1aI=",
       "dev": true
     },
     "colors": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
       "dev": true
     },
@@ -1567,7 +1576,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
@@ -1663,7 +1672,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
@@ -1875,7 +1884,7 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
@@ -2440,7 +2449,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
@@ -2509,7 +2518,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -2544,7 +2553,7 @@
       "dependencies": {
         "split2": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
           "integrity": "sha1-UuLiIdiMdfmnP5BVbiY/+WdysxQ=",
           "dev": true,
           "requires": {
@@ -3051,7 +3060,7 @@
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
@@ -3072,7 +3081,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -3081,7 +3090,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
@@ -3142,7 +3151,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -3179,6 +3188,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
       "dev": true
     },
     "is-stream": {
@@ -3794,7 +3809,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -4075,7 +4090,7 @@
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
       "dev": true,
       "requires": {
         "encoding": "^0.1.11",
@@ -8434,7 +8449,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -9187,7 +9202,7 @@
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
       "dev": true,
       "requires": {
         "glob": "^7.0.5"
@@ -9226,7 +9241,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -9756,7 +9771,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
@@ -9798,7 +9813,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -12952,7 +12967,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -13035,7 +13050,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
@@ -13261,7 +13276,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -13505,7 +13520,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -13530,7 +13545,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
@@ -13541,7 +13556,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -13588,7 +13603,7 @@
     },
     "xmlbuilder": {
       "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "acorn": "^6.0.4",
+    "assert-rejects": "^1.0.0",
     "async": "^2.6.0",
     "aws-sdk": "^2.202.0",
     "coveralls": "^3.0.0",

--- a/tests/test_basic_auth.js
+++ b/tests/test_basic_auth.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { test } = require('tap')
+const assertRejects = require('assert-rejects')
 const got = require('got')
 const nock = require('..')
 
@@ -24,9 +25,11 @@ test('basic auth with username and password', async t => {
   })
 
   await t.test('fails when it doesnt match', async tt => {
-    await tt.rejects(() => got('http://example.test/test'), {
-      message: 'Nock: No match for request',
-    })
+    await assertRejects(
+      got('http://example.test/test'),
+      Error,
+      'Nock: No match for request'
+    )
   })
 })
 
@@ -46,8 +49,10 @@ test('basic auth with username only', async t => {
   })
 
   await t.test('fails when it doesnt match', async tt => {
-    await tt.rejects(() => got('http://example.test/test'), {
-      message: 'Nock: No match for request',
-    })
+    await assertRejects(
+      got('http://example.test/test'),
+      Error,
+      'Nock: No match for request'
+    )
   })
 })

--- a/tests/test_delay.js
+++ b/tests/test_delay.js
@@ -4,6 +4,7 @@ const fs = require('fs')
 const path = require('path')
 const http = require('http')
 const stream = require('stream')
+const assertRejects = require('assert-rejects')
 const got = require('got')
 const mikealRequest = require('request')
 const { test } = require('tap')
@@ -364,9 +365,11 @@ test('delay with replyWithError: response is delayed', async t => {
   await resolvesInAtLeast(
     t,
     async () =>
-      t.rejects(() => got('http://example.test'), {
-        message: 'this is an error message',
-      }),
+      assertRejects(
+        got('http://example.test'),
+        Error,
+        'this is an error message'
+      ),
     100
   )
 })

--- a/tests/test_header_matching.js
+++ b/tests/test_header_matching.js
@@ -2,6 +2,7 @@
 
 const http = require('http')
 const domain = require('domain')
+const assertRejects = require('assert-rejects')
 const { test } = require('tap')
 const got = require('got')
 const mikealRequest = require('request')
@@ -118,40 +119,34 @@ test('match headers with function: matches when match accepted', async t => {
 })
 
 test('match headers with function: does not match when match declined', async t => {
-  const scope = nock('http://example.test')
+  nock('http://example.test')
     .get('/')
     .matchHeader('x-my-headers', val => false)
     .reply(200, 'Hello World!')
 
-  await t.rejects(
-    () =>
-      got('http://example.test/', {
-        headers: { 'X-My-Headers': 456 },
-      }),
-    {
-      message: 'Nock: No match for request',
-    }
+  await assertRejects(
+    got('http://example.test/', {
+      headers: { 'X-My-Headers': 456 },
+    }),
+    Error,
+    'Nock: No match for request'
   )
 })
 
-// TODO: This is failing test for a bug.
 test(
   'match headers with function: does not consume mock request when match declined',
-  { skip: true },
   async t => {
     const scope = nock('http://example.test')
       .get('/')
       .matchHeader('x-my-headers', val => false)
       .reply(200, 'Hello World!')
 
-    await t.rejects(
-      () =>
-        got('http://example.test/', {
-          headers: { 'X-My-Headers': 456 },
-        }),
-      {
-        message: 'Nock: No match for request',
-      }
+    await assertRejects(
+      got('http://example.test/', {
+        headers: { '-My-Headers': 456 },
+      }),
+      Error,
+      'Nock: No match for request'
     )
     t.throws(() => scope.done(), {
       message: 'Mocks not yet satisfied',

--- a/tests/test_header_matching.js
+++ b/tests/test_header_matching.js
@@ -81,7 +81,7 @@ test('match headers on number with regexp', async t => {
   scope.done()
 })
 
-test('match headers with function: gets the expected argument', async t => {
+test('match header on scope with function: gets the expected argument', async t => {
   t.plan(3)
 
   const scope = nock('http://example.test')
@@ -103,7 +103,7 @@ test('match headers with function: gets the expected argument', async t => {
   scope.done()
 })
 
-test('match headers with function: matches when match accepted', async t => {
+test('match header on scope with function: matches when match accepted', async t => {
   const scope = nock('http://example.test')
     .get('/')
     .matchHeader('x-my-headers', val => true)
@@ -118,7 +118,7 @@ test('match headers with function: matches when match accepted', async t => {
   scope.done()
 })
 
-test('match headers with function: does not match when match declined', async t => {
+test('match header on scope with function: does not match when match declined', async t => {
   nock('http://example.test')
     .get('/')
     .matchHeader('x-my-headers', val => false)
@@ -133,10 +133,88 @@ test('match headers with function: does not match when match declined', async t 
   )
 })
 
-test('match headers with function: does not consume mock request when match declined', async t => {
+test('match header on scope with function: does not consume mock request when match declined', async t => {
   const scope = nock('http://example.test')
     .get('/')
     .matchHeader('x-my-headers', val => false)
+    .reply(200, 'Hello World!')
+
+  await assertRejects(
+    got('http://example.test/', {
+      headers: { '-My-Headers': 456 },
+    }),
+    Error,
+    'Nock: No match for request'
+  )
+  t.throws(() => scope.done(), {
+    message: 'Mocks not yet satisfied',
+  })
+})
+
+test('match header on intercept with function: gets the expected argument', async t => {
+  t.plan(3)
+
+  const scope = nock('http://example.test')
+    .matchHeader('x-my-headers', val => {
+      // TODO: It's surprising that this function receives a number instead of
+      // a string. Probably this behavior should be changed.
+      t.equal(val, 456)
+      return true
+    })
+    // `.matchHeader()` is called on the interceptor. It precedes the call to
+    // `.get()`.
+    .get('/')
+    .reply(200, 'Hello World!')
+
+  const { statusCode, body } = await got('http://example.test/', {
+    headers: { 'X-My-Headers': 456 },
+  })
+
+  t.equal(statusCode, 200)
+  t.equal(body, 'Hello World!')
+  scope.done()
+})
+
+test('match header on interceptor with function: matches when match accepted', async t => {
+  const scope = nock('http://example.test')
+    .matchHeader('x-my-headers', val => true)
+    // `.matchHeader()` is called on the interceptor. It precedes the call to
+    // `.get()`.
+    .get('/')
+    .reply(200, 'Hello World!')
+
+  const { statusCode, body } = await got('http://example.test/', {
+    headers: { 'X-My-Headers': 456 },
+  })
+
+  t.equal(statusCode, 200)
+  t.equal(body, 'Hello World!')
+  scope.done()
+})
+
+test('match header on interceptor with function: does not match when match declined', async t => {
+  nock('http://example.test')
+    .matchHeader('x-my-headers', val => false)
+    // `.matchHeader()` is called on the interceptor. It precedes the call to
+    // `.get()`.
+    .get('/')
+    .reply(200, 'Hello World!')
+
+  await assertRejects(
+    got('http://example.test/', {
+      headers: { 'X-My-Headers': 456 },
+    }),
+    Error,
+    'Nock: No match for request'
+  )
+})
+
+test('match header on interceptor with function: does not consume mock request when match declined', async t => {
+  const scope = nock('http://example.test')
+    .matchHeader('x-my-headers', val => false)
+    // `.matchHeader()` is called on the interceptor. It precedes the call to
+    // `.get()`.
+    .get('/')
     .reply(200, 'Hello World!')
 
   await assertRejects(

--- a/tests/test_header_matching.js
+++ b/tests/test_header_matching.js
@@ -133,26 +133,23 @@ test('match headers with function: does not match when match declined', async t 
   )
 })
 
-test(
-  'match headers with function: does not consume mock request when match declined',
-  async t => {
-    const scope = nock('http://example.test')
-      .get('/')
-      .matchHeader('x-my-headers', val => false)
-      .reply(200, 'Hello World!')
+test('match headers with function: does not consume mock request when match declined', async t => {
+  const scope = nock('http://example.test')
+    .get('/')
+    .matchHeader('x-my-headers', val => false)
+    .reply(200, 'Hello World!')
 
-    await assertRejects(
-      got('http://example.test/', {
-        headers: { '-My-Headers': 456 },
-      }),
-      Error,
-      'Nock: No match for request'
-    )
-    t.throws(() => scope.done(), {
-      message: 'Mocks not yet satisfied',
-    })
-  }
-)
+  await assertRejects(
+    got('http://example.test/', {
+      headers: { '-My-Headers': 456 },
+    }),
+    Error,
+    'Nock: No match for request'
+  )
+  t.throws(() => scope.done(), {
+    message: 'Mocks not yet satisfied',
+  })
+})
 
 test('match all headers', async t => {
   const scope = nock('http://example.test')

--- a/tests/test_persist_optionally.js
+++ b/tests/test_persist_optionally.js
@@ -5,6 +5,7 @@
 
 const http = require('http')
 const path = require('path')
+const assertRejects = require('assert-rejects')
 const got = require('got')
 const { test } = require('tap')
 const nock = require('..')
@@ -207,9 +208,11 @@ test('stop persisting a persistent nock', async t => {
   t.equal(nock.activeMocks().length, 0)
   t.true(scope.isDone())
 
-  await t.rejects(async () => got('http://example.test/'), {
-    message: 'Nock: No match for request',
-  })
+  await assertRejects(
+    got('http://example.test/'),
+    Error,
+    'Nock: No match for request'
+  )
 })
 
 test("should throw an error when persist flag isn't a boolean", t => {

--- a/tests/test_replies.js
+++ b/tests/test_replies.js
@@ -100,7 +100,8 @@ test('get with reply callback returning callback without headers', async t => {
 
   await assertRejects(got('http://example.com/'), err => {
     t.equal(err.statusCode, 401)
-    t.equal(body, 'This is a body')
+    t.equal(err.body, 'This is a body')
+    return true
   })
   scope.done()
 })

--- a/tests/test_replies.js
+++ b/tests/test_replies.js
@@ -2,6 +2,7 @@
 
 const http = require('http')
 const path = require('path')
+const assertRejects = require('assert-rejects')
 const { test } = require('tap')
 const mikealRequest = require('request')
 const got = require('got')
@@ -97,9 +98,9 @@ test('get with reply callback returning callback without headers', async t => {
     .get('/')
     .reply(() => [401, 'This is a body'])
 
-  await t.rejects(async () => got('http://example.com/'), {
-    statusCode: 401,
-    body: 'This is a body',
+  await assertRejects(got('http://example.com/'), err => {
+    t.equal(err.statusCode, 401)
+    t.equal(body, 'This is a body')
   })
   scope.done()
 })


### PR DESCRIPTION
1. Assert the expected argument is passed. (It's the correct argument, though not the expected type!)
2. When the function returns true, assert the request matches.
3. When the function returns false, assert the request doesn't match.
4. When the function returns false, assert the mock is not consumed.
5. I added copies of these tests for `matchHeader` called on the interceptor instead of the scope.

Test 4 uncovered an unexpected behavior in tap, which is that `t.rejects` causes our `afterEach` hook to fire – since it's implemented as a subtest.

Not knowing how to work around this, I replaced our uses of `t.rejects` with a promise-rejection assertion that does not rely on a subtest.

Ref: https://github.com/nock/nock/issues/1305#issuecomment-475912886 and tapjs/node-tap#525

This was prompted by #1480, however this isn't related to that bug (which so far I can't reproduce).