### PR TITLE
Advertise and enforce 100% coverage, drop Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ jobs:
     - node_js: 8
       # Avoid running lint and prettier again.
       script: npm run --silent unit
-      after_script: npm run coverage:upload
     - stage: release
       node_js: lts/*
       env: semantic-release

--- a/README.md
+++ b/README.md
@@ -3,14 +3,13 @@
 [![npm](https://img.shields.io/npm/v/nock.svg)][npmjs]
 [![npm@beta](https://img.shields.io/npm/v/nock/beta.svg)][npmjs]
 [![Build Status](https://travis-ci.org/nock/nock.svg?branch=beta)][build]
-[![Coverage Status](https://img.shields.io/coveralls/github/nock/nock/beta.svg)][coverage]
+[Coverage Status](http://img.shields.io/badge/coverage-100%25-brightgreen.svg)
 [![Greenkeeper](https://badges.greenkeeper.io/nock/nock.svg)](https://greenkeeper.io/)
 [![Backers on Open Collective](https://opencollective.com/nock/backers/badge.svg)](#backers)
 [![Sponsors on Open Collective](https://opencollective.com/nock/sponsors/badge.svg)](#sponsors)
 
 [npmjs]: https://www.npmjs.com/package/nock
 [build]: https://travis-ci.org/nock/nock
-[coverage]: https://coveralls.io/github/nock/nock
 
 HTTP server mocking and expectations library for Node.js
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -439,8 +439,7 @@ function matchStringOrRegexp(target, pattern) {
  * @returns *[] the formatted [key, value] pair.
  */
 function formatQueryValue(key, value, stringFormattingFn) {
-  // TODO-coverage: Find out what's not covered. Probably refactor code to
-  // replace `switch(true)` with `if`/`else`.
+  // TODO: Probably refactor code to replace `switch(true)` with `if`/`else`.
   switch (true) {
     case _.isNumber(value): // fall-through
     case _.isBoolean(value):

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "acorn": "^6.1.1",
     "assert-rejects": "^1.0.0",
     "aws-sdk": "^2.437.0",
-    "coveralls": "^3.0.3",
     "eslint": "^6.0.0",
     "eslint-config-prettier": "^6.0.0",
     "eslint-config-standard": "^13.0.1",
@@ -60,12 +59,11 @@
     "tap": "^14.0.0"
   },
   "scripts": {
-    "unit": "tap --coverage --coverage-report=text ./tests/test_*.js",
+    "unit": "tap --100 --coverage --coverage-report=text ./tests/test_*.js",
     "pretest": "npm run -s lint",
     "test": "npm run -s unit",
     "posttest": "npm run -s prettier:check",
     "coverage": "tap --coverage-report=html && open coverage/lcov-report/index.html",
-    "coverage:upload": "tap --coverage-report=text-lcov | coveralls",
     "lint": "eslint \"**/*.js\"",
     "prettier": "prettier --write \"**/*.@(js|md|yml|json)\"",
     "prettier:check": "prettier --check \"**/*.@(js|md|yml|json)\"",


### PR DESCRIPTION
We've hit 100% coverage!

Coveralls is mostly useful for growing coverage over time. I think the text report is adequate for finding gaps in feature branches and preventing us from slipping. I don't think it's worth running Coveralls anymore.

I replaced the coverage badge with a static one!

Closes #1404