### PR TITLE
allow for duplicate headers if the values are the same

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -203,7 +203,10 @@ function headersFieldNamesToLowerCase(headers) {
   const lowerCaseHeaders = {}
   Object.entries(headers).forEach(([fieldName, fieldValue]) => {
     const key = fieldName.toLowerCase()
-    if (lowerCaseHeaders[key] !== undefined && lowerCaseHeaders[key] !== fieldValue) {
+    if (
+      lowerCaseHeaders[key] !== undefined &&
+      lowerCaseHeaders[key] !== fieldValue
+    ) {
       throw Error(
         `Failed to convert header keys to lower case due to field name conflict: ${key}`
       )

--- a/lib/common.js
+++ b/lib/common.js
@@ -203,7 +203,7 @@ function headersFieldNamesToLowerCase(headers) {
   const lowerCaseHeaders = {}
   Object.entries(headers).forEach(([fieldName, fieldValue]) => {
     const key = fieldName.toLowerCase()
-    if (lowerCaseHeaders[key] !== undefined) {
+    if (lowerCaseHeaders[key] !== undefined && lowerCaseHeaders[key] !== fieldValue) {
       throw Error(
         `Failed to convert header keys to lower case due to field name conflict: ${key}`
       )

--- a/lib/common.js
+++ b/lib/common.js
@@ -208,8 +208,9 @@ function headersFieldNamesToLowerCase(headers) {
       process.emitWarning(
         'Request made with duplicate headers! First value provided is being used. Other HTTP clients may do something different.'
       )
+    } else {
+      lowerCaseHeaders[key] = fieldValue
     }
-    lowerCaseHeaders[key] = fieldValue
   })
 
   return lowerCaseHeaders

--- a/lib/common.js
+++ b/lib/common.js
@@ -205,8 +205,10 @@ function headersFieldNamesToLowerCase(headers) {
   Object.entries(headers).forEach(([fieldName, fieldValue]) => {
     const key = fieldName.toLowerCase()
     if (lowerCaseHeaders[key] !== undefined) {
-      process.emitWarning('Request made with duplicate headers. This is does not match the HTTP W3 Header spec!')
-      if (lowerCaseHeaders[key] !== fieldValue){
+      process.emitWarning(
+        'Request made with duplicate headers. This is does not match the HTTP W3 Header spec!'
+      )
+      if (lowerCaseHeaders[key] !== fieldValue) {
         throw Error(
           `Failed to convert header keys to lower case due to field name conflict: ${key}`
         )

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const _ = require('lodash')
+const process = require('process')
 const debug = require('debug')('nock.common')
 const url = require('url')
 
@@ -203,13 +204,13 @@ function headersFieldNamesToLowerCase(headers) {
   const lowerCaseHeaders = {}
   Object.entries(headers).forEach(([fieldName, fieldValue]) => {
     const key = fieldName.toLowerCase()
-    if (
-      lowerCaseHeaders[key] !== undefined &&
-      lowerCaseHeaders[key] !== fieldValue
-    ) {
-      throw Error(
-        `Failed to convert header keys to lower case due to field name conflict: ${key}`
-      )
+    if (lowerCaseHeaders[key] !== undefined) {
+      process.emitWarning('Request made with duplicate headers. This is does not match the HTTP W3 Header spec!')
+      if (lowerCaseHeaders[key] !== fieldValue){
+        throw Error(
+          `Failed to convert header keys to lower case due to field name conflict: ${key}`
+        )
+      }
     }
     lowerCaseHeaders[key] = fieldValue
   })

--- a/lib/common.js
+++ b/lib/common.js
@@ -206,7 +206,7 @@ function headersFieldNamesToLowerCase(headers) {
     const key = fieldName.toLowerCase()
     if (lowerCaseHeaders[key] == undefined) {
       process.emitWarning(
-        "Request made with duplicate headers! First value provided is being used. Other HTTP clients may do something different."
+        'Request made with duplicate headers! First value provided is being used. Other HTTP clients may do something different.'
       )
       lowerCaseHeaders[key] = fieldValue
     }

--- a/lib/common.js
+++ b/lib/common.js
@@ -204,17 +204,12 @@ function headersFieldNamesToLowerCase(headers) {
   const lowerCaseHeaders = {}
   Object.entries(headers).forEach(([fieldName, fieldValue]) => {
     const key = fieldName.toLowerCase()
-    if (lowerCaseHeaders[key] !== undefined) {
+    if (lowerCaseHeaders[key] == undefined) {
       process.emitWarning(
-        'Request made with duplicate headers. This is does not match the HTTP W3 Header spec!'
+        "Request made with duplicate headers! First value provided is being used. Other HTTP clients may do something different."
       )
-      if (lowerCaseHeaders[key] !== fieldValue) {
-        throw Error(
-          `Failed to convert header keys to lower case due to field name conflict: ${key}`
-        )
-      }
+      lowerCaseHeaders[key] = fieldValue
     }
-    lowerCaseHeaders[key] = fieldValue
   })
 
   return lowerCaseHeaders

--- a/lib/common.js
+++ b/lib/common.js
@@ -204,12 +204,12 @@ function headersFieldNamesToLowerCase(headers) {
   const lowerCaseHeaders = {}
   Object.entries(headers).forEach(([fieldName, fieldValue]) => {
     const key = fieldName.toLowerCase()
-    if (lowerCaseHeaders[key] === undefined) {
+    if (lowerCaseHeaders[key] !== undefined) {
       process.emitWarning(
         'Request made with duplicate headers! First value provided is being used. Other HTTP clients may do something different.'
       )
-      lowerCaseHeaders[key] = fieldValue
     }
+    lowerCaseHeaders[key] = fieldValue
   })
 
   return lowerCaseHeaders

--- a/lib/common.js
+++ b/lib/common.js
@@ -204,7 +204,7 @@ function headersFieldNamesToLowerCase(headers) {
   const lowerCaseHeaders = {}
   Object.entries(headers).forEach(([fieldName, fieldValue]) => {
     const key = fieldName.toLowerCase()
-    if (lowerCaseHeaders[key] == undefined) {
+    if (lowerCaseHeaders[key] === undefined) {
       process.emitWarning(
         'Request made with duplicate headers! First value provided is being used. Other HTTP clients may do something different.'
       )

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -140,10 +140,10 @@ test('headersFieldNamesToLowerCase works', t => {
   t.end()
 })
 
-test('headersFieldNamesToLowerCase deduplicates', t => {
+test('headersFieldNamesToLowerCase deduplicates in the order the header was added to the object', t => {
   t.deepEqual(
     common.headersFieldNamesToLowerCase({
-      HoSt: 'example.test',
+      HoSt: 'example.test1',
       HOST: 'example.test',
       'Content-typE': 'plain/text',
     }),

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -140,22 +140,7 @@ test('headersFieldNamesToLowerCase works', t => {
   t.end()
 })
 
-test('headersFieldNamesToLowerCase throws on conflicting keys', t => {
-  t.throws(
-    () =>
-      common.headersFieldNamesToLowerCase({
-        HoSt: 'example.test',
-        HOST: 'example.tesT',
-      }),
-    {
-      message:
-        'Failed to convert header keys to lower case due to field name conflict: host',
-    }
-  )
-  t.end()
-})
-
-test('headersFieldNamesToLowerCase matches if the values are the same', t => {
+test('headersFieldNamesToLowerCase deduplicates', t => {
   t.deepEqual(
     common.headersFieldNamesToLowerCase({
       HoSt: 'example.test',
@@ -163,7 +148,7 @@ test('headersFieldNamesToLowerCase matches if the values are the same', t => {
       'Content-typE': 'plain/text',
     }),
     {
-      host: 'example.test',
+      host: 'example.test1',
       'content-type': 'plain/text',
     }
   )

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -145,11 +145,26 @@ test('headersFieldNamesToLowerCase throws on conflicting keys', t => {
     () =>
       common.headersFieldNamesToLowerCase({
         HoSt: 'example.test',
-        HOST: 'example.test',
+        HOST: 'example.tesT',
       }),
     {
       message:
         'Failed to convert header keys to lower case due to field name conflict: host',
+    }
+  )
+  t.end()
+})
+
+test('headersFieldNamesToLowerCase matches if the values are the same', t => {
+  t.deepEqual(
+    common.headersFieldNamesToLowerCase({
+      HoSt: 'example.test',
+      HOST: 'example.test',
+      'Content-typE': 'plain/text',
+    }),
+    {
+      host: 'example.test',
+      'content-type': 'plain/text',
     }
   )
   t.end()


### PR DESCRIPTION
Addresses this issue: https://github.com/nock/nock/issues/1191

When different cases of header have different values, it's ambiguous which one to take. However, if the values are the same, the question of which one to accept is meaningless. This fix prevents nock from throwing an error in a case where it doesn't need to.