### PR TITLE
fix: Fix crash when matching certain objects

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -578,6 +578,10 @@ function deepEqual(expected, actual) {
   }
 
   if (Array.isArray(expected) || _.isPlainObject(expected)) {
+    if (actual === undefined) {
+      return false
+    }
+
     const expKeys = Object.keys(expected)
     if (expKeys.length !== Object.keys(actual).length) {
       return false

--- a/tests/test_body_match.js
+++ b/tests/test_body_match.js
@@ -214,6 +214,25 @@ test("doesn't match body with mismatching keys", t => {
   )
 })
 
+// https://github.com/nock/nock/issues/1713
+test("doesn't match body with same number of keys but different keys", t => {
+  nock('http://example.test')
+    .post('/', { a: {} })
+    .reply()
+
+  mikealRequest(
+    {
+      url: 'http://example.test',
+      method: 'post',
+      json: { b: 123 },
+    },
+    function(err) {
+      assert.ok(err)
+      t.end()
+    }
+  )
+})
+
 test('match body with form multipart', t => {
   nock('http://example.test')
     .post(


### PR DESCRIPTION
When matching objects with the same number of keys but different keys,
should not match instead of crashing.

Close #1713