### PR TITLE
feat(interceptor): duplicate query keys throw

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -492,10 +492,14 @@ Interceptor.prototype.query = function query(queries) {
     queries instanceof url.URLSearchParams ? queries : Object.entries(queries)
 
   for (const [key, value] of entries) {
-    if (this.queries[key] === undefined) {
-      const formattedPair = common.formatQueryValue(key, value, strFormattingFn)
-      this.queries[formattedPair[0]] = formattedPair[1]
+    const formatted = common.formatQueryValue(key, value, strFormattingFn)
+    const [formattedKey, formattedValue] = formatted
+
+    if (formattedKey in this.queries) {
+      throw Error(`${formattedKey} already defined as a query parameter`)
     }
+
+    this.queries[formattedKey] = formattedValue
   }
 
   return this

--- a/tests/test_query.js
+++ b/tests/test_query.js
@@ -121,17 +121,19 @@ test('query() accepts URLSearchParams as input', async t => {
   scope.done()
 })
 
-test('multiple set query keys use the first occurrence', async t => {
-  const scope = nock('http://example.test')
+test('query() throws for duplicate keys', async t => {
+  const interceptor = nock('http://example.test')
     .get('/')
     .query({ foo: 'bar' })
-    .query({ foo: 'baz' })
-    .reply()
 
-  const { statusCode } = await got('http://example.test?foo=bar')
-
-  t.is(statusCode, 200)
-  scope.done()
+  t.throws(
+    () => {
+      interceptor.query({ foo: 'baz' })
+    },
+    {
+      message: 'foo already defined as a query parameter',
+    }
+  )
 })
 
 test('query() matches a query string that contains special RFC3986 characters', t => {


### PR DESCRIPTION
Resolves #1623

BREAKING CHANGE: Providing a duplicate search parameter to the `query`
method throws an error instead of ignoring subsequent values.