### PR TITLE
Support req.end with callback only

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -126,6 +126,10 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
 
   req.end = function(buffer, encoding, callback) {
     debug('req.end')
+    if (_.isFunction(buffer) && arguments.length === 1) {
+      callback = buffer
+      buffer = null
+    }
     if (!req.aborted && !ended) {
       req.write(buffer, encoding, function() {
         if (typeof callback === 'function') {


### PR DESCRIPTION
According to the docs, `req.end` can accept callback as a first argument. That's what `got` module does.

Closes #1509

```
request.end([data[, encoding]][, callback])
```