### PR TITLE
Feat: Added response.destroy method

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -113,11 +113,11 @@ function RequestOverrider(req, options, interceptors, remove) {
 
   // https://nodejs.org/api/http.html#http_message_destroy_error
   response.destroy = function(err) {
-    debug('res.destroy');
-    response.emit('close', err);
-    req.socket.destroy();
+    debug('res.destroy')
+    response.emit('close', err)
+    req.socket.destroy()
     if (err instanceof Error) {
-      emitError(err);
+      emitError(err)
     }
   }
 

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -111,6 +111,16 @@ function RequestOverrider(req, options, interceptors, remove) {
   req.socket = req.connection = new Socket({ proto: options.proto })
   response.socket = response.client = response.connection = req.socket
 
+  // https://nodejs.org/api/http.html#http_message_destroy_error
+  response.destroy = function(err) {
+    debug('res.destroy');
+    response.emit('close', err);
+    req.socket.destroy();
+    if (err instanceof Error) {
+      emitError(err);
+    }
+  }
+
   propagate(['timeout'], req.socket, req)
 
   // Emit a fake socket event on the next tick to mimic what would happen on a real request.

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -111,17 +111,7 @@ function RequestOverrider(req, options, interceptors, remove) {
   req.socket = req.connection = new Socket({ proto: options.proto })
   response.socket = response.client = response.connection = req.socket
 
-  // https://nodejs.org/api/http.html#http_message_destroy_error
-  response.destroy = function(err) {
-    debug('res.destroy')
-    response.emit('close', err)
-    req.socket.destroy()
-    if (err instanceof Error) {
-      emitError(err)
-    }
-  }
-
-  propagate(['timeout'], req.socket, req)
+  propagate(['timeout', 'error'], req.socket, req)
 
   // Emit a fake socket event on the next tick to mimic what would happen on a real request.
   // Some clients listen for a 'socket' event to be emitted before calling end(),

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -54,8 +54,12 @@ module.exports = class Socket extends EventEmitter {
     ).toString('base64')
   }
 
-  destroy() {
+  destroy(err) {
     this.destroyed = true
     this.readable = this.writable = false
+    if (err) {
+      this.emit('error', err)
+    }
+    return this
   }
 }

--- a/tests/test_destroy.js
+++ b/tests/test_destroy.js
@@ -14,12 +14,12 @@ test('req.destroy should emit error event if called with error', t => {
   http
     .get('http://example.test/', res => {
       if (res.statusCode !== 200) {
-        res.destroy(new Error("Response error"))
+        res.destroy(new Error('Response error'))
       }
     })
     .once('error', err => {
       t.type(err, Error)
-      t.equal(err.message, "Response error")
+      t.equal(err.message, 'Response error')
       t.end()
     })
 })

--- a/tests/test_destroy.js
+++ b/tests/test_destroy.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const nock = require('..')
+const http = require('http')
+const { test } = require('tap')
+
+require('./cleanup_after_each')()
+
+test('req.destroy should emit error event if called with error', t => {
+  nock('http://example.test')
+    .get('/')
+    .reply(404)
+
+  http
+    .get('http://example.test/', res => {
+      if (res.statusCode !== 200) {
+        res.destroy(new Error("Response error"))
+      }
+    })
+    .once('error', err => {
+      t.type(err, Error)
+      t.equal(err.message, "Response error")
+      t.end()
+    })
+})
+
+test('req.destroy should not emit error event if called without error', t => {
+  nock('http://example.test')
+    .get('/')
+    .reply(403)
+
+  http
+    .get('http://example.test/', res => {
+      if (res.statusCode === 403) {
+        res.destroy()
+      }
+
+      t.end()
+    })
+    .once('error', () => {
+      t.fail('should not emit error')
+    })
+})


### PR DESCRIPTION
It adds the [destroy](https://nodejs.org/api/http.html#http_message_destroy_error) method to the response to manually terminate a connection and optionally raise an error captured from listeners bound to request `error` event.

As discussed in #1669 

---

I'm still not sure if this is enough, I took a look at [http_incoming](https://github.com/nodejs/node/blob/787378879acfb212ed4ff824bf9f767a24a5cb43/lib/_http_incoming.js#L104-L107) from node http core:

```js
IncomingMessage.prototype.destroy = function destroy(error) {
  if (this.socket)
    this.socket.destroy(error);
};
```
And from [http_client](https://github.com/nodejs/node/blob/787378879acfb212ed4ff824bf9f767a24a5cb43/lib/_http_client.js#L450-L456) also from node http core:

```js
if (ret instanceof Error) {
    prepareError(ret, parser, d);
    debug('parse error', ret);
    freeParser(parser, req, socket);
    socket.destroy();
    req.socket._hadError = true;
    req.emit('error', ret);
} ...
```

And based on the [description](https://nodejs.org/api/http.html#http_class_http_incomingmessage) provided in the documentation:

> https://nodejs.org/api/http.html#http_class_http_incomingmessage

It will raise the `error` event only if called with an actual **Error** instance.

But since I'm not familiar with node http core lib I'm not sure if this will terminate the connection properly or is required to manually perform other tasks on the request object.