### PR TITLE
Bugfix Interceptor.filteringPath

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -417,12 +417,12 @@ Interceptor.prototype.matchAddress = function matchAddress(options) {
   return comparisonKey === matchKey
 }
 
-Interceptor.prototype.filteringPath = function filteringPath() {
-  if (_.isFunction(arguments[0])) {
-    this.scope.transformFunction = arguments[0]
-  }
+Interceptor.prototype.filteringPath = function filteringPath(...args) {
+  this.scope.filteringPath(...args)
   return this
 }
+
+// filtering by path is valid on the intercept level, but not filtering by request body?
 
 Interceptor.prototype.discard = function discard() {
   if ((this.scope.shouldPersist() || this.counter > 0) && this.filePath) {

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -199,22 +199,6 @@ test('reply with callback and filtered path and body', async t => {
   scope.done()
 })
 
-test('filteringPath with invalid argument throws expected', t => {
-  t.throws(() => nock('http://example.test').filteringPath('abc123'), {
-    message:
-      'Invalid arguments: filtering path should be a function or a regular expression',
-  })
-  t.end()
-})
-
-test('filteringRequestBody with invalid argument throws expected', t => {
-  t.throws(() => nock('http://example.test').filteringRequestBody('abc123'), {
-    message:
-      'Invalid arguments: filtering request body should be a function or a regular expression',
-  })
-  t.end()
-})
-
 test('head', async t => {
   const scope = nock('http://example.test')
     .head('/')
@@ -276,62 +260,15 @@ test('encoding', async t => {
 })
 
 test('filter path with function', async t => {
+  // Interceptor.filteringPath simply proxies to Scope.filteringPath, this test covers the proxy,
+  // testing the logic of filteringPath itself is done in test_scope.js.
   const scope = nock('http://example.test')
-    .filteringPath(path => '/?a=2&b=1')
     .get('/?a=2&b=1')
+    .filteringPath(() => '/?a=2&b=1')
     .reply(200, 'Hello World!')
 
   const { statusCode } = await got('http://example.test/', {
     query: { a: '1', b: '2' },
-  })
-
-  t.equal(statusCode, 200)
-  scope.done()
-})
-
-test('filter path with regexp', async t => {
-  const scope = nock('http://example.test')
-    .filteringPath(/\d/g, '3')
-    .get('/?a=3&b=3')
-    .reply(200, 'Hello World!')
-
-  const { statusCode } = await got('http://example.test/', {
-    query: { a: '1', b: '2' },
-  })
-
-  t.equal(statusCode, 200)
-  scope.done()
-})
-
-test('filter body with function', async t => {
-  let filteringRequestBodyCounter = 0
-
-  const scope = nock('http://example.test')
-    .filteringRequestBody(body => {
-      ++filteringRequestBodyCounter
-      t.equal(body, 'mamma mia')
-      return 'mamma tua'
-    })
-    .post('/', 'mamma tua')
-    .reply(200, 'Hello World!')
-
-  const { statusCode } = await got('http://example.test/', {
-    body: 'mamma mia',
-  })
-
-  t.equal(statusCode, 200)
-  scope.done()
-  t.equal(filteringRequestBodyCounter, 1)
-})
-
-test('filter body with regexp', async t => {
-  const scope = nock('http://example.test')
-    .filteringRequestBody(/mia/, 'nostra')
-    .post('/', 'mamma nostra')
-    .reply(200, 'Hello World!')
-
-  const { statusCode } = await got('http://example.test/', {
-    body: 'mamma mia',
   })
 
   t.equal(statusCode, 200)

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -259,7 +259,7 @@ test('encoding', async t => {
   scope.done()
 })
 
-test('filter path with function', async t => {
+test('on interceptor, filter path with function', async t => {
   // Interceptor.filteringPath simply proxies to Scope.filteringPath, this test covers the proxy,
   // testing the logic of filteringPath itself is done in test_scope.js.
   const scope = nock('http://example.test')

--- a/tests/test_scope.js
+++ b/tests/test_scope.js
@@ -5,6 +5,7 @@ const { test } = require('tap')
 const proxyquire = require('proxyquire').noPreserveCache()
 const Interceptor = require('../lib/interceptor')
 const nock = require('..')
+const got = require('./got_client')
 
 require('./cleanup_after_each')()
 
@@ -84,5 +85,84 @@ test('loadDefs throws expected when fs is not available', t => {
 
   t.throws(() => loadDefs(), { message: 'No fs' })
 
+  t.end()
+})
+
+test('filter path with function', async t => {
+  const scope = nock('http://example.test')
+    .filteringPath(() => '/?a=2&b=1')
+    .get('/?a=2&b=1')
+    .reply(200, 'Hello World!')
+
+  const { statusCode } = await got('http://example.test/', {
+    query: { a: '1', b: '2' },
+  })
+
+  t.equal(statusCode, 200)
+  scope.done()
+})
+
+test('filter path with regexp', async t => {
+  const scope = nock('http://example.test')
+    .filteringPath(/\d/g, '3')
+    .get('/?a=3&b=3')
+    .reply(200, 'Hello World!')
+
+  const { statusCode } = await got('http://example.test/', {
+    query: { a: '1', b: '2' },
+  })
+
+  t.equal(statusCode, 200)
+  scope.done()
+})
+
+test('filteringPath with invalid argument throws expected', t => {
+  t.throws(() => nock('http://example.test').filteringPath('abc123'), {
+    message:
+      'Invalid arguments: filtering path should be a function or a regular expression',
+  })
+  t.end()
+})
+
+test('filter body with function', async t => {
+  let filteringRequestBodyCounter = 0
+
+  const scope = nock('http://example.test')
+    .filteringRequestBody(body => {
+      ++filteringRequestBodyCounter
+      t.equal(body, 'mamma mia')
+      return 'mamma tua'
+    })
+    .post('/', 'mamma tua')
+    .reply(200, 'Hello World!')
+
+  const { statusCode } = await got('http://example.test/', {
+    body: 'mamma mia',
+  })
+
+  t.equal(statusCode, 200)
+  scope.done()
+  t.equal(filteringRequestBodyCounter, 1)
+})
+
+test('filter body with regexp', async t => {
+  const scope = nock('http://example.test')
+    .filteringRequestBody(/mia/, 'nostra')
+    .post('/', 'mamma nostra')
+    .reply(200, 'Hello World!')
+
+  const { statusCode } = await got('http://example.test/', {
+    body: 'mamma mia',
+  })
+
+  t.equal(statusCode, 200)
+  scope.done()
+})
+
+test('filteringRequestBody with invalid argument throws expected', t => {
+  t.throws(() => nock('http://example.test').filteringRequestBody('abc123'), {
+    message:
+      'Invalid arguments: filtering request body should be a function or a regular expression',
+  })
   t.end()
 })


### PR DESCRIPTION
Calling `filteringPath` on the intercept instance was broken as the
transform fn set on the scope had the wrong name.
Proxying to the Scope’s method allows for the regex version to work too.

The bulk of the changed lines come from moving the tests to their
appropriate file since the real logic acts on the Scope.

Found when looking at uncovered lines in Coveralls.

Side work, pulled out from #1520.