### PR TITLE
 refactor: overhaul body and query matching

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -544,6 +544,53 @@ function urlToOptions(url) {
   return options
 }
 
+/**
+ * Determines if request data matches the expected schema.
+ *
+ * Used for comparing decoded search parameters, request body JSON objects,
+ * and URL decoded request form bodies.
+ *
+ * Performs a general recursive strict comparision with two caveats:
+ *  - The expected data can use regexp to compare values
+ *  - JSON path notation and nested objects are considered equal
+ */
+const dataEqual = (expected, actual) =>
+  deepEqual(expand(expected), expand(actual))
+
+/**
+ * Converts flat objects whose keys use JSON path notation to nested objects.
+ *
+ * The input object is not mutated.
+ *
+ * @example
+ * { 'foo[bar][0]': 'baz' } -> { foo: { bar: [ 'baz' ] } }
+ */
+const expand = input =>
+  Object.entries(input).reduce((acc, [k, v]) => _.set(acc, k, v), {})
+
+/**
+ * Performs a recursive strict comparison between two values.
+ *
+ * Expected values or leaf nodes of expected object values that are RegExp use test() for comparison.
+ */
+const deepEqual = (expected, actual) => {
+  debug('deepEqual comparing', typeof expected, expected, typeof actual, actual)
+  if (expected instanceof RegExp) {
+    return expected.test(actual)
+  }
+
+  if (Array.isArray(expected) || _.isPlainObject(expected)) {
+    const expKeys = Object.keys(expected)
+    if (expKeys.length !== Object.keys(actual).length) {
+      return false
+    }
+
+    return expKeys.every(key => deepEqual(expected[key], actual[key]))
+  }
+
+  return expected === actual
+}
+
 exports.normalizeClientRequestArgs = normalizeClientRequestArgs
 exports.normalizeRequestOptions = normalizeRequestOptions
 exports.normalizeOrigin = normalizeOrigin
@@ -565,3 +612,4 @@ exports.percentDecode = percentDecode
 exports.matchStringOrRegexp = matchStringOrRegexp
 exports.formatQueryValue = formatQueryValue
 exports.isStream = isStream
+exports.dataEqual = dataEqual

--- a/lib/common.js
+++ b/lib/common.js
@@ -423,9 +423,7 @@ function matchStringOrRegexp(target, pattern) {
   const str =
     (!_.isUndefined(target) && target.toString && target.toString()) || ''
 
-  return pattern instanceof RegExp
-    ? str.match(pattern)
-    : str === String(pattern)
+  return pattern instanceof RegExp ? pattern.test(str) : str === String(pattern)
 }
 
 /**

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -374,12 +374,12 @@ Interceptor.prototype.match = function match(options, body) {
     this.scope.logger(`matching ${matchKey}${path} to ${this._key}: ${matches}`)
   }
 
-  if (matches) {
+  if (matches && this._requestBody !== undefined) {
     if (this.scope.transformRequestBodyFunction) {
       body = this.scope.transformRequestBodyFunction(body, this._requestBody)
     }
 
-    matches = matchBody.call(options, this._requestBody, body)
+    matches = matchBody(options, this._requestBody, body)
     if (!matches) {
       this.scope.logger("bodies don't match: \n", this._requestBody, '\n', body)
     }

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -412,11 +412,11 @@ Interceptor.prototype.matchAddress = function matchAddress(options) {
   const matchKey = `${method} ${proto}://${options.host}${path}`
 
   if (isRegex && !isRegexBasePath) {
-    return !!matchKey.match(comparisonKey) && !!path.match(this.path)
+    return !!matchKey.match(comparisonKey) && this.path.test(path)
   }
 
   if (isRegexBasePath) {
-    return !!matchKey.match(this.scope.basePath) && !!path.match(this.path)
+    return this.scope.basePath.test(matchKey) && !!path.match(this.path)
   }
 
   return comparisonKey === matchKey

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -1,12 +1,13 @@
 'use strict'
 
-const matchBody = require('./match_body')
-const common = require('./common')
-const _ = require('lodash')
 const debug = require('debug')('nock.interceptor')
 const stringify = require('json-stringify-safe')
-const qs = require('qs')
+const _ = require('lodash')
+const querystring = require('querystring')
 const url = require('url')
+
+const common = require('./common')
+const matchBody = require('./match_body')
 
 let fs
 try {
@@ -230,10 +231,15 @@ Interceptor.prototype.match = function match(options, body) {
   }
 
   const method = (options.method || 'GET').toUpperCase()
-  let { path } = options
+  let { path = '' } = options
   let matches
   let matchKey
   const { proto } = options
+
+  if (this.method !== method) {
+    debug(`Method did not match. Request ${method} Interceptor ${this.method}`)
+    return false
+  }
 
   if (this.scope.transformPathFunction) {
     path = this.scope.transformPathFunction(path)
@@ -283,6 +289,25 @@ Interceptor.prototype.match = function match(options, body) {
     return false
   }
 
+  // Match query strings when using query()
+  if (this.queries === null) {
+    debug('query matching skipped')
+  } else {
+    // can't rely on pathname or search being in the options, but path has a default
+    const [pathname, search] = path.split('?')
+    const matchQueries = this.matchQuery({ search })
+
+    debug(matchQueries ? 'query matching succeeded' : 'query matching failed')
+
+    if (!matchQueries) {
+      return false
+    }
+
+    // If the query string was explicitly checked then subsequent checks against
+    // the path using a callback or regexp only validate the pathname.
+    path = pathname
+  }
+
   //  If we have a filtered scope then we use it instead reconstructing
   //  the scope from the request options (proto, host and port) as these
   //  two won't necessarily match and we have to remove the scope that was
@@ -293,86 +318,19 @@ Interceptor.prototype.match = function match(options, body) {
     matchKey = common.normalizeOrigin(proto, options.host, options.port)
   }
 
-  // Match query strings when using query()
-  let matchQueries = true
-  let queryIndex = -1
-  let queryString
-  let queries
-
-  if (this.queries) {
-    queryIndex = path.indexOf('?')
-    queryString = queryIndex !== -1 ? path.slice(queryIndex + 1) : ''
-    queries = qs.parse(queryString)
-
-    // Only check for query string matches if this.queries is an object
-    if (_.isObject(this.queries)) {
-      if (_.isFunction(this.queries)) {
-        matchQueries = this.queries(queries)
-      } else {
-        // Make sure that you have an equal number of keys. We are
-        // looping through the passed query params and not the expected values
-        // if the user passes fewer query params than expected but all values
-        // match this will throw a false positive. Testing that the length of the
-        // passed query params is equal to the length of expected keys will prevent
-        // us from doing any value checking BEFORE we know if they have all the proper
-        // params
-        debug('this.queries: %j', this.queries)
-        debug('queries: %j', queries)
-        if (_.size(this.queries) !== _.size(queries)) {
-          matchQueries = false
-        } else {
-          const self = this
-          _.forOwn(queries, function matchOneKeyVal(val, key) {
-            const expVal = self.queries[key]
-            let isMatch
-            if (val === undefined || expVal === undefined) {
-              isMatch = false
-            } else if (expVal instanceof RegExp) {
-              isMatch = common.matchStringOrRegexp(val, expVal)
-            } else if (_.isArray(expVal) || _.isObject(expVal)) {
-              isMatch = _.isEqual(val, expVal)
-            } else {
-              isMatch = common.matchStringOrRegexp(val, expVal)
-            }
-            matchQueries = matchQueries && !!isMatch
-          })
-        }
-        debug('matchQueries: %j', matchQueries)
-      }
-    }
-
-    // Remove the query string from the path
-    if (queryIndex !== -1) {
-      path = path.substr(0, queryIndex)
-    }
-  }
-
   if (typeof this.uri === 'function') {
     matches =
-      matchQueries &&
-      method === this.method &&
       common.matchStringOrRegexp(matchKey, this.basePath) &&
       // This is a false positive, as `uri` is not bound to `this`.
       // eslint-disable-next-line no-useless-call
       this.uri.call(this, path)
   } else {
     matches =
-      method === this.method &&
       common.matchStringOrRegexp(matchKey, this.basePath) &&
-      common.matchStringOrRegexp(path, this.path) &&
-      matchQueries
+      common.matchStringOrRegexp(path, this.path)
   }
 
-  // special logger for query()
-  if (queryIndex !== -1) {
-    this.scope.logger(
-      `matching ${matchKey}${path}?${queryString} to ${
-        this._key
-      } with query(${stringify(this.queries)}): ${matches}`
-    )
-  } else {
-    this.scope.logger(`matching ${matchKey}${path} to ${this._key}: ${matches}`)
-  }
+  this.scope.logger(`matching ${matchKey}${path} to ${this._key}: ${matches}`)
 
   if (matches && this._requestBody !== undefined) {
     if (this.scope.transformRequestBodyFunction) {
@@ -424,6 +382,22 @@ Interceptor.prototype.matchAddress = function matchAddress(options) {
 
 Interceptor.prototype.matchHostName = function matchHostName(options) {
   return options.hostname === this.scope.urlParts.hostname
+}
+
+Interceptor.prototype.matchQuery = function matchQuery(options) {
+  if (this.queries === true) {
+    return true
+  }
+
+  const reqQueries = querystring.parse(options.search)
+  debug('Interceptor queries: %j', this.queries)
+  debug('    Request queries: %j', reqQueries)
+
+  if (_.isFunction(this.queries)) {
+    return this.queries(reqQueries)
+  }
+
+  return common.dataEqual(this.queries, reqQueries)
 }
 
 Interceptor.prototype.filteringPath = function filteringPath(...args) {
@@ -493,7 +467,7 @@ Interceptor.prototype.query = function query(queries) {
   if (queries instanceof url.URLSearchParams) {
     // Normalize the data into the shape that is matched against.
     // Duplicate keys are handled by combining the values into an array.
-    queries = qs.parse(queries.toString())
+    queries = querystring.parse(queries.toString())
   } else if (!_.isPlainObject(queries)) {
     throw Error(`Argument Error: ${queries}`)
   }

--- a/lib/match_body.js
+++ b/lib/match_body.js
@@ -9,7 +9,7 @@ const common = require('./common')
 
 module.exports = function matchBody(options, spec, body) {
   if (spec instanceof RegExp) {
-    return body.match(spec)
+    return spec.test(body)
   }
 
   if (Buffer.isBuffer(spec)) {

--- a/lib/match_body.js
+++ b/lib/match_body.js
@@ -5,13 +5,9 @@ const qs = require('qs')
 const _ = require('lodash')
 const common = require('./common')
 
-module.exports = function matchBody(spec, body) {
-  if (typeof spec === 'undefined') {
-    return true
-  }
 
-  const options = this || {}
 
+module.exports = function matchBody(options, spec, body) {
   if (spec instanceof RegExp) {
     return body.match(spec)
   }
@@ -50,7 +46,7 @@ module.exports = function matchBody(spec, body) {
   }
 
   if (typeof spec === 'function') {
-    return spec.call(this, body)
+    return spec.call(options, body)
   }
 
   // strip line endings from both so that we get a match no matter what OS we are running on

--- a/lib/match_body.js
+++ b/lib/match_body.js
@@ -1,11 +1,9 @@
 'use strict'
 
-const deepEqual = require('deep-equal')
-const qs = require('qs')
 const _ = require('lodash')
+const querystring = require('querystring')
+
 const common = require('./common')
-
-
 
 module.exports = function matchBody(options, spec, body) {
   if (spec instanceof RegExp) {
@@ -26,9 +24,8 @@ module.exports = function matchBody(options, spec, body) {
     ''
   ).toString()
 
-  const isMultipart = contentType.indexOf('multipart') >= 0
-  const isUrlencoded =
-    contentType.indexOf('application/x-www-form-urlencoded') >= 0
+  const isMultipart = contentType.includes('multipart')
+  const isUrlencoded = contentType.includes('application/x-www-form-urlencoded')
 
   // try to transform body to json
   let json
@@ -41,7 +38,7 @@ module.exports = function matchBody(options, spec, body) {
     if (json !== undefined) {
       body = json
     } else if (isUrlencoded) {
-      body = qs.parse(body, { allowDots: true })
+      body = querystring.parse(body)
     }
   }
 
@@ -59,6 +56,8 @@ module.exports = function matchBody(options, spec, body) {
     spec = spec.replace(/\r?\n|\r/g, '')
   }
 
+  // Because the nature of URL encoding, all the values in the body have been cast to strings.
+  // dataEqual does strict checking so we we have to cast the non-regexp values in the spec too.
   if (isUrlencoded) {
     spec = mapValuesDeep(spec, function(val) {
       if (_.isRegExp(val)) {
@@ -68,7 +67,7 @@ module.exports = function matchBody(options, spec, body) {
     })
   }
 
-  return deepEqualExtended(spec, body)
+  return common.dataEqual(spec, body)
 }
 
 /**
@@ -87,28 +86,4 @@ function mapValuesDeep(obj, cb) {
     })
   }
   return cb(obj)
-}
-
-function deepEqualExtended(spec, body) {
-  if (spec && spec.constructor === RegExp) {
-    return spec.test(body)
-  }
-  if (
-    spec &&
-    (spec.constructor === Object || spec.constructor === Array) &&
-    body
-  ) {
-    const keys = Object.keys(spec)
-    const bodyKeys = Object.keys(body)
-    if (keys.length !== bodyKeys.length) {
-      return false
-    }
-    for (let i = 0; i < keys.length; i++) {
-      if (!deepEqualExtended(spec[keys[i]], body[keys[i]])) {
-        return false
-      }
-    }
-    return true
-  }
-  return deepEqual(spec, body, { strict: true })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1795,11 +1795,6 @@
         "type-detect": "^4.0.0"
       }
     },
-    "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
-    },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -8624,7 +8619,8 @@
     "qs": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+      "dev": true
     },
     "querystring": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -23,12 +23,10 @@
   "dependencies": {
     "chai": "^4.1.2",
     "debug": "^4.1.0",
-    "deep-equal": "^1.0.0",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.13",
     "mkdirp": "^0.5.0",
-    "propagate": "^2.0.0",
-    "qs": "^6.5.1"
+    "propagate": "^2.0.0"
   },
   "devDependencies": {
     "acorn": "^6.1.1",

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -11,6 +11,7 @@ require('./cleanup_after_each')()
 test('matchBody ignores new line characters from strings', t => {
   t.true(
     matchBody(
+      {},
       'something //here is something more \n',
       'something //here is something more \n\r'
     )
@@ -21,16 +22,18 @@ test('matchBody ignores new line characters from strings', t => {
 test("when spec is a function, it's called with newline characters intact", t => {
   const exampleBody = 'something //here is something more \n'
   let param
-  matchBody(body => {
+  const matchCb = body => {
     param = body
-  }, exampleBody)
+  }
+
+  matchBody({}, matchCb, exampleBody)
   t.equal(param, exampleBody)
   t.end()
 })
 
 test('matchBody should not throw, when headers come node-fetch style as array', t => {
   t.false(
-    matchBody.call(
+    matchBody(
       { headers: { 'Content-Type': ['multipart/form-data;'] } },
       {},
       'test'
@@ -41,7 +44,7 @@ test('matchBody should not throw, when headers come node-fetch style as array', 
 
 test("matchBody should not ignore new line characters from strings when Content-Type contains 'multipart'", t => {
   t.true(
-    matchBody.call(
+    matchBody(
       { headers: { 'Content-Type': 'multipart/form-data;' } },
       'something //here is something more \nHello',
       'something //here is something more \nHello'
@@ -52,7 +55,7 @@ test("matchBody should not ignore new line characters from strings when Content-
 
 test("matchBody should not ignore new line characters from strings when Content-Type contains 'multipart' (arrays come node-fetch style as array)", t => {
   t.true(
-    matchBody.call(
+    matchBody(
       { headers: { 'Content-Type': ['multipart/form-data;'] } },
       'something //here is something more \nHello',
       'something //here is something more \nHello'
@@ -62,7 +65,7 @@ test("matchBody should not ignore new line characters from strings when Content-
 })
 
 test('matchBody uses strict equality for deep comparisons', t => {
-  t.false(matchBody({ number: 1 }, '{"number": "1"}'))
+  t.false(matchBody({}, { number: 1 }, '{"number": "1"}'))
   t.end()
 })
 

--- a/tests/test_complex_querystring.js
+++ b/tests/test_complex_querystring.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { test } = require('tap')
-const qs = require('qs')
+
 const nock = require('..')
 const got = require('./got_client')
 
@@ -9,7 +9,7 @@ require('./cleanup_after_each')()
 
 const exampleText = 'it worked!'
 
-test('query with array', async t => {
+test('query with array', async () => {
   // In Node 10.x this can be updated:
   // const exampleQuery = new URLSearchParams([
   //   ['list', 123],
@@ -18,12 +18,13 @@ test('query with array', async t => {
   //   ['a', 'b'],
   // ])
   const expectedQuery = { list: [123, 456, 789], a: 'b' }
+  const encodedQuery = 'list=123&list=456&list=789&a=b'
 
   const scope = nock('http://example.test')
     .get('/test')
     .query(expectedQuery)
     .reply(200, exampleText)
-  await got(`http://example.test/test?${qs.stringify(expectedQuery)}`)
+  await got(`http://example.test/test?${encodedQuery}`)
 
   scope.done()
 })
@@ -31,19 +32,21 @@ test('query with array', async t => {
 // These tests enforce the historical behavior of query strings as encoded by
 // the `qs` library. These are not standard, although they are compatible with
 // the `qs` option to `request`.
-test('query with array which contains unencoded value', async t => {
+test('query with array which contains unencoded value', async () => {
   const expectedQuery = { list: ['hello%20world', '2hello%20world', 3], a: 'b' }
+  const encodedQuery =
+    'list%5B0%5D=hello%2520world&list%5B1%5D=2hello%2520world&list%5B2%5D=3&a=b'
 
   const scope = nock('http://example.test')
     .get('/test')
     .query(expectedQuery)
     .reply(200, exampleText)
-  await got(`http://example.test/test?${qs.stringify(expectedQuery)}`)
+  await got(`http://example.test/test?${encodedQuery}`)
 
   scope.done()
 })
 
-test('query with array which contains pre-encoded values ', async t => {
+test('query with array which contains pre-encoded values ', async () => {
   const expectedQuery = { list: ['hello%20world', '2hello%20world'] }
   const queryString = 'list%5B0%5D=hello%20world&list%5B1%5D=2hello%20world'
 
@@ -56,40 +59,42 @@ test('query with array which contains pre-encoded values ', async t => {
   scope.done()
 })
 
-test('query with object', async t => {
+test('query with object', async () => {
   const expectedQuery = {
     a: {
       b: ['c', 'd'],
     },
     e: [1, 2, 3, 4],
   }
+  const encodedQuery = 'a[b][0]=c&a[b][1]=d&e[0]=1&e[1]=2&e[2]=3&e[3]=4'
 
   const scope = nock('http://example.test')
     .get('/test')
     .query(expectedQuery)
     .reply(200, exampleText)
-  await got(`http://example.test/test?${qs.stringify(expectedQuery)}`)
+  await got(`http://example.test/test?${encodedQuery}`)
 
   scope.done()
 })
 
-test('query with object which contains unencoded value', async t => {
+test('query with object which contains unencoded value', async () => {
   const exampleQuery = {
     a: {
       b: 'hello%20world',
     },
   }
+  const encodedQuery = 'a%5Bb%5D=hello%2520world'
 
   const scope = nock('http://example.test')
     .get('/test')
     .query(exampleQuery)
     .reply(200, exampleText)
-  await got(`http://example.test/test?${qs.stringify(exampleQuery)}`)
+  await got(`http://example.test/test?${encodedQuery}`)
 
   scope.done()
 })
 
-test('query with object which contains pre-encoded values', async t => {
+test('query with object which contains pre-encoded values', async () => {
   const queryString = 'a%5Bb%5D=hello%20world'
   const exampleQuery = {
     a: {
@@ -106,12 +111,7 @@ test('query with object which contains pre-encoded values', async t => {
   scope.done()
 })
 
-test('query with array and regexp', async t => {
-  const exampleQuery = {
-    list: [123, 456, 789],
-    foo: 'bar',
-    a: 'b',
-  }
+test('query with array and regexp', async () => {
   // In Node 10.x this can be updated:
   // const exampleQuery = new URLSearchParams([
   //   ['list', 123],
@@ -119,7 +119,9 @@ test('query with array and regexp', async t => {
   //   ['list', 789],
   //   ['foo', 'bar'],
   //   ['a', 'b'],
-  // ])
+  // ]).toString()
+  const encodedQuery = 'list=123&list=456&list=789&foo=bar&a=b'
+
   const expectedQuery = {
     list: [123, 456, 789],
     foo: /.*/,
@@ -130,7 +132,7 @@ test('query with array and regexp', async t => {
     .get('/test')
     .query(expectedQuery)
     .reply(200, exampleText)
-  await got(`http://example.test/test?${qs.stringify(exampleQuery)}`)
+  await got(`http://example.test/test?${encodedQuery}`)
 
   scope.done()
 })

--- a/tests/test_query.js
+++ b/tests/test_query.js
@@ -412,3 +412,35 @@ test('query(true) will match when the path has no query', t => {
     t.end()
   })
 })
+
+test('query matching should not consider request arrays equal to comma-separated expectations', t => {
+  nock('http://example.test')
+    .get('/')
+    .query({
+      foo: 'bar,baz',
+    })
+    .reply()
+
+  t.rejects(got('http://example.test?foo[]=bar&foo[]=baz'), {
+    name: 'RequestError',
+    message: 'Nock: No match for request',
+  })
+
+  t.done()
+})
+
+test('query matching should not consider comma-separated requests equal to array expectations', t => {
+  nock('http://example.test')
+    .get('/')
+    .query({
+      foo: ['bar', 'baz'],
+    })
+    .reply()
+
+  t.rejects(got('http://example.test?foo=bar%2Cbaz'), {
+    name: 'RequestError',
+    message: 'Nock: No match for request',
+  })
+
+  t.done()
+})


### PR DESCRIPTION
Drop `deep-equal` and `qs` dependencies.

Replace `qs.parse` with `querystring.parse` from the std lib.
The main difference between the two being that `qs` "unpacks" nested
objects when the search keys use JSON path notation eg "foo[bar][0]".
This has no affect on URL encoded form bodies during matching because
we manually convert the notation to nested objects for comparison now,
which means users can now provide expectations in either form.
Similarly, when matching search params using a provided object, there
is no net effect. The only breaking change is when a user provides a
callback function to `.query()`.

Replace `deep-equal` with a custom utility function in common.js.
Doing so not only dropped a dependency, it also achieved a more generic
utility for our use case with less code.

Interceptor matching had some refactoring:
- Query matching was moved to its own method in an effort to isolate concerns.
- Matching the request method was moved to the top of the match method.
- Debugging statements were updated as a baby step towards having more insight into why a match was missed.

Fixes #507
Fixes #1552

BREAKING CHANGE: The only argument passed to the Interceptor.query
callback now receives the output from querystring.parse instead of
qs.parse. This means that instead of nested objects the argument will
be a flat object.