### PR TITLE
refactor: special asterisk bodies in definitions.

### DIFF
--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -311,7 +311,7 @@ function record(recOptions) {
         //  Check that the request was made during the current recording.
         //  If it hasn't then skip it. There is no other simple way to handle
         //  this as it depends on the timing of requests and responses. Throwing
-        //  will make some recordings/unit tests faily randomly depending on how
+        //  will make some recordings/unit tests fail randomly depending on how
         //  fast/slow the response arrived.
         //  If you are seeing this error then you need to make sure that all
         //  the requests made during a single recording session finish before

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -326,7 +326,6 @@ function define(nockDefs) {
     const rawHeaders = nockDef.rawHeaders || []
     const reqheaders = nockDef.reqheaders || {}
     const badheaders = nockDef.badheaders || []
-    const body = nockDef.body || ''
     const options = { ...nockDef.options }
 
     //  We use request headers for both filtering (see below) and mocking.
@@ -334,6 +333,17 @@ function define(nockDefs) {
     //  be changing the user's options object so we clone it first.
     options.reqheaders = reqheaders
     options.badheaders = badheaders
+
+    let { body } = nockDef
+
+    if (body === '*') {
+      // In previous versions, it was impossible to NOT filter on request bodies. This special value
+      // is sniffed out for users manipulating the definitions and not wanting to match on the
+      // request body. For newer versions, users should remove the `body` key or set to `undefined`
+      // to achieve the same affect. Maintaining legacy behavior for now.
+      // Log a deprecation warning?
+      body = undefined
+    }
 
     //  Response is not always JSON as it could be a string or binary data or
     //  even an array of binary buffers (e.g. when content is encoded)
@@ -348,34 +358,21 @@ function define(nockDefs) {
         : nockDef.response
     }
 
-    let nock
-    // TODO-coverage: Find out what `body === '*'` means. Add a comment here
-    // explaining it, and a test case if necessary. Also, update the readme
-    // example of `filteringRequestBody()` because it doesn't explain what the
-    // `*` really means.
-    if (body === '*') {
-      nock = startScope(nscope, options)
-        .filteringRequestBody(function() {
-          return '*'
-        })
-        [method](npath, '*')
-        .reply(status, response, rawHeaders)
-    } else {
-      nock = startScope(nscope, options)
-      //  If request headers were specified filter by them.
-      if (_.size(reqheaders) > 0) {
-        for (const k in reqheaders) {
-          nock.matchHeader(k, reqheaders[k])
-        }
+    const nock = startScope(nscope, options)
+
+    // If request headers were specified filter by them.
+    Object.entries(reqheaders).forEach(([fieldName, value]) => {
+      nock.matchHeader(fieldName, value)
+    })
+
+    const acceptableFilters = ['filteringRequestBody', 'filteringPath']
+    acceptableFilters.forEach(filter => {
+      if (nockDef[filter]) {
+        nock[filter](nockDef[filter])
       }
-      const acceptableFilters = ['filteringRequestBody', 'filteringPath']
-      acceptableFilters.forEach(filter => {
-        if (nockDef[filter]) {
-          nock[filter](nockDef[filter])
-        }
-      })
-      nock.intercept(npath, method, body).reply(status, response, rawHeaders)
-    }
+    })
+
+    nock.intercept(npath, method, body).reply(status, response, rawHeaders)
 
     nocks.push(nock)
   })

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -312,6 +312,13 @@ function tryJsonParse(string) {
   }
 }
 
+// Use a noop deprecate util instead calling emitWarning directly so we get --no-deprecation and single warning behavior for free.
+const emitAsteriskDeprecation = util.deprecate(
+  () => {},
+  'Skipping body matching using "*" is deprecated. Set the definition body to undefined instead.',
+  'NOCK1579'
+)
+
 function define(nockDefs) {
   const nocks = []
 
@@ -341,7 +348,7 @@ function define(nockDefs) {
       // is sniffed out for users manipulating the definitions and not wanting to match on the
       // request body. For newer versions, users should remove the `body` key or set to `undefined`
       // to achieve the same affect. Maintaining legacy behavior for now.
-      // Log a deprecation warning?
+      emitAsteriskDeprecation()
       body = undefined
     }
 

--- a/tests/test_define.js
+++ b/tests/test_define.js
@@ -306,6 +306,8 @@ test('define() uses badheaders', t => {
 })
 
 test('define() treats a * body as a special case for not matching the request body', async t => {
+  t.plan(4)
+
   nock.define([
     {
       scope: 'http://example.test',
@@ -315,6 +317,11 @@ test('define() treats a * body as a special case for not matching the request bo
       response: 'matched',
     },
   ])
+
+  process.once('warning', warning => {
+    t.equal(warning.name, 'DeprecationWarning')
+    t.match(warning.message, 'Skipping body matching using')
+  })
 
   const { statusCode, body } = await got.post('http://example.test/', {
     body: 'foo bar',

--- a/tests/test_define.js
+++ b/tests/test_define.js
@@ -158,7 +158,7 @@ test('define() works with non-JSON responses', async t => {
   })
 
   t.equal(statusCode, 200)
-  // TODO: beacuse `{ encoding: false }` is passed to `got`, `body` should be
+  // TODO: because `{ encoding: false }` is passed to `got`, `body` should be
   // a buffer, but it's a string. Is this a bug in nock or got?
   t.equal(body, exampleResponseBody)
 })
@@ -303,4 +303,23 @@ test('define() uses badheaders', t => {
     }
   )
   req.end()
+})
+
+test('define() treats a * body as a special case for not matching the request body', async t => {
+  nock.define([
+    {
+      scope: 'http://example.test',
+      method: 'POST',
+      path: '/',
+      body: '*',
+      response: 'matched',
+    },
+  ])
+
+  const { statusCode, body } = await got.post('http://example.test/', {
+    body: 'foo bar',
+  })
+
+  t.equal(statusCode, 200)
+  t.equal(body, 'matched')
 })


### PR DESCRIPTION
Clarify and add test definitions bodies that are simply "*".

The investigation for this TODO also led to the creation of #1578, which has a description on the history of `*`.

---
Before v2.0, it was not possible to **not** filter on request bodies.

For [users wanting](https://github.com/nock/nock/issues/39) to match regardless of the request body, a [convention](https://github.com/nock/nock/commit/460aac919149fb190e910117c10c82f9d0e4c68e)
became the norm of using `filteringRequestBody` to modify the body into
a special string (`*`) then match against that specific string in the
Interceptor.

In more recent versions, the preferred way to not match request bodies
is to not provide a body argument when creating an Interceptor. This
updates the docs to reflect that.