### PR TITLE
feat(requestoverrider): Add method property to mocked requests

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -94,6 +94,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
   }
 
   req.path = options.path
+  req.method = options.method
 
   options.getHeader = function(name) {
     return getHeader(req, name)

--- a/tests/test_request_overrider.js
+++ b/tests/test_request_overrider.js
@@ -396,7 +396,7 @@ test('should throw expected error when creating request with missing options', t
 
 // https://github.com/nock/nock/issues/1558
 test("mocked requests have 'method' property", t => {
-  nock('http://example.test')
+  const scope = nock('http://example.test')
     .get('/somepath')
     .reply(200, {})
 
@@ -409,6 +409,7 @@ test("mocked requests have 'method' property", t => {
   t.equal(req.method, 'GET')
   req.on('response', function(res) {
     t.equal(res.req.method, 'GET')
+    scope.done()
     t.end()
   })
   req.end()

--- a/tests/test_request_overrider.js
+++ b/tests/test_request_overrider.js
@@ -393,3 +393,23 @@ test('should throw expected error when creating request with missing options', t
   })
   t.end()
 })
+
+// https://github.com/nock/nock/issues/1558
+test("mocked requests have 'method' property", t => {
+  nock('http://example.test')
+    .get('/somepath')
+    .reply(200, {})
+
+  const req = http.request({
+    host: 'example.test',
+    path: '/somepath',
+    method: 'GET',
+    port: 80,
+  })
+  t.equal(req.method, 'GET')
+  req.on('response', function(res) {
+    t.equal(res.req.method, 'GET')
+    t.end()
+  })
+  req.end()
+})


### PR DESCRIPTION
Mocked requests were missing the 'method' property on them.

Added a testcase to the `test_request_overrider` testsuite.