### PR TITLE
bug(recorder): replace qs lib with native querystring

### DIFF
--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const debug = require('debug')('nock.recorder')
-const qs = require('qs')
+const querystring = require('querystring')
 const { inspect } = require('util')
 
 const common = require('./common')
@@ -112,7 +112,7 @@ function generateRequestAndResponse(
 
     // Create the query() object
     const queryStr = req.path.slice(queryIndex + 1)
-    queryObj = qs.parse(queryStr)
+    queryObj = querystring.parse(queryStr)
   }
   // Always encoding the query parameters when recording.
   const encodedQueryObj = {}


### PR DESCRIPTION
The `qs` dependency was removed, however, recorder.js retained usage of it. 
Replacing it with `querystring` from the std lib is sufficient.

Introduced: #1632
Fixes: #1651

Note that the output of `generateRequestAndResponse` will change for requests with search params, however, the net effect when that output is used will be the same. 