### PR TITLE
test(socket): add coverage for timeout without a callback

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -35,6 +35,10 @@ util.inherits(Socket, EventEmitter)
 
 Socket.prototype.setTimeout = function setTimeout(timeoutMs, fn) {
   this.timeoutMs = timeoutMs
+  // Before Node v10, setting a timeout on a request would proxy the callback to this method, however,
+  // v10+ sets the callback on the request and relies on the socket -> request propagation. Therefore,
+  // when run code coverage is run on Node v8 the else path is never executed.
+  /* istanbul ignore else */
   if (fn) {
     this.once('timeout', fn)
   }

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -35,10 +35,6 @@ util.inherits(Socket, EventEmitter)
 
 Socket.prototype.setTimeout = function setTimeout(timeoutMs, fn) {
   this.timeoutMs = timeoutMs
-  // Before Node v10, setting a timeout on a request would proxy the callback to this method, however,
-  // v10+ sets the callback on the request and relies on the socket -> request propagation. Therefore,
-  // when run code coverage is run on Node v8 the else path is never executed.
-  /* istanbul ignore else */
   if (fn) {
     this.once('timeout', fn)
   }

--- a/tests/test_socketdelay.js
+++ b/tests/test_socketdelay.js
@@ -112,3 +112,18 @@ test('Socket#setTimeout adds callback as a one-time listener for parity with a r
     socket.setTimeout(50, onTimeout)
   })
 })
+
+test('Socket#setTimeout can be called without a callback', t => {
+  nock('http://example.test')
+    .get('/')
+    .socketDelay(100)
+    .reply()
+
+  http.get('http://example.test').on('socket', socket => {
+    socket.setTimeout(50)
+
+    socket.on('timeout', () => {
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
I'm not sure if this is the right approach.

Another option would be to send the coverage to Coveralls from Node 10
or 12. But that still may confuse devs when testing 8 locally.

@paulmelnikow ref a07b0bae8d6c7358274cd3129f276dda9389cff6