### PR TITLE
Lint: Remove overrides.

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -21,7 +21,6 @@ rules:
   # on.
   node/no-deprecated-api: 'off'
   handle-callback-err: 'off'
-  camelcase: 'off'
 
   # Nock additions.
   strict: ['error', 'safe']

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -20,7 +20,6 @@ rules:
   # TODO These are included in standard and should be cleaned up and turned
   # on.
   node/no-deprecated-api: 'off'
-  no-throw-literal: 'off'
   handle-callback-err: 'off'
   eqeqeq: 'off'
   new-cap: 'off'

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -21,7 +21,6 @@ rules:
   # on.
   node/no-deprecated-api: 'off'
   handle-callback-err: 'off'
-  new-cap: 'off'
   camelcase: 'off'
 
   # Nock additions.

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -20,7 +20,6 @@ rules:
   # TODO These are included in standard and should be cleaned up and turned
   # on.
   node/no-deprecated-api: 'off'
-  no-path-concat: 'off'
   no-throw-literal: 'off'
   handle-callback-err: 'off'
   eqeqeq: 'off'

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -20,7 +20,6 @@ rules:
   # TODO These are included in standard and should be cleaned up and turned
   # on.
   node/no-deprecated-api: 'off'
-  handle-callback-err: 'off'
 
   # Nock additions.
   strict: ['error', 'safe']

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -21,7 +21,6 @@ rules:
   # on.
   node/no-deprecated-api: 'off'
   handle-callback-err: 'off'
-  eqeqeq: 'off'
   new-cap: 'off'
   camelcase: 'off'
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -14,7 +14,7 @@ const normalizeRequestOptions = function(options) {
   if (options.host) {
     debug('options.host:', options.host)
     if (!options.hostname) {
-      if (options.host.split(':').length == 2) {
+      if (options.host.split(':').length === 2) {
         options.hostname = options.host.split(':')[0]
       } else {
         options.hostname = options.host
@@ -140,7 +140,7 @@ const restoreOverriddenRequests = function() {
  * Get high level information about request as string
  * @param  {Object} options
  * @param  {string} options.method
- * @param  {string} options.port
+ * @param  {number|string} options.port
  * @param  {string} options.proto
  * @param  {string} options.hostname
  * @param  {string} options.path
@@ -154,11 +154,13 @@ function stringifyRequest(options, body) {
   let { port } = options
   // TODO-coverage: Add a test to cover the missing condition, or remove if
   // not reachable.
-  if (!port) port = options.proto == 'https' ? '443' : '80'
+  // The step seems useless considering we don't show the port for standard 80/443 anyway.
+  // The net affect this has is to default the port to 80 when the proto *is not* http. (which probably isn't right)
+  if (!port) port = options.proto === 'https' ? '443' : '80'
 
   if (
-    (options.proto == 'https' && port == '443') ||
-    (options.proto == 'http' && port == '80')
+    (options.proto === 'https' && (port === 443 || port === '443')) ||
+    (options.proto === 'http' && (port === 80 || port === '80'))
   ) {
     port = ''
   }

--- a/lib/common.js
+++ b/lib/common.js
@@ -155,7 +155,8 @@ function stringifyRequest(options, body) {
   // TODO-coverage: Add a test to cover the missing condition, or remove if
   // not reachable.
   // The step seems useless considering we don't show the port for standard 80/443 anyway.
-  // The net affect this has is to default the port to 80 when the proto *is not* http. (which probably isn't right)
+  // It's not clear whether the port could be set to something other than http or https. If
+  // it is, this would make an unspecified port default to 80, which is probably incorrect.
   if (!port) port = options.proto === 'https' ? '443' : '80'
 
   if (

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -193,12 +193,12 @@ function generateRequestAndResponse(req, bodyChunks, options, res, dataChunks) {
 //  to finish (which is the point of the test).
 let currentRecordingId = 0
 
-function record(options) {
+function record(recOptions) {
   //  Set the new current recording ID and capture its value in this instance of record().
   currentRecordingId = currentRecordingId + 1
   const thisRecordingId = currentRecordingId
 
-  debug('start recording', thisRecordingId, JSON.stringify(options))
+  debug('start recording', thisRecordingId, JSON.stringify(recOptions))
 
   //  Trying to start recording with recording already in progress implies an error
   //  in the recording configuration (double recording makes no sense and used to lead
@@ -211,18 +211,18 @@ function record(options) {
 
   //  Originally the parameters was a dont_print boolean flag.
   //  To keep the existing code compatible we take that case into account.
-  const optionsIsObject = typeof options === 'object'
+  const optionsIsObject = typeof recOptions === 'object'
   const dontPrint =
-    (typeof options === 'boolean' && options) ||
-    (optionsIsObject && options.dont_print)
-  const outputObjects = optionsIsObject && options.output_objects
+    (typeof recOptions === 'boolean' && recOptions) ||
+    (optionsIsObject && recOptions.dont_print)
+  const outputObjects = optionsIsObject && recOptions.output_objects
   const enableReqHeadersRecording =
-    optionsIsObject && options.enable_reqheaders_recording
+    optionsIsObject && recOptions.enable_reqheaders_recording
   // eslint-disable-next-line no-console
-  const logging = (optionsIsObject && options.logging) || console.log
+  const logging = (optionsIsObject && recOptions.logging) || console.log
   let useSeparator = true
-  if (optionsIsObject && _.has(options, 'use_separator')) {
-    useSeparator = options.use_separator
+  if (optionsIsObject && _.has(recOptions, 'use_separator')) {
+    useSeparator = recOptions.use_separator
   }
 
   debug(thisRecordingId, 'restoring overridden requests before new overrides')

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -193,12 +193,12 @@ function generateRequestAndResponse(req, bodyChunks, options, res, dataChunks) {
 //  to finish (which is the point of the test).
 let currentRecordingId = 0
 
-function record(rec_options) {
+function record(options) {
   //  Set the new current recording ID and capture its value in this instance of record().
   currentRecordingId = currentRecordingId + 1
   const thisRecordingId = currentRecordingId
 
-  debug('start recording', thisRecordingId, JSON.stringify(rec_options))
+  debug('start recording', thisRecordingId, JSON.stringify(options))
 
   //  Trying to start recording with recording already in progress implies an error
   //  in the recording configuration (double recording makes no sense and used to lead
@@ -209,20 +209,20 @@ function record(rec_options) {
 
   recordingInProgress = true
 
-  //  Originaly the parameters was a dont_print boolean flag.
+  //  Originally the parameters was a dont_print boolean flag.
   //  To keep the existing code compatible we take that case into account.
-  const optionsIsObject = typeof rec_options === 'object'
-  const dont_print =
-    (typeof rec_options === 'boolean' && rec_options) ||
-    (optionsIsObject && rec_options.dont_print)
-  const output_objects = optionsIsObject && rec_options.output_objects
-  const enable_reqheaders_recording =
-    optionsIsObject && rec_options.enable_reqheaders_recording
+  const optionsIsObject = typeof options === 'object'
+  const dontPrint =
+    (typeof options === 'boolean' && options) ||
+    (optionsIsObject && options.dont_print)
+  const outputObjects = optionsIsObject && options.output_objects
+  const enableReqHeadersRecording =
+    optionsIsObject && options.enable_reqheaders_recording
   // eslint-disable-next-line no-console
-  const logging = (optionsIsObject && rec_options.logging) || console.log
-  let use_separator = true
-  if (optionsIsObject && _.has(rec_options, 'use_separator')) {
-    use_separator = rec_options.use_separator
+  const logging = (optionsIsObject && options.logging) || console.log
+  let useSeparator = true
+  if (optionsIsObject && _.has(options, 'use_separator')) {
+    useSeparator = options.use_separator
   }
 
   debug(thisRecordingId, 'restoring overridden requests before new overrides')
@@ -276,7 +276,7 @@ function record(rec_options) {
         debug(thisRecordingId, proto, 'intercepted request ended')
 
         let out
-        if (output_objects) {
+        if (outputObjects) {
           out = generateRequestAndResponseObject(
             req,
             bodyChunks,
@@ -292,7 +292,7 @@ function record(rec_options) {
             common.deleteHeadersField(out.reqheaders, 'user-agent')
 
             //  Remove request headers completely unless it was explicitly enabled by the user (see README)
-            if (!enable_reqheaders_recording) {
+            if (!enableReqHeadersRecording) {
               delete out.reqheaders
             }
           }
@@ -323,8 +323,8 @@ function record(rec_options) {
 
         outputs.push(out)
 
-        if (!dont_print) {
-          if (use_separator) {
+        if (!dontPrint) {
+          if (useSeparator) {
             if (typeof out !== 'string') {
               // TODO-coverage: This is missing coverage. Could this be
               // connected to the `output_object` option?

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -243,7 +243,7 @@ function record(rec_options) {
   ) {
     const bodyChunks = []
 
-    if (typeof options == 'string') {
+    if (typeof options === 'string') {
       // TODO-coverage: Investigate why this was added. Add a test if
       // possible. If we can't figure it out, remove it.
       const url = URL.parse(options)

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -21,7 +21,7 @@ function setHeader(request, name, value) {
 
   request.setHeader(name.toLowerCase(), value)
 
-  if (name == 'expect' && value == '100-continue') {
+  if (name === 'expect' && value === '100-continue') {
     timers.setImmediate(function() {
       debug('continue')
       request.emit('continue')
@@ -192,7 +192,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
   // extraordinarily confusing behavior.
   req.once = req.on = function(event, listener) {
     // emit a fake socket.
-    if (event == 'socket') {
+    if (event === 'socket') {
       listener.call(req, req.socket)
       req.socket.emit('connect', req.socket)
       req.socket.emit('secureConnect', req.socket)

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1,4 +1,5 @@
-/* eslint-disable strict */
+'use strict'
+
 /**
  * @module nock/scope
  */

--- a/tests/test_abort.js
+++ b/tests/test_abort.js
@@ -54,7 +54,7 @@ test('Aborting an aborted request should not emit an error', t => {
     .reply(200)
 
   let errorCount = 0
-  const req = http.get('http://example.test/status').on('error', err => {
+  const req = http.get('http://example.test/status').on('error', () => {
     errorCount++
     if (errorCount < 3) {
       // Abort 3 times at max, otherwise this would be an endless loop,

--- a/tests/test_allow_unmocked.js
+++ b/tests/test_allow_unmocked.js
@@ -138,7 +138,7 @@ test('allow unmocked option works', t => {
 })
 
 test('allow unmocked post with json data', t => {
-  t.plan(2)
+  t.plan(3)
   t.once('end', function() {
     server.close()
   })
@@ -160,7 +160,8 @@ test('allow unmocked post with json data', t => {
       json: { some: 'data' },
     }
 
-    mikealRequest(options, function(err, resp, body) {
+    mikealRequest(options, function(err, resp) {
+      t.error(err)
       t.equal(200, resp.statusCode)
       t.end()
     })
@@ -168,7 +169,7 @@ test('allow unmocked post with json data', t => {
 })
 
 test('allow unmocked passthrough with mismatched bodies', t => {
-  t.plan(2)
+  t.plan(3)
   t.once('end', function() {
     server.close()
   })
@@ -181,7 +182,7 @@ test('allow unmocked passthrough with mismatched bodies', t => {
 
   server.listen(() => {
     nock(`http://localhost:${server.address().port}`, { allowUnmocked: true })
-      .post('/post', { some: 'otherdata' })
+      .post('/post', { some: 'other data' })
       .reply(404, 'Hey!')
 
     const options = {
@@ -190,7 +191,8 @@ test('allow unmocked passthrough with mismatched bodies', t => {
       json: { some: 'data' },
     }
 
-    mikealRequest(options, function(err, resp, body) {
+    mikealRequest(options, function(err, resp) {
+      t.error(err)
       t.equal(200, resp.statusCode)
       t.end()
     })

--- a/tests/test_allow_unmocked.js
+++ b/tests/test_allow_unmocked.js
@@ -85,7 +85,7 @@ test('allow unmocked option works', t => {
           response => {
             response.destroy()
 
-            t.assert(response.statusCode === 200, 'Do not intercept /')
+            t.is(response.statusCode, 200, 'Do not intercept /')
 
             server.close(t.end)
           }
@@ -123,7 +123,7 @@ test('allow unmocked option works', t => {
         port: server.address().port,
       },
       response => {
-        t.assert(response.statusCode === 304, 'Intercept /abc')
+        t.is(response.statusCode, 304, 'Intercept /abc')
 
         response.on('end', firstIsDone)
         // Streams start in 'paused' mode and must be started.

--- a/tests/test_allow_unmocked.js
+++ b/tests/test_allow_unmocked.js
@@ -85,7 +85,7 @@ test('allow unmocked option works', t => {
           response => {
             response.destroy()
 
-            t.assert(response.statusCode == 200, 'Do not intercept /')
+            t.assert(response.statusCode === 200, 'Do not intercept /')
 
             server.close(t.end)
           }
@@ -123,7 +123,7 @@ test('allow unmocked option works', t => {
         port: server.address().port,
       },
       response => {
-        t.assert(response.statusCode == 304, 'Intercept /abc')
+        t.assert(response.statusCode === 304, 'Intercept /abc')
 
         response.on('end', firstIsDone)
         // Streams start in 'paused' mode and must be started.

--- a/tests/test_define.js
+++ b/tests/test_define.js
@@ -206,7 +206,7 @@ test('define() works with binary buffers', t => {
     }
   )
 
-  req.on('error', err => {
+  req.on('error', () => {
     //  This should never happen.
     t.fail('Error should never occur.')
     t.end()

--- a/tests/test_define.js
+++ b/tests/test_define.js
@@ -183,7 +183,7 @@ test('define() works with binary buffers', t => {
     ])
   )
 
-  const req = new http.request(
+  const req = http.request(
     {
       host: 'example.com',
       method: 'POST',
@@ -238,7 +238,7 @@ test('define() uses reqheaders', t => {
 
   // Make a request which should match the mock that was configured above.
   // This does not hit the network.
-  const req = new http.request(
+  const req = http.request(
     {
       host: 'example.com',
       method: 'GET',
@@ -282,7 +282,7 @@ test('define() uses badheaders', t => {
     ])
   )
 
-  const req = new http.request(
+  const req = http.request(
     {
       host: 'example.com',
       method: 'GET',

--- a/tests/test_delay.js
+++ b/tests/test_delay.js
@@ -267,6 +267,7 @@ test('using reply callback with delay can reply JSON', t => {
       json: true,
     },
     function(err, res, body) {
+      t.error(err)
       t.equals(res.headers['content-type'], 'application/json')
       t.deepEqual(body, { a: 1 })
       t.end()

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -13,15 +13,15 @@ const got = require('./got_client')
 
 require('./cleanup_after_each')()
 
-const globalCount = Object.keys(global).length
-const acceptableLeaks = [
+const acceptableGlobalKeys = new Set([
+  ...Object.keys(global),
   '_key',
   '__core-js_shared__',
   'fetch',
   'Response',
   'Headers',
   'Request',
-]
+])
 
 test('invalid or missing method parameter throws an exception', t => {
   t.throws(() => nock('https://example.com').intercept('/somepath'), {
@@ -1300,12 +1300,10 @@ test('data is sent with flushHeaders', t => {
     .flushHeaders()
 })
 
-test('teardown', t => {
-  let leaks = Object.keys(global).splice(globalCount, Number.MAX_VALUE)
-
-  leaks = leaks.filter(function(key) {
-    return acceptableLeaks.indexOf(key) === -1
-  })
+test('no new keys were added to the global namespace', t => {
+  const leaks = Object.keys(global).filter(
+    key => !acceptableGlobalKeys.has(key)
+  )
 
   t.deepEqual(leaks, [], 'No leaks')
   t.end()

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -657,6 +657,7 @@ test('superagent works', t => {
     .reply(200, responseText, headers)
 
   superagent.get('http://example.test/somepath').end(function(err, res) {
+    t.error(err)
     t.equal(res.text, responseText)
     t.end()
   })
@@ -670,6 +671,7 @@ test('superagent works with query string', t => {
     .reply(200, responseText, headers)
 
   superagent.get('http://example.test/somepath?a=b').end(function(err, res) {
+    t.error(err)
     t.equal(res.text, responseText)
     t.end()
   })
@@ -684,6 +686,7 @@ test('superagent posts', t => {
     .post('http://example.test/somepath?b=c')
     .send('some data')
     .end(function(err, res) {
+      t.error(err)
       t.equal(res.status, 204)
       t.end()
     })
@@ -709,6 +712,7 @@ test('sending binary and receiving JSON should work ', t => {
       headers: { Accept: 'application/json', 'Content-Length': 23861 },
     },
     function(err, res, body) {
+      t.error(err)
       scope.done()
 
       t.equal(res.statusCode, 201)
@@ -736,8 +740,10 @@ test('handles get with restify client', t => {
     url: 'https://example.test',
   })
 
-  client.get('/get', function(err, req, res) {
+  client.get('/get', function(err, req) {
+    t.error(err)
     req.on('result', function(err, res) {
+      t.error(err)
       res.body = ''
       res.setEncoding('utf8')
       res.on('data', function(chunk) {
@@ -762,8 +768,10 @@ test('handles post with restify client', t => {
     url: 'https://example.test',
   })
 
-  client.post('/post', function(err, req, res) {
+  client.post('/post', function(err, req) {
+    t.error(err)
     req.on('result', function(err, res) {
+      t.error(err)
       res.body = ''
       res.setEncoding('utf8')
       res.on('data', function(chunk) {
@@ -792,6 +800,7 @@ test('handles get with restify JsonClient', t => {
   })
 
   client.get('/get', function(err, req, res, obj) {
+    t.error(err)
     t.equal(obj.get, 'ok')
     t.end()
     scope.done()
@@ -808,6 +817,7 @@ test('handles post with restify JsonClient', t => {
   })
 
   client.post('/post', { username: 'banana' }, function(err, req, res, obj) {
+    t.error(err)
     t.equal(obj.post, 'ok')
     t.end()
     scope.done()
@@ -823,7 +833,10 @@ test('handles 404 with restify JsonClient', t => {
     url: 'https://example.test',
   })
 
-  client.put('/404', function(err, req, res, obj) {
+  client.put('/404', function(err, req, res) {
+    if (!err) {
+      t.fail('No Error was provided')
+    }
     t.equal(res.statusCode, 404)
     t.end()
     scope.done()
@@ -839,7 +852,10 @@ test('handles 500 with restify JsonClient', t => {
     url: 'https://example.test',
   })
 
-  client.del('/500', function(err, req, res, obj) {
+  client.del('/500', function(err, req, res) {
+    if (!err) {
+      t.fail('No Error was provided')
+    }
     t.equal(res.statusCode, 500)
     t.end()
     scope.done()
@@ -1175,6 +1191,7 @@ test('you must setup an interceptor for each request', t => {
     .reply(200, 'First match')
 
   mikealRequest.get('http://example.test/hey', function(error, res, body) {
+    t.error(error)
     t.equal(res.statusCode, 200)
     t.equal(body, 'First match', 'should match first request response body')
 

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -1287,7 +1287,7 @@ test('teardown', t => {
   let leaks = Object.keys(global).splice(globalCount, Number.MAX_VALUE)
 
   leaks = leaks.filter(function(key) {
-    return acceptableLeaks.indexOf(key) == -1
+    return acceptableLeaks.indexOf(key) === -1
   })
 
   t.deepEqual(leaks, [], 'No leaks')

--- a/tests/test_net_connect.js
+++ b/tests/test_net_connect.js
@@ -63,7 +63,7 @@ test('disallow request for other domains, via string', t => {
 
   http
     .get('http://www.amazon.com', function(res) {
-      throw 'should not deliver this request'
+      throw Error('should not deliver this request')
     })
     .on('error', function(err) {
       t.equal(
@@ -97,7 +97,7 @@ test('disallow request for other domains, via regexp', t => {
 
   http
     .get('http://www.amazon.com', function(res) {
-      throw 'should not deliver this request'
+      throw Error('should not deliver this request')
     })
     .on('error', function(err) {
       t.equal(

--- a/tests/test_nock_lifecycle.js
+++ b/tests/test_nock_lifecycle.js
@@ -88,7 +88,7 @@ test('clean all works', t => {
         t.assert(res.statusCode !== 200, 'should clean up properly')
         t.end()
       })
-      .on('error', function(err) {
+      .on('error', function() {
         t.end()
       })
   })

--- a/tests/test_recorder.js
+++ b/tests/test_recorder.js
@@ -414,12 +414,12 @@ test('records nonstandard ports', t => {
         port: testServer.address().port,
         path: '/',
       }
-      const rec_options = {
+      const recOptions = {
         dont_print: true,
         output_objects: true,
       }
 
-      nock.recorder.rec(rec_options)
+      nock.recorder.rec(recOptions)
 
       const req = http.request(options, res => {
         res.resume()

--- a/tests/test_recorder.js
+++ b/tests/test_recorder.js
@@ -1225,7 +1225,7 @@ test('records and replays binary response correctly', t => {
 test('teardown', t => {
   let leaks = Object.keys(global).splice(globalCount, Number.MAX_VALUE)
 
-  if (leaks.length == 1 && leaks[0] == '_key') {
+  if (leaks.length === 1 && leaks[0] === '_key') {
     leaks = []
   }
   t.deepEqual(leaks, [], 'No leaks')

--- a/tests/test_recorder.js
+++ b/tests/test_recorder.js
@@ -114,7 +114,7 @@ test('records objects', t => {
       output_objects: true,
     })
 
-    mikealRequest(options, (err, resp, body) => {
+    mikealRequest(options, () => {
       nock.restore()
       const ret = nock.recorder.play()
       t.equal(ret.length, 1)


### PR DESCRIPTION
Removes most of the eslint overrides that had the "TODO These are included in standard and should be cleaned up and turned on."
- no-path-concat
- no-throw-literal
- handle-callback-err
- eqeqeq
- new-cap
- camelcase

Each rule is isolated in it's own commit to ease reviewing. 

The only setting I left in place was `no-deprecated-api`. There are two places where this rule is broken and each deserve their own PR.

- `tests/test_header_matching.js` makes use of the `domain` module, which has been deprecated since Node v4.0.0, to aid in asserting errors. That whole file needs to be refactored anyway to use `got`.
- `url.parse` was deprecated in Node v11.0.0 in favor of the `url.URL` constructor. This will require some careful work to change as POJOs that resemble the output of `url.parse` get passed around a lot without a whole lot of documenting or commenting. I started down this rabbit hole and ran into a few edge cases that I think would introduce backwards breaking API changes.