### PR TITLE
refactor(interceptor): remove dead code for casting body to string

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -209,6 +209,7 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
     debug('match %s, body = %s', stringify(options), stringify(body))
   }
 
+  // TODO move this use case to its own method
   if (hostNameOnly) {
     return options.hostname === this.scope.urlParts.hostname
   }
@@ -221,12 +222,6 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
 
   if (this.scope.transformPathFunction) {
     path = this.scope.transformPathFunction(path)
-  }
-  if (typeof body !== 'string') {
-    body = body.toString()
-  }
-  if (this.scope.transformRequestBodyFunction) {
-    body = this.scope.transformRequestBodyFunction(body, this._requestBody)
   }
 
   const requestMatchesFilter = ({ name, value: predicate }) => {
@@ -367,6 +362,10 @@ Interceptor.prototype.match = function match(options, body, hostNameOnly) {
   }
 
   if (matches) {
+    if (this.scope.transformRequestBodyFunction) {
+      body = this.scope.transformRequestBodyFunction(body, this._requestBody)
+    }
+
     matches = matchBody.call(options, this._requestBody, body)
     if (!matches) {
       this.scope.logger("bodies don't match: \n", this._requestBody, '\n', body)


### PR DESCRIPTION
For #1404 

`Interceptor.match` is only called by the Request Overrider in the `end` function. 
Only the first call on line 245 ever uses the `body` arg.
https://github.com/nock/nock/blob/2c4edba933c996003c565f04ab8ce53c5df023aa/lib/request_overrider.js#L225-L253
Note that the logic block on lines 225-229 ensures that the `requestBody` variable is always a string.

Also, moved the call to `transformRequestBodyFunction` way down to just
before `matchBody` is called, just so it isn't unnecessarily called if
any of the non-body matches fail before it gets to that point.