### PR TITLE
fix(types): use export = and declares

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,14 +5,14 @@ import { ClientRequest, IncomingMessage, RequestOptions } from 'http'
 import { ParsedUrlQuery } from 'querystring'
 import { Url, URLSearchParams } from 'url'
 
-export default Nock
+export = nock
 
-export function Nock(
+declare function nock(
   basePath: string | RegExp | Url,
-  options?: Nock.Options
-): Nock.Scope
+  options?: nock.Options
+): nock.Scope
 
-export namespace Nock {
+declare namespace nock {
   function cleanAll(): void
   function activate(): void
   function isActive(): boolean

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -249,7 +249,7 @@ nock('http://example.test', { encodedQueryParams: true })
   .query('foo%5Bbar%5D%3Dhello%20world%21')
   .reply(200, { results: [{ id: 'foo' }] })
 
-nock('http://example.test',)
+nock('http://example.test')
   .get('/')
   .query(new URLSearchParams([['foo', 'one'], ['foo', 'two']]))
   .reply()

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -1,12 +1,11 @@
 import nock from 'nock'
 import * as fs from 'fs'
-import { URL } from 'url'
+import { URL, URLSearchParams } from 'url'
 
 let scope: nock.Scope = nock('http://example.test')
 let inst: nock.Interceptor
 let str = 'foo'
 let strings: string[]
-let bool = true
 let defs: nock.Definition[]
 let options: nock.Options = {}
 
@@ -55,7 +54,7 @@ inst = scope.merge(str, obj)
 inst = scope.merge(str, regex)
 
 inst = inst.query(obj)
-inst = inst.query(bool)
+inst = inst.query(true)
 
 inst = scope.intercept(str, str)
 inst = scope.intercept(str, str, str)
@@ -117,9 +116,9 @@ inst = inst.delayBody(2000)
 inst = inst.delayConnection(2000)
 inst = inst.socketDelay(2000)
 
-scope.done()
-bool = scope.isDone()
-scope.restore()
+scope.done() // $ExpectType void
+scope.isDone() // $ExpectType boolean
+scope.restore() // $ExpectType void
 
 nock.recorder.rec()
 nock.recorder.rec(true)
@@ -249,6 +248,11 @@ nock('http://example.test', { encodedQueryParams: true })
   .get('/users')
   .query('foo%5Bbar%5D%3Dhello%20world%21')
   .reply(200, { results: [{ id: 'foo' }] })
+
+nock('http://example.test',)
+  .get('/')
+  .query(new URLSearchParams([['foo', 'one'], ['foo', 'two']]))
+  .reply()
 
 // Specifying replies
 scope = nock('http://example.test')


### PR DESCRIPTION
Fixes: #1694
From my testing, I haven't been able to find any negatives with using
`export =` and `declare` vs direct export when using TS 3+. Going
this route allows for consumers still using TS2 and/or not using
`esModuleInterop` to still utilize the bundled types.

Closes: #1684
I don't think the casing of the exported object makes a difference
either way, but using lowercase seems to fit with common usage (as a
function) better.