### PR TITLE
Async Reply functions (always emit errors)

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,9 @@ const scope = nock('http://www.google.com')
   })
 ```
 
+In Nock 11 and later, if an error is passed to the callback, Nock will rethrow it as a programmer error.
+In Nock 10 and earlier, the error was sent in the response body, with a 500 HTTP response status code.
+
 You can also return the status code and body using just one function:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -396,8 +396,6 @@ const scope = nock('http://www.google.com')
   })
 ```
 
-> Note: When using a callback, if you call back with an error as the first argument, that error will be sent in the response body, with a 500 HTTP response status code.
-
 You can also return the status code and body using just one function:
 
 ```js

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -314,7 +314,7 @@ function RequestOverrider(req, options, interceptors, remove) {
 
       Promise.resolve(fn.call(interceptor, options.path, parsedRequestBody))
         .then(continueWithResponseBody)
-        .catch(continueWithResponseError)
+        .catch(emitError)
       return
     }
 
@@ -328,7 +328,7 @@ function RequestOverrider(req, options, interceptors, remove) {
 
       Promise.resolve(fn.call(interceptor, options.path, parsedRequestBody))
         .then(continueWithFullResponse)
-        .catch(continueWithResponseError)
+        .catch(emitError)
       return
     }
 
@@ -389,11 +389,6 @@ function RequestOverrider(req, options, interceptors, remove) {
       }
 
       continueWithResponseBody(responseBody)
-    }
-
-    function continueWithResponseError(err) {
-      response.statusCode = 500
-      continueWithResponseBody(err.stack)
     }
 
     function continueWithResponseBody(responseBody) {

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -216,8 +216,6 @@ function RequestOverrider(req, options, interceptors, remove) {
     ended = true
     let requestBody, responseBody, responseBuffers, interceptor
 
-    let continued = false
-
     //  When request body is a binary buffer we internally use in its hexadecimal representation.
     const requestBodyBuffer = Buffer.concat(requestBodyBuffers)
     const isBinaryRequestBodyBuffer = common.isUtf8Representable(
@@ -399,15 +397,8 @@ function RequestOverrider(req, options, interceptors, remove) {
     }
 
     function continueWithResponseBody(responseBody) {
-      if (continued) {
-        // subsequent calls from reply callbacks are ignored
-        return
-      }
-      continued = true
-
       //  Transform the response body if it exists (it may not exist
       //  if we have `responseBuffers` instead)
-
       if (responseBody !== undefined) {
         debug('transform the response body')
 

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -6,6 +6,7 @@ const { IncomingMessage, ClientRequest } = require('http')
 const _ = require('lodash')
 const propagate = require('propagate')
 const timers = require('timers')
+const util = require('util')
 const zlib = require('zlib')
 
 const common = require('./common')
@@ -307,41 +308,29 @@ function RequestOverrider(req, options, interceptors, remove) {
     if (interceptor.replyFunction) {
       const parsedRequestBody = parseJSONRequestBody(req, requestBody)
 
-      if (interceptor.replyFunction.length === 3) {
+      let fn = interceptor.replyFunction
+      if (fn.length === 3) {
         // Handle the case of an async reply function, the third parameter being the callback.
-        interceptor.replyFunction(
-          options.path,
-          parsedRequestBody,
-          continueWithResponseBody
-        )
-        return
+        fn = util.promisify(fn)
       }
 
-      const replyResponseBody = interceptor.replyFunction(
-        options.path,
-        parsedRequestBody
-      )
-      continueWithResponseBody(null, replyResponseBody)
+      Promise.resolve(fn.call(interceptor, options.path, parsedRequestBody))
+        .then(continueWithResponseBody)
+        .catch(continueWithResponseError)
       return
     }
 
     if (interceptor.fullReplyFunction) {
       const parsedRequestBody = parseJSONRequestBody(req, requestBody)
 
-      if (interceptor.fullReplyFunction.length === 3) {
-        interceptor.fullReplyFunction(
-          options.path,
-          parsedRequestBody,
-          continueWithFullResponse
-        )
-        return
+      let fn = interceptor.fullReplyFunction
+      if (fn.length === 3) {
+        fn = util.promisify(fn)
       }
 
-      const fullReplyResult = interceptor.fullReplyFunction(
-        options.path,
-        parsedRequestBody
-      )
-      continueWithFullResponse(null, fullReplyResult)
+      Promise.resolve(fn.call(interceptor, options.path, parsedRequestBody))
+        .then(continueWithFullResponse)
+        .catch(continueWithResponseError)
       return
     }
 
@@ -367,7 +356,7 @@ function RequestOverrider(req, options, interceptors, remove) {
         ? interceptor.body
         : [interceptor.body]
       responseBuffers = bufferData.map(data => Buffer.from(data, 'hex'))
-      continueWithResponseBody(null, undefined)
+      continueWithResponseBody()
       return
     }
 
@@ -391,32 +380,30 @@ function RequestOverrider(req, options, interceptors, remove) {
       }
     }
 
-    return continueWithResponseBody(null, responseBody)
+    return continueWithResponseBody(responseBody)
 
-    function continueWithFullResponse(err, fullReplyResult) {
-      if (!err) {
-        try {
-          responseBody = parseFullReplyResult(response, fullReplyResult)
-        } catch (innerErr) {
-          emitError(innerErr)
-          return
-        }
+    function continueWithFullResponse(fullReplyResult) {
+      try {
+        responseBody = parseFullReplyResult(response, fullReplyResult)
+      } catch (innerErr) {
+        emitError(innerErr)
+        return
       }
 
-      continueWithResponseBody(err, responseBody)
+      continueWithResponseBody(responseBody)
     }
 
-    function continueWithResponseBody(err, responseBody) {
+    function continueWithResponseError(err) {
+      response.statusCode = 500
+      continueWithResponseBody(err.stack)
+    }
+
+    function continueWithResponseBody(responseBody) {
       if (continued) {
         // subsequent calls from reply callbacks are ignored
         return
       }
       continued = true
-
-      if (err) {
-        response.statusCode = 500
-        responseBody = err.stack
-      }
 
       //  Transform the response body if it exists (it may not exist
       //  if we have `responseBuffers` instead)

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -312,6 +312,8 @@ function RequestOverrider(req, options, interceptors, remove) {
         fn = util.promisify(fn)
       }
 
+      // At this point `fn` is either a synchronous function or a promise-returning function;
+      // wrapping in `Promise.resolve` makes it into a promise either way.
       Promise.resolve(fn.call(interceptor, options.path, parsedRequestBody))
         .then(continueWithResponseBody)
         .catch(emitError)

--- a/tests/test_reply_function_async.js
+++ b/tests/test_reply_function_async.js
@@ -56,7 +56,7 @@ test('reply should throw on error on the callback', async t => {
       callback(new Error('Database failed'))
     )
 
-  t.rejects(got('http://example.test'), {
+  await t.rejects(got('http://example.test'), {
     name: 'RequestError',
     message: 'Database failed',
   })
@@ -69,7 +69,7 @@ test('an error passed to the callback propagates when [err, fullResponseArray] i
       callback(Error('boom'))
     })
 
-  t.rejects(got('http://example.test'), {
+  await t.rejects(got('http://example.test'), {
     name: 'RequestError',
     message: 'boom',
   })
@@ -94,7 +94,7 @@ test('subsequent calls to the reply callback are ignored', async t => {
   t.equal(body, 'one')
 })
 
-test('reply can take a direct async function without a callback', async t => {
+test('reply can take a status code with an 2-arg async function, and passes it the correct arguments', async t => {
   const scope = nock('http://example.com')
     .get('/')
     .reply(200, async (path, requestBody) => {
@@ -109,7 +109,7 @@ test('reply can take a direct async function without a callback', async t => {
   scope.done()
 })
 
-test('reply can take a dynamic async function without a callback', async t => {
+test('reply can take a status code with a 0-arg async function, and passes it the correct arguments', async t => {
   const scope = nock('http://example.com')
     .get('/')
     .reply(async () => [201, 'Hello World!'])
@@ -121,20 +121,20 @@ test('reply can take a dynamic async function without a callback', async t => {
   scope.done()
 })
 
-test('reply with a direct async function that rejects', async t => {
+test('when reply is called with a status code and an async function that throws, it propagates the error', async t => {
   nock('http://example.test')
     .get('/')
     .reply(201, async () => {
       throw Error('oh no!')
     })
 
-  t.rejects(got('http://example.test'), {
+  await t.rejects(got('http://example.test'), {
     name: 'RequestError',
     message: 'oh no!',
   })
 })
 
-test('reply with a dynamic async function that rejects', async t => {
+test('when reply is called with an async function that throws, it propagates the error', async t => {
   nock('http://example.test')
     .get('/')
     .reply(async () => {

--- a/tests/test_reply_function_async.js
+++ b/tests/test_reply_function_async.js
@@ -115,7 +115,7 @@ test('subsequent calls to the reply callback are ignored', async t => {
     .reply(201, (path, requestBody, callback) => {
       callback(null, 'one')
       callback(null, 'two')
-      callback(null, 'three')
+      callback(new Error('three'))
       t.pass()
     })
 

--- a/tests/test_reply_function_async.js
+++ b/tests/test_reply_function_async.js
@@ -96,16 +96,19 @@ test('subsequent calls to the reply callback are ignored', async t => {
 
 test('reply can take a status code with an 2-arg async function, and passes it the correct arguments', async t => {
   const scope = nock('http://example.com')
-    .get('/')
-    .reply(200, async (path, requestBody) => {
-      t.equal(path, '/')
-      t.equal(requestBody, '')
-      return 'Hello World!'
+    .post('/foo')
+    .reply(201, async (path, requestBody) => {
+      t.equal(path, '/foo')
+      t.equal(requestBody, 'request-body')
+      return 'response-body'
     })
 
-  const response = await got('http://example.com/')
+  const response = await got.post('http://example.com/foo', {
+    body: 'request-body',
+  })
 
-  t.equal(response.body, 'Hello World!')
+  t.equal(response.statusCode, 201)
+  t.equal(response.body, 'response-body')
   scope.done()
 })
 
@@ -141,7 +144,7 @@ test('when reply is called with an async function that throws, it propagates the
       throw Error('oh no!')
     })
 
-  t.rejects(got('http://example.test'), {
+  await t.rejects(got('http://example.test'), {
     name: 'RequestError',
     message: 'oh no!',
   })


### PR DESCRIPTION
This is a POC for #1557 and is offered as an Option B to #1572. 

The difference between this change and #1572 is that this takes a hard line on how to handle errors in reply functions. It always emits an error (105fda4b7948a008626d189350b2e7c84c9c1869). 

I personally believe this is the right design long term but it does introduce a breaking change.

Using the example from the docs:
```js
const scope = nock('http://www.google.com')
  .post('/echo')
  .reply(201, (uri, requestBody, cb) => {
    fs.readFile('cat-poems.txt', cb) // Error-first callback
  })
```
Currently, if `readFile` errs, the request will succeed with a response that has a 500 status code.
To achieve the same affect, the code would have to be rewritten by the consumer to:
```js
const scope = nock('http://www.google.com')
  .post('/echo')
  .reply((uri, requestBody, cb) => {
    fs.readFile('cat-poems.txt', (err, contents) => {
      if (err) cb([500, err.stack])
      else cb([201, contents])
    })
  })
```
However, I would argue that this is not the standard use case nor the most intuitive handling of a test.