### PR TITLE
bug(interceptor): call transformRequestBodyFunction without body spec defined

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -326,15 +326,20 @@ Interceptor.prototype.match = function match(options, body) {
 
   this.scope.logger(`matching ${matchKey}${path} to ${this._key}: ${matches}`)
 
-  if (matches && this._requestBody !== undefined) {
-    if (this.scope.transformRequestBodyFunction) {
-      body = this.scope.transformRequestBodyFunction(body, this._requestBody)
-    }
+  if (!matches) {
+    return false
+  }
 
+  if (this.scope.transformRequestBodyFunction) {
+    body = this.scope.transformRequestBodyFunction(body, this._requestBody)
+  }
+
+  if (this._requestBody !== undefined) {
     matches = matchBody(options, this._requestBody, body)
-    if (!matches) {
-      this.scope.logger("bodies don't match: \n", this._requestBody, '\n', body)
-    }
+  }
+
+  if (!matches) {
+    this.scope.logger("bodies don't match: \n", this._requestBody, '\n', body)
   }
 
   return matches

--- a/tests/test_scope.js
+++ b/tests/test_scope.js
@@ -134,13 +134,31 @@ test('filter body with function', async t => {
       return 'mamma tua'
     })
     .post('/', 'mamma tua')
-    .reply(200, 'Hello World!')
+    .reply()
 
   const { statusCode } = await got('http://example.test/', {
     body: 'mamma mia',
   })
 
-  t.equal(statusCode, 200)
+  t.is(statusCode, 200)
+  scope.done()
+  t.equal(filteringRequestBodyCounter, 1)
+})
+
+test('filter body with function and empty body', async t => {
+  let filteringRequestBodyCounter = 0
+
+  const scope = nock('http://example.test')
+    .filteringRequestBody(body => {
+      ++filteringRequestBodyCounter
+      return true
+    })
+    .post('/')
+    .reply()
+
+  const { statusCode } = await got.post('http://example.test/')
+
+  t.is(statusCode, 200)
   scope.done()
   t.equal(filteringRequestBodyCounter, 1)
 })


### PR DESCRIPTION
Fixes #1652

`transformRequestBodyFunction` is now called if it's defined on the scope even if the Interceptor has no spec body defined. 