### PR TITLE
fix: response.complete must be true after res.end

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -448,6 +448,8 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
           })
           responseBody.on('end', function() {
             response.push(null)
+            // https://nodejs.org/dist/latest-v10.x/docs/api/http.html#http_message_complete
+            response.complete = true
           })
           responseBody.on('error', function(err) {
             response.emit('error', err)
@@ -556,6 +558,8 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
               } else {
                 debug('ending response stream')
                 response.push(null)
+                // https://nodejs.org/dist/latest-v10.x/docs/api/http.html#http_message_complete
+                response.complete = true
                 interceptor.scope.emit('replied', req, interceptor)
               }
             })

--- a/tests/test_request_overrider.js
+++ b/tests/test_request_overrider.js
@@ -429,3 +429,30 @@ test("mocked requests have 'method' property", t => {
   })
   req.end()
 })
+
+// https://github.com/nock/nock/issues/1493
+test("response have 'complete' property and it's true after end", t => {
+  const scope = nock('http://example.test')
+    .get('/')
+    .reply(200, 'Hello World!')
+
+  const req = http.request(
+    {
+      host: 'example.test',
+      method: 'GET',
+      path: '/',
+      port: 80,
+    },
+    res => {
+      res.on('end', () => {
+        t.is(res.complete, true)
+        scope.done()
+        t.end()
+      })
+      // Streams start in 'paused' mode and must be started.
+      // See https://nodejs.org/api/stream.html#stream_class_stream_readable
+      res.resume()
+    }
+  )
+  req.end()
+})


### PR DESCRIPTION
Fixes https://github.com/nock/nock/issues/1493

https://nodejs.org/dist/latest-v10.x/docs/api/http.html#http_message_complete