### PR TITLE
feat: `afterRecord` now returns object or stringified.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ stages:
   - lint
   - test
   - name: release
-    if: branch = master AND type IN (push)
+    if: branch =~ /^(\d+\.x|master|next|beta)$/ AND type IN (push)
 
 jobs:
   include:

--- a/README.md
+++ b/README.md
@@ -1369,7 +1369,7 @@ As an optional second parameter you can pass the following options
 
 - `before`: a preprocessing function, gets called before nock.define
 - `after`: a postprocessing function, gets called after nock.define
-- `afterRecord`: a postprocessing function, gets called after recording. Is passed the array of scopes recorded and should return the array scopes to save to the fixture
+- `afterRecord`: a postprocessing function, gets called after recording. Is passed the array of scopes recorded and should return the array scopes as an object or stringified to save to the fixture
 - `recorder`: custom options to pass to the recorder
 
 ##### Example

--- a/README.md
+++ b/README.md
@@ -1369,7 +1369,7 @@ As an optional second parameter you can pass the following options
 
 - `before`: a preprocessing function, gets called before nock.define
 - `after`: a postprocessing function, gets called after nock.define
-- `afterRecord`: a postprocessing function, gets called after recording. Is passed the array of scopes recorded and should return the array scopes as an object or stringified to save to the fixture
+- `afterRecord`: a postprocessing function, gets called after recording. Is passed the array of scopes recorded and should return the intact array, a modified version of the array, or if custom formatting is desired, a stringified version of the array to save to the fixture
 - `recorder`: custom options to pass to the recorder
 
 ##### Example

--- a/lib/back.js
+++ b/lib/back.js
@@ -194,7 +194,7 @@ var record = {
         outputs = options.afterRecord(outputs);
       }
 
-      outputs = JSON.stringify(outputs, null, 4);
+      outputs = typeof outputs === 'string' ? outputs : JSON.stringify(outputs, null, 4);
       debug('recorder outputs:', outputs);
 
       mkdirp.sync(path.dirname(fixture));

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "request-promise": "^4.2.2",
     "restify-clients": "^2.2.0",
     "rimraf": "^2.6.2",
-    "semantic-release": "^16.0.0-beta.10",
+    "semantic-release": "^16.0.0-beta.13",
     "superagent": "^4.0.0",
     "tap": "^12.0.0"
   },

--- a/tests/test_back.js
+++ b/tests/test_back.js
@@ -394,8 +394,6 @@ tap.test('nockBack record tests', nw => {
 
     t.false(exists(fixtureLoc));
 
-    // You would do some filtering here, but for this test we'll just return
-    // an empty array.
     const afterRecord = scopes => 'string-response';
 
     nockBack(fixture, {afterRecord: afterRecord}, function (done) {

--- a/tests/test_back.js
+++ b/tests/test_back.js
@@ -230,7 +230,7 @@ tap.test('nockBack dryrun tests', nw => {
 });
 
 
-tap.test('nockBack record tests', { only: true }, nw => {
+tap.test('nockBack record tests', nw => {
   nockBack.setMode('record');
 
   nw.test('it records when configured correctly', t => {


### PR DESCRIPTION
#1599