### PR TITLE
POC Async Reply functions.

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -238,7 +238,7 @@ function ErroringClientRequest(error) {
 inherits(ErroringClientRequest, http.ClientRequest)
 
 function overrideClientRequest() {
-  // Here's some background discussion about overridding ClientRequest:
+  // Here's some background discussion about overriding ClientRequest:
   // - https://github.com/nodejitsu/mock-request/issues/4
   // - https://github.com/nock/nock/issues/26
   // It would be good to add a comment that explains this more clearly.

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -11,6 +11,7 @@ const debug = require('debug')('nock.request_overrider')
 const globalEmitter = require('./global_emitter')
 const zlib = require('zlib')
 const timers = require('timers')
+const util = require('util')
 
 function getHeader(request, name) {
   return request.getHeader(name.toLowerCase())
@@ -309,41 +310,29 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
     if (interceptor.replyFunction) {
       const parsedRequestBody = parseJSONRequestBody(req, requestBody)
 
-      if (interceptor.replyFunction.length === 3) {
+      let fn = interceptor.replyFunction
+      if (fn.length === 3) {
         // Handle the case of an async reply function, the third parameter being the callback.
-        interceptor.replyFunction(
-          options.path,
-          parsedRequestBody,
-          continueWithResponseBody
-        )
-        return
+        fn = util.promisify(fn)
       }
 
-      const replyResponseBody = interceptor.replyFunction(
-        options.path,
-        parsedRequestBody
-      )
-      continueWithResponseBody(null, replyResponseBody)
+      Promise.resolve(fn.call(interceptor, options.path, parsedRequestBody))
+        .then(continueWithResponseBody)
+        .catch(continueWithResponseError)
       return
     }
 
     if (interceptor.fullReplyFunction) {
       const parsedRequestBody = parseJSONRequestBody(req, requestBody)
 
-      if (interceptor.fullReplyFunction.length === 3) {
-        interceptor.fullReplyFunction(
-          options.path,
-          parsedRequestBody,
-          continueWithFullResponse
-        )
-        return
+      let fn = interceptor.fullReplyFunction
+      if (fn.length === 3) {
+        fn = util.promisify(fn)
       }
 
-      const fullReplyResult = interceptor.fullReplyFunction(
-        options.path,
-        parsedRequestBody
-      )
-      continueWithFullResponse(null, fullReplyResult)
+      Promise.resolve(fn.call(interceptor, options.path, parsedRequestBody))
+        .then(continueWithFullResponse)
+        .catch(continueWithResponseError)
       return
     }
 
@@ -369,7 +358,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
         ? interceptor.body
         : [interceptor.body]
       responseBuffers = bufferData.map(data => Buffer.from(data, 'hex'))
-      continueWithResponseBody(null, undefined)
+      continueWithResponseBody()
       return
     }
 
@@ -393,32 +382,30 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
       }
     }
 
-    return continueWithResponseBody(null, responseBody)
+    return continueWithResponseBody(responseBody)
 
-    function continueWithFullResponse(err, fullReplyResult) {
-      if (!err) {
-        try {
-          responseBody = parseFullReplyResult(response, fullReplyResult)
-        } catch (innerErr) {
-          emitError(innerErr)
-          return
-        }
+    function continueWithFullResponse(fullReplyResult) {
+      try {
+        responseBody = parseFullReplyResult(response, fullReplyResult)
+      } catch (innerErr) {
+        emitError(innerErr)
+        return
       }
 
-      continueWithResponseBody(err, responseBody)
+      continueWithResponseBody(responseBody)
     }
 
-    function continueWithResponseBody(err, responseBody) {
+    function continueWithResponseError(err) {
+      response.statusCode = 500
+      continueWithResponseBody(err.stack)
+    }
+
+    function continueWithResponseBody(responseBody) {
       if (continued) {
         // subsequent calls from reply callbacks are ignored
         return
       }
       continued = true
-
-      if (err) {
-        response.statusCode = 500
-        responseBody = err.stack
-      }
 
       //  Transform the response body if it exists (it may not exist
       //  if we have `responseBuffers` instead)

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -218,8 +218,6 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
     ended = true
     let requestBody, responseBody, responseBuffers, interceptor
 
-    let continued = false
-
     //  When request body is a binary buffer we internally use in its hexadecimal representation.
     const requestBodyBuffer = Buffer.concat(requestBodyBuffers)
     const isBinaryRequestBodyBuffer = common.isUtf8Representable(
@@ -401,15 +399,8 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
     }
 
     function continueWithResponseBody(responseBody) {
-      if (continued) {
-        // subsequent calls from reply callbacks are ignored
-        return
-      }
-      continued = true
-
       //  Transform the response body if it exists (it may not exist
       //  if we have `responseBuffers` instead)
-
       if (responseBody !== undefined) {
         debug('transform the response body')
 

--- a/tests/test_reply_function_async.js
+++ b/tests/test_reply_function_async.js
@@ -115,7 +115,7 @@ test('subsequent calls to the reply callback are ignored', async t => {
     .reply(201, (path, requestBody, callback) => {
       callback(null, 'one')
       callback(null, 'two')
-      callback(null, 'three')
+      callback(new Error('three'))
       t.pass()
     })
 


### PR DESCRIPTION
This is a POC for #1557.

Besides adding the extra functionality, I think it cleans up the massive function  `.end()` a little. It removes the need for `continueWithResponseBody` to have an error first signature.

The area where I question this logic is around error handling, but this has roots in the current code. My question is, what should happen to errors from inside user provided reply functions?

#### Current logic:
Throw an error **without** accepting a callback arg
```js
nock('http://example.com').get('/').reply((path, requestBody) => {
  throw Error('boom!')
})

http.get('http://example.com', res => {
  console.log(res)
})
```
```
Error: boom!
    at Interceptor.nock.get.reply [as fullReplyFunction] (./nock/test.js:7:9)
    at end (./nock/lib/request_overrider.js:339:43)
    at ./nock/lib/request_overrider.js:141:9
    at OverriddenClientRequest.RequestOverrider.req.write (./nock/lib/request_overrider.js:115:9)
    at OverriddenClientRequest.RequestOverrider.req.end (./nock/lib/request_overrider.js:137:11)
    at Object.module.get (./nock/lib/common.js:114:11)
```
Throw an error **with** accepting a callback arg
```js
nock('http://example.com').get('/').reply((path, requestBody, callback) => {
  throw Error('boom!')
})

http.get('http://example.com', res => {
  console.log(res)
})
```
```
Error: boom!
    <same stack trace as above>
```
Passing an error to the callback
```js
nock('http://example.com').get('/').reply((path, requestBody, callback) => {
  callback(Error('boom!'))
})

http.get('http://example.com', res => {
  console.log(res)
})
```
```
IncomingMessage<statusCode: 500>
data event -> buffer -> toString: 
Error: boom!
    <same stack trace as above>
```

#### With proposed logic
- Throw an error **without** accepting a callback arg: stays the same
- Throw an error **with** accepting a callback arg: Returns a 500 instead of bubbling up.
- Passing an error to the callback: stays the same

New use case: throw an error inside an **async** function (or return a rejecting promise)
```js
nock('http://example.com').get('/').reply(async (path, requestBody) => {
  throw Error('boom!')
})

http.get('http://example.com', res => {
  console.log(res)
})
```
```
IncomingMessage<statusCode: 500>
data event -> buffer -> toString: 
Error: boom!
    <same stack trace as above>
```

So it's kinda the same 🤷‍♂. I wish all these scenarios did one or the other.
In general, I question why we sometimes want errors to result in valid responses with 500 status codes, instead of letting the user defined function catch errors and return the 500 manually. But that might be out of scope for this topic and I'm overthinking it. 