### PR TITLE
refactor: default function arguments

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -44,6 +44,7 @@ const normalizeRequestOptions = function(options) {
  * accordingly. We've inadvertently gotten it flipped.
  *
  * @param  {Object} buffer - a Buffer object
+ * @returns {boolean}
  */
 const isUtf8Representable = function(buffer) {
   if (!Buffer.isBuffer(buffer)) {

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -74,7 +74,6 @@ function isEnabledForNetConnect(options) {
 /**
  * Disable all real requests.
  * @public
- * @param {String|RegExp} matcher=RegExp.new('.*') Expression to match
  * @example
  * nock.disableNetConnect();
  */

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -79,11 +79,13 @@ function Interceptor(scope, uri, method, requestBody, interceptorOptions) {
   }
 }
 
-Interceptor.prototype.optionally = function optionally(value) {
+Interceptor.prototype.optionally = function optionally(flag = true) {
   // The default behaviour of optionally() with no arguments is to make the mock optional.
-  value = typeof value === 'undefined' ? true : value
+  if (typeof flag !== 'boolean') {
+    throw new Error('Invalid arguments: argument should be a boolean')
+  }
 
-  this.optional = value
+  this.optional = flag
 
   return this
 }
@@ -444,14 +446,9 @@ Interceptor.prototype.matchHeader = function matchHeader(name, value) {
   return this
 }
 
-Interceptor.prototype.basicAuth = function basicAuth(options) {
-  const username = options['user']
-  const password = options['pass'] || ''
-  const name = 'authorization'
-  const value = `Basic ${Buffer.from(`${username}:${password}`).toString(
-    'base64'
-  )}`
-  this.interceptorMatchHeaders.push({ name, value })
+Interceptor.prototype.basicAuth = function basicAuth({ user, pass = '' }) {
+  const encoded = Buffer.from(`${user}:${pass}`).toString('base64')
+  this.matchHeader('authorization', `Basic ${encoded}`)
   return this
 }
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -231,11 +231,11 @@ class Scope extends EventEmitter {
     return this
   }
 
-  persist(flag) {
-    this._persist = flag == null ? true : flag
-    if (typeof this._persist !== 'boolean') {
+  persist(flag = true) {
+    if (typeof flag !== 'boolean') {
       throw new Error('Invalid arguments: argument should be a boolean')
     }
+    this._persist = flag
     return this
   }
 

--- a/tests/test_persist_optionally.js
+++ b/tests/test_persist_optionally.js
@@ -44,6 +44,15 @@ test('calling optionally(false) on a mock leaves it as required', t => {
   t.end()
 })
 
+test('calling optionally() with a non-boolean argument throws an error', t => {
+  const interceptor = nock('http://example.test').get('/')
+
+  t.throws(() => interceptor.optionally('foo'), {
+    message: 'Invalid arguments: argument should be a boolean',
+  })
+  t.end()
+})
+
 test('optional mocks are still functional', t => {
   nock('http://example.test')
     .get('/abc')


### PR DESCRIPTION
Make use of in-line default args, available in Node since v6.