### PR TITLE
Fix compilation errors with Typescript 3.2.2

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -83,9 +83,9 @@ declare namespace nock {
 
   type StatusCode = number
   type ReplyFnResult =
-    | readonly [StatusCode]
-    | readonly [StatusCode, ReplyBody]
-    | readonly [StatusCode, ReplyBody, ReplyHeaders]
+    | Readonly<[StatusCode]>
+    | Readonly<[StatusCode, ReplyBody]>
+    | Readonly<[StatusCode, ReplyBody, ReplyHeaders]>
 
   interface ReplyFnContext extends Interceptor {
     req: ClientRequest & {


### PR DESCRIPTION
Here is the error I get:

```node_modules/nock/types/index.d.ts:81:27 - error TS1005: ']' expected.

81     | readonly [StatusCode, ReplyBody]
                             ~

node_modules/nock/types/index.d.ts:81:38 - error TS1005: ';' expected.

81     | readonly [StatusCode, ReplyBody]
                                        ~

node_modules/nock/types/index.d.ts:82:5 - error TS1109: Expression expected.

82     | readonly [StatusCode, ReplyBody, ReplyHeaders]
       ~```

What version of Typescript do you want to support?