### PR TITLE
bug: alias connection to socket.

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -89,10 +89,6 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
     )
   }
 
-  if (!req.connection) {
-    req.connection = new EventEmitter()
-  }
-
   req.path = options.path
   req.method = options.method
 
@@ -100,7 +96,9 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
     return getHeader(req, name)
   }
 
-  req.socket = response.socket = Socket({ proto: options.proto })
+  req.socket = req.connection = response.socket = response.connection = Socket({
+    proto: options.proto,
+  })
 
   req.write = function(buffer, encoding, callback) {
     debug('write', arguments)

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -96,6 +96,9 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
     return getHeader(req, name)
   }
 
+  // ClientRequest.connection is an alias for ClientRequest.socket
+  // IncomingMessage.connection is an alias for IncomingMessage.socket
+  // The same Socket is shared between the request and response to mimic native behavior.
   req.socket = req.connection = response.socket = response.connection = Socket({
     proto: options.proto,
   })

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -97,7 +97,10 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
   }
 
   // ClientRequest.connection is an alias for ClientRequest.socket
+  // https://nodejs.org/api/http.html#http_request_socket
+  // https://github.com/nodejs/node/blob/b0f75818f39ed4e6bd80eb7c4010c1daf5823ef7/lib/_http_client.js#L640-L641
   // IncomingMessage.connection is an alias for IncomingMessage.socket
+  // https://github.com/nodejs/node/blob/b0f75818f39ed4e6bd80eb7c4010c1daf5823ef7/lib/_http_incoming.js#L44-L45
   // The same Socket is shared between the request and response to mimic native behavior.
   req.socket = req.connection = response.socket = response.connection = Socket({
     proto: options.proto,

--- a/tests/test_request_overrider.js
+++ b/tests/test_request_overrider.js
@@ -329,6 +329,21 @@ test('request emits socket', t => {
   })
 })
 
+test('socket is shared and aliased correctly', t => {
+  nock('http://example.test')
+    .get('/')
+    .reply()
+
+  const req = http.get('http://example.test')
+
+  req.once('response', res => {
+    t.is(req.socket, req.connection)
+    t.is(req.socket, res.socket)
+    t.is(res.socket, res.connection)
+    t.end()
+  })
+})
+
 test('socket emits connect and secureConnect', t => {
   t.plan(3)
 


### PR DESCRIPTION
`ClientRequest.connection` is an alias for `ClientRequest.socket`.
https://nodejs.org/api/http.html#http_request_socket
https://github.com/nodejs/node/blob/master/lib/_http_client.js#L640-L641

`IncomingMessage.connection` is an alias for `IncomingMessage.socket`.
https://github.com/nodejs/node/blob/master/lib/_http_incoming.js#L44-L45

Adding `req.connection` and `res.connection` as a basic `EventEmitter` was to fix #74 when the `request` lib use to inspect the alias. [This is not the case anymore](https://github.com/request/request/search?q=connection+extension%3Ajs+-path%3Atests).
`res.connection` was [removed](b8c1bde2be58ee2378f8536a6732cb5e2ea98b33) a few years later to improve coverage.