### PR TITLE
refactor: Convert DelayedBody to a class

### DIFF
--- a/lib/delayed_body.js
+++ b/lib/delayed_body.js
@@ -8,46 +8,45 @@
  * @param  {Integer} ms - The delay in milliseconds
  * @constructor
  */
-module.exports = DelayedBody
 
 const { Transform } = require('stream')
-const util = require('util')
 const common = require('./common')
 
-function DelayedBody(ms, body) {
-  Transform.call(this)
+module.exports = class DelayedBody extends Transform {
+  constructor(ms, body) {
+    super()
 
-  const self = this
-  let data = ''
-  let ended = false
+    const self = this
+    let data = ''
+    let ended = false
 
-  if (common.isStream(body)) {
-    body.on('data', function(chunk) {
-      data += Buffer.isBuffer(chunk) ? chunk.toString() : chunk
-    })
+    if (common.isStream(body)) {
+      body.on('data', function(chunk) {
+        data += Buffer.isBuffer(chunk) ? chunk.toString() : chunk
+      })
 
-    body.once('end', function() {
-      ended = true
-    })
+      body.once('end', function() {
+        ended = true
+      })
 
-    body.resume()
+      body.resume()
+    }
+
+    // TODO: This would be more readable if the stream case were moved into
+    // the `if` statement above.
+    setTimeout(function() {
+      if (common.isStream(body) && !ended) {
+        body.once('end', function() {
+          self.end(data)
+        })
+      } else {
+        self.end(data || body)
+      }
+    }, ms)
   }
 
-  // TODO: This would be more readable if the stream case were moved into
-  // the `if` statement above.
-  setTimeout(function() {
-    if (common.isStream(body) && !ended) {
-      body.once('end', function() {
-        self.end(data)
-      })
-    } else {
-      self.end(data || body)
-    }
-  }, ms)
-}
-util.inherits(DelayedBody, Transform)
-
-DelayedBody.prototype._transform = function(chunk, encoding, cb) {
-  this.push(chunk)
-  process.nextTick(cb)
+  _transform(chunk, encoding, cb) {
+    this.push(chunk)
+    process.nextTick(cb)
+  }
 }


### PR DESCRIPTION
As the start of some modernization / stylistic updates, I started converting the `Foo.prototype`'s to ES6 classes.