### PR TITLE
refactor: add utility to identify non-standard ports

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -131,19 +131,17 @@ const restoreOverriddenRequests = function() {
 }
 
 /**
- * Determines if the port should be included along with the host because it's nonstandard.
- *
- * Returns false if a host is provided and already has a port.
+ * In WHATWG URL vernacular, this returns the origin portion of a URL.
+ * However, the port is not included if it's standard and not already present on the host.
  */
-const addNonStandardPort = (proto, port, host) => {
-  if (host && host.includes(':')) {
-    return false
-  }
+const normalizeOrigin = (proto, host, port) => {
+  const hostHasPort = host.includes(':')
+  const portIsStandard =
+    (proto === 'http' && (port === 80 || port === '80')) ||
+    (proto === 'https' && (port === 443 || port === '443'))
+  const portStr = hostHasPort || portIsStandard ? '' : `:${port}`
 
-  return (
-    (proto === 'http' && port !== 80 && port !== '80') ||
-    (proto === 'https' && port !== 443 && port !== '443')
-  )
+  return `${proto}://${host}${portStr}`
 }
 
 /**
@@ -160,11 +158,11 @@ const addNonStandardPort = (proto, port, host) => {
  */
 function stringifyRequest(options, body) {
   const { method = 'GET', path = '', port } = options
-  const portStr = addNonStandardPort(options.proto, port) ? `:${port}` : ''
+  const origin = normalizeOrigin(options.proto, options.hostname, port)
 
   const log = {
     method,
-    url: `${options.proto}://${options.hostname}${portStr}${path}`,
+    url: `${origin}${path}`,
     headers: options.headers,
   }
 
@@ -552,7 +550,7 @@ function urlToOptions(url) {
 
 exports.normalizeClientRequestArgs = normalizeClientRequestArgs
 exports.normalizeRequestOptions = normalizeRequestOptions
-exports.addNonStandardPort = addNonStandardPort
+exports.normalizeOrigin = normalizeOrigin
 exports.isUtf8Representable = isUtf8Representable
 exports.overrideRequests = overrideRequests
 exports.restoreOverriddenRequests = restoreOverriddenRequests

--- a/lib/common.js
+++ b/lib/common.js
@@ -131,6 +131,22 @@ const restoreOverriddenRequests = function() {
 }
 
 /**
+ * Determines if the port should be included along with the host because it's nonstandard.
+ *
+ * Returns false if a host is provided and already has a port.
+ */
+const addNonStandardPort = (proto, port, host) => {
+  if (host && host.includes(':')) {
+    return false
+  }
+
+  return (
+    (proto === 'http' && port !== 80 && port !== '80') ||
+    (proto === 'https' && port !== 443 && port !== '443')
+  )
+}
+
+/**
  * Get high level information about request as string
  * @param  {Object} options
  * @param  {string} options.method
@@ -143,21 +159,12 @@ const restoreOverriddenRequests = function() {
  * @return {string}
  */
 function stringifyRequest(options, body) {
-  const { method = 'GET', path = '' } = options
-  let { port } = options
-
-  if (
-    (options.proto === 'https' && (port === 443 || port === '443')) ||
-    (options.proto === 'http' && (port === 80 || port === '80'))
-  ) {
-    port = ''
-  } else {
-    port = `:${port}`
-  }
+  const { method = 'GET', path = '', port } = options
+  const portStr = addNonStandardPort(options.proto, port) ? `:${port}` : ''
 
   const log = {
     method,
-    url: `${options.proto}://${options.hostname}${port}${path}`,
+    url: `${options.proto}://${options.hostname}${portStr}${path}`,
     headers: options.headers,
   }
 
@@ -545,6 +552,7 @@ function urlToOptions(url) {
 
 exports.normalizeClientRequestArgs = normalizeClientRequestArgs
 exports.normalizeRequestOptions = normalizeRequestOptions
+exports.addNonStandardPort = addNonStandardPort
 exports.isUtf8Representable = isUtf8Representable
 exports.overrideRequests = overrideRequests
 exports.restoreOverriddenRequests = restoreOverriddenRequests

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -282,10 +282,7 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
   if (this.__nock_filteredScope) {
     matchKey = this.__nock_filteredScope
   } else {
-    matchKey = `${proto}://${options.host}`
-    if (common.addNonStandardPort(options.proto, options.port, options.host)) {
-      matchKey += `:${options.port}`
-    }
+    matchKey = common.normalizeOrigin(proto, options.host, options.port)
   }
 
   // Match query strings when using query()

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -283,12 +283,7 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
     matchKey = this.__nock_filteredScope
   } else {
     matchKey = `${proto}://${options.host}`
-    if (
-      options.port &&
-      options.host.indexOf(':') < 0 &&
-      (options.port !== 80 || options.proto !== 'http') &&
-      (options.port !== 443 || options.proto !== 'https')
-    ) {
+    if (common.addNonStandardPort(options.proto, options.port, options.host)) {
       matchKey += `:${options.port}`
     }
   }

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -28,16 +28,8 @@ function getScope(options) {
 
   scope.push(options.host)
 
-  // TODO-coverage Some part of this conditional is not reached.
-  /* istanbul ignore if */
-  if (
-    options.host.indexOf(':') === -1 &&
-    options.port &&
-    ((options.proto && options.port.toString() !== '443') ||
-      (!options.proto && options.port.toString() !== '80'))
-  ) {
-    scope.push(':')
-    scope.push(options.port)
+  if (common.addNonStandardPort(options.proto, options.port, options.host)) {
+    scope.push(':', options.port)
   }
 
   return scope.join('')

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -17,22 +17,8 @@ let recordingInProgress = false
 let outputs = []
 
 function getScope(options) {
-  common.normalizeRequestOptions(options)
-
-  const scope = []
-  if (options.proto === 'https') {
-    scope.push('https://')
-  } else {
-    scope.push('http://')
-  }
-
-  scope.push(options.host)
-
-  if (common.addNonStandardPort(options.proto, options.port, options.host)) {
-    scope.push(':', options.port)
-  }
-
-  return scope.join('')
+  const { proto, host, port } = common.normalizeRequestOptions(options)
+  return common.normalizeOrigin(proto, host, port)
 }
 
 function getMethod(options) {


### PR DESCRIPTION
For #1404

We were doing this logic in several places and not always getting good coverage. 
Adding a small utility DRYs it up.