### PR TITLE
docs(README): Replace --save option

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Nock works by overriding Node's `http.request` function. Also, it overrides `htt
 ## Install
 
 ```sh
-$ npm install --save nock
+$ npm install --save-dev nock
 ```
 
 ### Node version support


### PR DESCRIPTION
Hey,

As I understand `nock` usually used in dev environment so there is a little update for docs.