### PR TITLE
fix: Interceptor.reply to allow callback and raw headers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,14 @@ const scope = nock('https://api.github.com')
   .reply(200, { license: 'MIT' }, { 'X-RateLimit-Remaining': 4999 })
 ```
 
+Or along with a callback:
+
+```js
+const scope = nock('http://www.example.com')
+  .get('/ping')
+  .reply(() => 'OK!', { 'X-Powered-By': 'Rails' })
+```
+
 Or you can use a function to generate the headers values. The function will be
 passed the request, response, and body (if available). The body will be either a
 buffer, a stream, or undefined.

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -79,6 +79,7 @@ Interceptor.prototype.replyWithError = function replyWithError(errorMessage) {
 
 Interceptor.prototype.reply = function reply(statusCode, body, rawHeaders) {
   if (arguments.length <= 2 && _.isFunction(statusCode)) {
+    rawHeaders = body
     body = statusCode
     statusCode = 200
   }
@@ -453,7 +454,7 @@ Interceptor.prototype.basicAuth = function basicAuth(options) {
 /**
  * Set query strings for the interceptor
  * @name query
- * @param Object Object of query string name,values (accepts regexp values)
+ * @param queries Object of query string name,values (accepts regexp values)
  * @public
  * @example
  * // Will match 'http://zombo.com/?q=t'
@@ -495,7 +496,7 @@ Interceptor.prototype.query = function query(queries) {
 /**
  * Set number of times will repeat the interceptor
  * @name times
- * @param Integer Number of times to repeat (should be > 0)
+ * @param newCounter Number of times to repeat (should be > 0)
  * @public
  * @example
  * // Will repeat mock 5 times for same king of request


### PR DESCRIPTION
Fixes #1513.

Ensures raw headers are still returned when using the form `reply(callback, rawHeaders)`.