### PR TITLE
fix(define): Throw error when legacy reply is in wrong format

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -268,14 +268,14 @@ function load(path) {
 }
 
 function getStatusFromDefinition(nockDef) {
-  //  Backward compatibility for when `status` was encoded as string in `reply`.
+  // Backward compatibility for when `status` was encoded as string in `reply`.
   if (!_.isUndefined(nockDef.reply)) {
-    //  Try parsing `reply` property.
     const parsedReply = parseInt(nockDef.reply, 10)
-    if (_.isNumber(parsedReply)) {
-      return parsedReply
+    if (isNaN(parsedReply)) {
+      throw Error('`reply`, when present, must be a numeric string')
     }
-    // TODO-coverage: `else` throw with an error.
+
+    return parsedReply
   }
 
   const DEFAULT_STATUS_OK = 200

--- a/tests/test_define.js
+++ b/tests/test_define.js
@@ -50,6 +50,24 @@ test('define() is backward compatible', t => {
   req.end()
 })
 
+test('define() throws when reply is not a numeric string', t => {
+  t.throws(
+    () =>
+      nock.define([
+        {
+          scope: 'http://example.com:1451',
+          method: 'GET',
+          path: '/',
+          reply: 'frodo',
+        },
+      ]),
+    {
+      message: '`reply`, when present, must be a numeric string',
+    }
+  )
+  t.end()
+})
+
 test('define() applies default status code when none is specified', async t => {
   const body = '�'
 


### PR DESCRIPTION
Shockingly, `_.isNumber(NaN)` is `true` which means this conditional check didn’t even work as intended.

Testing error paths is important!

Ref #1404