### PR TITLE
feat: Throw errors for URL paths without leading slashes, which will never match

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -31,13 +31,13 @@ module.exports = class Interceptor {
   constructor(scope, uri, method, requestBody, interceptorOptions) {
     const uriIsStr = typeof uri === 'string'
     // Check for leading slash. Uri can be either a string or a regexp, but
-    // we only need to check strings.
+    // When enabled filteringScope ignores the passed URL entirely so we skip validation.
 
     if (
+      !scope.scopeOptions.filteringScope &&
       uriIsStr &&
       !uri.startsWith('/') &&
-      !uri.startsWith('*') &&
-      !scope.scopeOptions.filteringScope
+      !uri.startsWith('*')
     ) {
       throw Error(
         `Non-wildcard URL path strings must begin with a slash (otherwise they won't match anything) (got: ${uri})`

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -31,8 +31,13 @@ module.exports = class Interceptor {
   constructor(scope, uri, method, requestBody, interceptorOptions) {
     const uriIsStr = typeof uri === 'string'
     // Check for leading slash. Uri can be either a string or a regexp, but
-    // we only need to check strings.
-    if (uriIsStr && /^[^/*]/.test(uri)) {
+    // we only need to check strings./tests/test_allow_unmocked.js
+
+    if (
+      uriIsStr &&
+      /^[^/*]|^\s*$/.test(uri) &&
+      !scope.scopeOptions.filteringScope
+    ) {
       throw Error(
         `Non-wildcard URL path strings must begin with a slash (otherwise they won't match anything) (got: ${uri})`
       )
@@ -224,7 +229,7 @@ module.exports = class Interceptor {
     }
 
     const method = (options.method || 'GET').toUpperCase()
-    let { path = '' } = options
+    let { path = '/' } = options
     let matches
     let matchKey
     const { proto } = options

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -31,7 +31,7 @@ module.exports = class Interceptor {
   constructor(scope, uri, method, requestBody, interceptorOptions) {
     const uriIsStr = typeof uri === 'string'
     // Check for leading slash. Uri can be either a string or a regexp, but
-    // we only need to check strings./tests/test_allow_unmocked.js
+    // we only need to check strings.
 
     if (
       uriIsStr &&

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -35,7 +35,8 @@ module.exports = class Interceptor {
 
     if (
       uriIsStr &&
-      /^[^/*]|^\s*$/.test(uri) &&
+      !uri.startsWith('/') &&
+      !uri.startsWith('*') &&
       !scope.scopeOptions.filteringScope
     ) {
       throw Error(

--- a/package-lock.json
+++ b/package-lock.json
@@ -11449,7 +11449,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11449,8 +11449,7 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "string_decoder": {
           "version": "1.1.1",

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -1335,7 +1335,7 @@ test('data is sent with flushHeaders', t => {
 })
 
 // https://github.com/nock/nock/issues/1730
-test('incorrect path structure is passed to http verb method', t => {
+test('incorrect URL structure is passed to http verb method', t => {
   t.throws(() => nock('http://example.test').get(''), {
     message:
       "Non-wildcard URL path strings must begin with a slash (otherwise they won't match anything) (got: )",
@@ -1344,13 +1344,13 @@ test('incorrect path structure is passed to http verb method', t => {
   t.end()
 })
 
-test('wildcard param passed should not throw error', t => {
-  nock('http://example.test', { filteringScope: () => {} }).get('*')
+test('wildcard param URL should not throw error', t => {
+  nock('http://example.test').get('*')
 
   t.end()
 })
 
-test('incorrect path structure is passed but filteringScope option present should not throw error', t => {
+test('incorrect URL structure is passed but filteringScope option present should not throw error', t => {
   nock('http://example.test', { filteringScope: () => {} }).get('')
 
   t.end()

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -1300,7 +1300,7 @@ test('match domain and path using regexp', t => {
 // https://github.com/nock/nock/issues/1003
 test('correctly parse request without specified path', t => {
   const scope1 = nock('https://example.test')
-    .get('')
+    .get('/')
     .reply(200)
 
   https
@@ -1317,7 +1317,7 @@ test('correctly parse request without specified path', t => {
 
 test('data is sent with flushHeaders', t => {
   const scope1 = nock('https://example.test')
-    .get('')
+    .get('/')
     .reply(200, 'this is data')
 
   https
@@ -1332,6 +1332,16 @@ test('data is sent with flushHeaders', t => {
       })
     })
     .flushHeaders()
+})
+
+// https://github.com/nock/nock/issues/1730
+test('incorrect path structure is passed to http verb method', t => {
+  t.throws(() => nock('http://example.test').get(''), {
+    message:
+      "Non-wildcard URL path strings must begin with a slash (otherwise they won't match anything) (got: )",
+  })
+
+  t.end()
 })
 
 test('no new keys were added to the global namespace', t => {

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -1335,7 +1335,7 @@ test('data is sent with flushHeaders', t => {
 })
 
 // https://github.com/nock/nock/issues/1730
-test('incorrect URL structure is passed to http verb method', t => {
+test('URL path without leading slash throws expected error', t => {
   t.throws(() => nock('http://example.test').get(''), {
     message:
       "Non-wildcard URL path strings must begin with a slash (otherwise they won't match anything) (got: )",
@@ -1350,7 +1350,7 @@ test('wildcard param URL should not throw error', t => {
   t.end()
 })
 
-test('incorrect URL structure is passed but filteringScope option present should not throw error', t => {
+test('with filteringScope, URL path without leading slash does not throw error', t => {
   nock('http://example.test', { filteringScope: () => {} }).get('')
 
   t.end()

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -1344,6 +1344,18 @@ test('incorrect path structure is passed to http verb method', t => {
   t.end()
 })
 
+test('wildcard param passed should not throw error', t => {
+  nock('http://example.test', { filteringScope: () => {} }).get('*')
+
+  t.end()
+})
+
+test('incorrect path structure is passed but filteringScope option present should not throw error', t => {
+  nock('http://example.test', { filteringScope: () => {} }).get('')
+
+  t.end()
+})
+
 test('no new keys were added to the global namespace', t => {
   const leaks = Object.keys(global).filter(
     key => !acceptableGlobalKeys.has(key)


### PR DESCRIPTION
Added a check for filteringScope in the scope options as @paulmelnikow suggested. Also updated the two test which did not have the root path defined as this change will enforce this. To make the compatible with request like { hostname: 'example.test' } changed default value from { path = '' } to { path = '/' } in the interceptor class.

Fix #1730