### PR TITLE
feat: improve error output by showing which URL caused the error

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -34,7 +34,7 @@ module.exports = class Interceptor {
     // we only need to check strings.
     if (uriIsStr && /^[^/*]/.test(uri)) {
       throw Error(
-        "Non-wildcard URL path strings must begin with a slash (otherwise they won't match anything)"
+        `Non-wildcard URL path strings must begin with a slash (otherwise they won't match anything) (got: ${uri})`
       )
     }
 


### PR DESCRIPTION
After getting an error in the interceptor, mentioning URL's need to start with a slash, it was difficult to find out which URL was causing the issue. With this change, since the URL is included in the error message, it's easier to troubleshoot the issue.

=> Reopening to master by request of @paulmelnikow