### PR TITLE
test(intercept): Reference the issue

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -182,9 +182,10 @@ Interceptor.prototype.reqheaderMatches = function reqheaderMatches(
     header = header.toString()
   }
 
-  //  We skip 'host' header comparison unless it's available in both mock and actual request.
-  //  This because 'host' may get inserted by Nock itself and then get recorder.
-  //  NOTE: We use lower-case header field names throughout Nock.
+  // We skip 'host' header comparison unless it's available in both mock and
+  // actual request. This because 'host' may get inserted by Nock itself and
+  // then get recorded. NOTE: We use lower-case header field names throughout
+  // Nock. See https://github.com/nock/nock/pull/196.
   // TODO-coverage: This looks very special. Worth an investigation.
   if (key === 'host' && (_.isUndefined(header) || _.isUndefined(reqHeader))) {
     return true


### PR DESCRIPTION
I did a partial investigation into the host-matching issue. I can't say I got to the bottom of it. But I did learn a few things.

1. At the time this code was added, the recorder was changed to no longer by default record saved request headers.
2. The comment says nock sets these headers. Also [the readme says so](https://github.com/nock/nock/blob/dca678849a7fc0a779b2b9c49e416b4299cfebfb/README.md#specifying-request-headers). I am not completely sure what this means, nor why we do this.
3. The `setRequestHeaders` function seems to have something to do with this, but I don't completely understand why we're doing this here and in this particular way. https://github.com/nock/nock/blob/dca678849a7fc0a779b2b9c49e416b4299cfebfb/lib/request_overrider.js#L35-L61
4. The code is unreachable because the `Host` header is present in every request I tried, whether via `request` or `got`. I think this is related to (3) though I'm not sure. Therefore `_.isUndefined(header)` is always true.
5. There is a test related to this in https://github.com/nock/nock/blob/dca678849a7fc0a779b2b9c49e416b4299cfebfb/tests/test_intercept.js#L1300-L1320. I suspect this test is pointless though I'm having a difficult time reasoning why.