### PR TITLE
chore: add extension to main field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "engines": {
     "node": ">= 8.0"
   },
-  "main": "./index",
+  "main": "./index.js",
   "types": "types",
   "dependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
This doesn't add much value from Node's POV, since it can resolve it all
the same, however, some tools get confused.

[`index.js` is also the default](https://docs.npmjs.com/creating-a-package-json-file#default-values-extracted-from-the-current-directory) value for the field so it could be
removed, but it's probably for the best to be explicit.

Fixes: #1654