### PR TITLE
fix: request.end accepted arguments

### DIFF
--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -392,8 +392,8 @@ function record(recOptions) {
       }
     }
 
-    // Starting in Node 8, `res.end()` does not call `res.write()` directly.
-    // TODO: This is `req.end()`; is that a typo? ^^
+    // Starting in Node 8, `OutgoingMessage.end()` directly calls an internal `write_` function instead
+    // of proxying to the public `OutgoingMessage.write()` method, so we have to wrap `end` too.
     const oldEnd = req.end
     req.end = function(data, encoding, callback) {
       // TODO Shuffle the arguments for parity with the real `req.end()`.

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -378,14 +378,18 @@ function record(recOptions) {
       }
     })
 
+    const recordChunk = (chunk, encoding) => {
+      debug(thisRecordingId, 'new', proto, 'body chunk')
+      if (!Buffer.isBuffer(chunk)) {
+        chunk = Buffer.from(chunk, encoding)
+      }
+      bodyChunks.push(chunk)
+    }
+
     const oldWrite = req.write
-    req.write = function(data, encoding) {
-      if (typeof data !== 'undefined') {
-        debug(thisRecordingId, 'new', proto, 'body chunk')
-        if (!Buffer.isBuffer(data)) {
-          data = Buffer.from(data, encoding)
-        }
-        bodyChunks.push(data)
+    req.write = function(chunk, encoding) {
+      if (typeof chunk !== 'undefined') {
+        recordChunk(chunk, encoding)
         oldWrite.apply(req, arguments)
       } else {
         throw new Error('Data was undefined.')
@@ -395,22 +399,20 @@ function record(recOptions) {
     // Starting in Node 8, `OutgoingMessage.end()` directly calls an internal `write_` function instead
     // of proxying to the public `OutgoingMessage.write()` method, so we have to wrap `end` too.
     const oldEnd = req.end
-    req.end = function(data, encoding, callback) {
-      // TODO Shuffle the arguments for parity with the real `req.end()`.
-      // https://github.com/nock/nock/issues/1549
-      if (_.isFunction(data) && arguments.length === 1) {
-        callback = data
-        data = null
+    req.end = function(chunk, encoding, callback) {
+      debug('req.end')
+      if (typeof chunk === 'function') {
+        callback = chunk
+        chunk = null
+      } else if (typeof encoding === 'function') {
+        callback = encoding
+        encoding = null
       }
-      if (data) {
-        debug(thisRecordingId, 'new', proto, 'body chunk')
-        if (!Buffer.isBuffer(data)) {
-          // TODO-coverage: Add a test.
-          data = Buffer.from(data, encoding)
-        }
-        bodyChunks.push(data)
+
+      if (chunk) {
+        recordChunk(chunk, encoding)
       }
-      oldEnd.apply(req, arguments)
+      oldEnd.call(req, chunk, encoding, callback)
     }
 
     return req

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -129,16 +129,18 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
     return false
   }
 
-  req.end = function(data, encoding, callback) {
+  req.end = function(chunk, encoding, callback) {
     debug('req.end')
-    // TODO Shuffle the arguments for parity with the real `req.end()`.
-    // https://github.com/nock/nock/issues/1549
-    if (_.isFunction(data) && arguments.length === 1) {
-      callback = data
-      data = null
+    if (typeof chunk === 'function') {
+      callback = chunk
+      chunk = null
+    } else if (typeof encoding === 'function') {
+      callback = encoding
+      encoding = null
     }
+
     if (!req.aborted && !ended) {
-      req.write(data, encoding, function() {
+      req.write(chunk, encoding, () => {
         if (typeof callback === 'function') {
           callback()
         }

--- a/tests/test_request_overrider.js
+++ b/tests/test_request_overrider.js
@@ -135,6 +135,85 @@ test('end callback called when end has callback, but no buffer', t => {
   })
 })
 
+test('request.end called with all three arguments', t => {
+  const scope = nock('http://example.test')
+    .post('/', 'foobar')
+    .reply()
+
+  let callbackCalled = false
+  const req = http.request(
+    {
+      host: 'example.test',
+      method: 'POST',
+      path: '/',
+    },
+    res => {
+      t.true(callbackCalled)
+      res.on('end', () => {
+        scope.done()
+        t.end()
+      })
+      res.resume()
+    }
+  )
+
+  // hex(foobar) == 666F6F626172
+  req.end('666F6F626172', 'hex', () => {
+    callbackCalled = true
+  })
+})
+
+test('request.end called with only data and encoding', t => {
+  const scope = nock('http://example.test')
+    .post('/', 'foobar')
+    .reply()
+
+  const req = http.request(
+    {
+      host: 'example.test',
+      method: 'POST',
+      path: '/',
+    },
+    res => {
+      res.on('end', () => {
+        scope.done()
+        t.end()
+      })
+      res.resume()
+    }
+  )
+
+  // hex(foobar) == 666F6F626172
+  req.end('666F6F626172', 'hex')
+})
+
+test('request.end called with only data and a callback', t => {
+  const scope = nock('http://example.test')
+    .post('/', 'foobar')
+    .reply()
+
+  let callbackCalled = false
+  const req = http.request(
+    {
+      host: 'example.test',
+      method: 'POST',
+      path: '/',
+    },
+    res => {
+      t.true(callbackCalled)
+      res.on('end', () => {
+        scope.done()
+        t.end()
+      })
+      res.resume()
+    }
+  )
+
+  req.end('foobar', () => {
+    callbackCalled = true
+  })
+})
+
 // http://github.com/nock/nock/issues/139
 test('finish event fired before end event', t => {
   const scope = nock('http://example.test')


### PR DESCRIPTION
Fixes #1549

The method now correctly accepts all the permutations allowed.
```js
request.end(data, encoding, callback)
request.end(data, callback)
request.end(data, encoding)
request.end(data)
request.end(callback)
request.end()
```
And a few tests were added to ensure all cases are explicitly covered.