### PR TITLE
bug(overrider): unmocked HTTPS request with partial interceptor match

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -2,7 +2,12 @@
 
 const debug = require('debug')('nock.request_overrider')
 const { EventEmitter } = require('events')
-const { IncomingMessage, ClientRequest } = require('http')
+const {
+  IncomingMessage,
+  ClientRequest,
+  request: originalHttpRequest,
+} = require('http')
+const { request: originalHttpsRequest } = require('https')
 const _ = require('lodash')
 const propagate = require('propagate')
 const timers = require('timers')
@@ -253,7 +258,11 @@ function RequestOverrider(req, options, interceptors, remove) {
       )
 
       if (allowUnmocked && req instanceof ClientRequest) {
-        const newReq = new ClientRequest(options)
+        const newReq =
+          options.proto === 'https'
+            ? originalHttpsRequest(options)
+            : originalHttpRequest(options)
+
         propagate(newReq, req)
         //  We send the raw buffer as we received it, not as we interpreted it.
         newReq.end(requestBodyBuffer)


### PR DESCRIPTION
Fixes: #1422

The `allowUnmocked` option is processed in two places. Once in the
intercept when there are no interceptors that come close to matching
the request. And again in the overrider when there are interceptors
that partially match, eg just path, but don't completely match.

This fixes and explicitly tests the later case in the overrider by
making an HTTPS request for a path that has an interceptor but fails to
match the query constraint.