### PR TITLE
fix: authorize undefined values in DataMatcher type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -42,6 +42,7 @@ declare namespace nock {
     [k: string]:
       | boolean
       | null
+      | undefined
       | number
       | string
       | RegExp

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -11,6 +11,7 @@ let options: nock.Options = {}
 
 const num = 42
 const obj: { [k: string]: any } = {}
+const objWithUndefinedValue: { a: string; b?: string } = { a: 'a' }
 const regex = /test/
 
 scope.head(str) // $ExpectType Interceptor
@@ -55,6 +56,7 @@ inst = scope.merge(str, regex)
 
 inst = inst.query(obj)
 inst = inst.query(true)
+inst = inst.query(objWithUndefinedValue)
 
 inst = scope.intercept(str, str)
 inst = scope.intercept(str, str, str)


### PR DESCRIPTION
When the type used in `.query` defines optional keys using undefined, TypeScript was complaining :

```
Error:(59, 19) TS2345: Argument of type '{ a: string; b?: string | undefined; }' is not assignable to parameter of type 'string | boolean | DataMatcher | URLSearchParams | ((parsedObj: ParsedUrlQuery) => boolean)'.
  Type '{ a: string; b?: string | undefined; }' is not assignable to type 'DataMatcher'.
    Property 'b' is incompatible with index signature.
      Type 'string | undefined' is not assignable to type 'string | number | boolean | RegExp | DataMatcher | (string | number | boolean | RegExp | DataMatcher | null)[] | null'.
        Type 'undefined' is not assignable to type 'string | number | boolean | RegExp | DataMatcher | (string | number | boolean | RegExp | DataMatcher | null)[] | null'.
```