### PR TITLE
refactor(scope): Replace unreachable conditional with an assertion

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -180,10 +180,8 @@ Scope.prototype.buildFilter = function buildFilter() {
         // be a string, regardless of what options might be passed to it.
         // However the code used to contain a truthiness test of `candidate`.
         // The check is being preserved for now.
-        //
-        // If you DO encounter this error, please report it as a bug.
         throw Error(
-          `Nock internal assertion failed: typeof candidate is ${typeof candidate}`
+          `Nock internal assertion failed: typeof candidate is ${typeof candidate}. If you encounter this error, please report it as a bug.`
         )
       }
       return candidate.replace(filteringArguments[0], filteringArguments[1])

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -174,17 +174,19 @@ Scope.prototype.buildFilter = function buildFilter() {
 
   if (arguments[0] instanceof RegExp) {
     return function(candidate) {
-      // TODO-coverage: Try to find an actual use case where a non-string
-      // argument can be passed here. Don't add coverage that uses '' which
-      // technically would cover this block, but would not be helpful. If
-      // a use case can't be found, remove the conditional.
-      if (candidate) {
-        candidate = candidate.replace(
-          filteringArguments[0],
-          filteringArguments[1]
+      /* istanbul ignore if */
+      if (typeof candidate !== 'string') {
+        // Given the way nock is written, it seems like `candidate` will always
+        // be a string, regardless of what options might be passed to it.
+        // However the code used to contain a truthiness test of `candidate`.
+        // The check is being preserved for now.
+        //
+        // If you DO encounter this error, please report it as a bug.
+        throw Error(
+          `Nock internal assertion failed: typeof candidate is ${typeof candidate}`
         )
       }
-      return candidate
+      return candidate.replace(filteringArguments[0], filteringArguments[1])
     }
   } else if (_.isFunction(arguments[0])) {
     return arguments[0]


### PR DESCRIPTION
Several hours have been spent on this puzzling bit of uncovered code. I can’t remember what the last investigation revealed. It did not quite reach a conclusion nor can I find any notes about it.

I think this particular case is not worth investigating any further. Let’s keep the check (at least as long as this code is sitting around), and throw an error if it fails. We’ll find out soon enough if there is a use case where a non-string argument can reach this function.