### PR TITLE
added noop method `unref` to Socket

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -26,6 +26,7 @@ function Socket(options) {
   this.setNoDelay = noop
   this.setKeepAlive = noop
   this.resume = noop
+  this.unref = noop
 
   // totalDelay that has already been applied to the current
   // request/connection, timeout error will be generated if


### PR DESCRIPTION
it has been implemented in node.js 0.9.1 but it's seldomly used.

ref: https://nodejs.org/api/net.html#net_socket_unref


I came across this while mocking tests for a project using [apm-nodejs-http-client](https://github.com/elastic/apm-nodejs-http-client) [^](https://github.com/elastic/apm-nodejs-http-client/blob/fe9945ef8f96885802e029835cf3181ca2dd11b5/test/lib/utils.js#L33)