### PR TITLE
chore: limit published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,5 +77,10 @@
       "tests/"
     ]
   },
-  "license": "MIT"
+  "license": "MIT",
+  "files": [
+    "index.js",
+    "lib",
+    "types/index.d.ts"
+  ]
 }


### PR DESCRIPTION
By default, NPM will pack and publish all files in the directory.
For us, that was 50+ files including lint configs, Github templates,
RFCs, examples, etc.
This change limits the files to just those used by consumers when in the
context of a dependency. Plus what NPM always includes: README, LICENSE,
and CHANGELOG.

