### PR TITLE
chore(docs): Add encodedQueryParams option to docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,16 @@ nock('http://example.com')
   .reply(200, { results: [{ id: 'pgte' }] })
 ```
 
+A query string that is already [URL encoded](https://en.wikipedia.org/wiki/Percent-encoding) can be
+matched by passing the `encodedQueryParams` flag in the options when creating the Scope.
+
+```js
+nock('http://example.com', { encodedQueryParams: true })
+  .get('/users')
+  .query('foo%5Bbar%5D%3Dhello%20world%21')
+  .reply(200, { results: [{ id: 'pgte' }] })
+```
+
 ### Specifying replies
 
 You can specify the return status code for a path on the first argument of reply like this:


### PR DESCRIPTION
Identified as missing here https://github.com/nock/nock/issues/1514#issuecomment-488742980.

This option seems to have been added to better support how the
recorder saves and plays back. But as it is a valid, public option it
should be documented.

Tests already exist. 