### PR TITLE
docs: Mention strategy of testing common utility code

### DIFF
--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -1,5 +1,16 @@
 'use strict'
 
+// Nock's strategy is to test as much as possible either through the public API
+// or, when that is not possible, through the mock surface.
+//
+// Whenever tests can be written against the public API or the mock surface, do
+// that rather than add tests here.
+//
+// This helps ensure that the code in the common module stays tight, and that
+// it's all necessary for handling the supported use cases. The project enforces
+// 100% test coverage, so when utility code falls out of test, we know it's time
+// to remove it.
+
 const http = require('http')
 const { test } = require('tap')
 const common = require('../lib/common')


### PR DESCRIPTION
This came up in #1748. `test_common` is probably one good place to mention this.

It'd also be nice to write a longer summary of our test strategy and maybe add it to CONTRIBUTING.md, though this seems like a decent start.