### PR TITLE
refactor(router): pass socket to IncomingMessage constructor.

### DIFF
--- a/lib/intercepted_request_router.js
+++ b/lib/intercepted_request_router.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const debug = require('debug')('nock.request_overrider')
-const { EventEmitter } = require('events')
 const {
   IncomingMessage,
   ClientRequest,
@@ -32,8 +31,8 @@ class InterceptedRequestRouter {
     }
     this.interceptors = interceptors
 
-    this.response = new IncomingMessage(new EventEmitter())
     this.socket = new Socket({ proto: options.proto })
+    this.response = new IncomingMessage(this.socket)
     this.playbackStarted = false
     this.requestBodyBuffers = []
 
@@ -63,11 +62,8 @@ class InterceptedRequestRouter {
     // ClientRequest.connection is an alias for ClientRequest.socket
     // https://nodejs.org/api/http.html#http_request_socket
     // https://github.com/nodejs/node/blob/b0f75818f39ed4e6bd80eb7c4010c1daf5823ef7/lib/_http_client.js#L640-L641
-    // IncomingMessage.connection & IncomingMessage.client are aliases for IncomingMessage.socket
-    // https://nodejs.org/api/http.html#http_response_socket
-    // https://github.com/nodejs/node/blob/b0f75818f39ed4e6bd80eb7c4010c1daf5823ef7/lib/_http_incoming.js#L44-L69
     // The same Socket is shared between the request and response to mimic native behavior.
-    req.socket = req.connection = response.socket = response.client = response.connection = socket
+    req.socket = req.connection = socket
 
     propagate(['error', 'timeout'], req.socket, req)
 


### PR DESCRIPTION
Passing the socket from the request to the `IncomingMessage` is what
happens in native Node. Using a dummy `EventEmitter` then tacking the
socket onto the response later is kludge from historical tech-debt that
can now safely be cleaned up.