### PR TITLE
Add coverage ignores to recorder, and emit text report

### DIFF
--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -1,5 +1,9 @@
 'use strict'
 
+// This file contains some coverage ignores marked TODO-coverage. Before
+// refactoring within this file, these lines should be cleaned up.
+// https://github.com/nock/nock/issues/1607
+
 const { inspect } = require('util')
 const { parse: urlParse } = require('url')
 const common = require('./common')
@@ -25,6 +29,8 @@ function getScope(options) {
 
   scope.push(options.host)
 
+  // TODO-coverage Some part of this conditional is not reached.
+  /* istanbul ignore if */
   if (
     options.host.indexOf(':') === -1 &&
     options.port &&
@@ -153,6 +159,7 @@ function generateRequestAndResponse(req, bodyChunks, options, res, dataChunks) {
   }
   ret.push(')\n')
   // TODO-coverage: Try to add coverage of this case.
+  /* istanbul ignore if */
   if (req.headers) {
     for (const k in req.headers) {
       ret.push(
@@ -173,6 +180,7 @@ function generateRequestAndResponse(req, bodyChunks, options, res, dataChunks) {
   ret.push(res.statusCode.toString())
   ret.push(', ')
   ret.push(JSON.stringify(responseBody))
+  /* istanbul ignore else */
   if (res.rawHeaders) {
     ret.push(', ')
     ret.push(inspect(res.rawHeaders))
@@ -257,6 +265,7 @@ function record(recOptions) {
 
     // Node 0.11 https.request calls http.request -- don't want to record things
     // twice.
+    /* istanbul ignore if */
     if (options._recording) {
       return overriddenRequest(options, callback)
     }
@@ -284,6 +293,7 @@ function record(recOptions) {
             res,
             dataChunks
           )
+          /* istanbul ignore else */
           // TODO-coverage: The `else` case is missing coverage. Maybe look
           // into the enable_reqheaders_recording option.
           if (out.reqheaders) {
@@ -325,6 +335,7 @@ function record(recOptions) {
 
         if (!dontPrint) {
           if (useSeparator) {
+            /* istanbul ignore if */
             if (typeof out !== 'string') {
               // TODO-coverage: This is missing coverage. Could this be
               // connected to the `output_object` option?

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "tap": "^14.0.0"
   },
   "scripts": {
-    "unit": "tap --coverage ./tests/test_*.js",
+    "unit": "tap --coverage --coverage-report=text ./tests/test_*.js",
     "pretest": "npm run -s lint",
     "test": "npm run -s unit",
     "posttest": "npm run -s prettier:check",


### PR DESCRIPTION
Ref https://github.com/nock/nock/issues/1404#issuecomment-509347456

This leaves intact two missed coverage spots in `lib/recorder.js` which are being taken care of in #1588.

Also ref #1607