### PR TITLE
refactor(test_allow_unmocked_https): Avoid a hardcoded port

### DIFF
--- a/tests/test_allow_unmocked_https.js
+++ b/tests/test_allow_unmocked_https.js
@@ -10,21 +10,23 @@ const got = require('./got_client')
 require('./cleanup_after_each')()
 
 test('Nock with allowUnmocked and an url match', async t => {
-  const options = {
-    key: fs.readFileSync('tests/ssl/ca.key'),
-    cert: fs.readFileSync('tests/ssl/ca.crt'),
-  }
-
-  const server = https
-    .createServer(options, (req, res) => {
+  const server = https.createServer(
+    {
+      key: fs.readFileSync('tests/ssl/ca.key'),
+      cert: fs.readFileSync('tests/ssl/ca.crt'),
+    },
+    (req, res) => {
       res.writeHead(200)
       res.end({ status: 'default' })
-    })
-    .listen(3000)
+    }
+  )
+  t.on('end', () => server.close())
+
+  await new Promise(resolve => server.listen(resolve))
 
   const url = `https://127.0.0.1:${server.address().port}`
 
-  nock(url, { allowUnmocked: true })
+  const scope = nock(url, { allowUnmocked: true })
     .get('/urlMatch')
     .reply(201, JSON.stringify({ status: 'intercepted' }))
 
@@ -32,10 +34,9 @@ test('Nock with allowUnmocked and an url match', async t => {
     rejectUnauthorized: false,
   })
 
-  t.true(statusCode === 201)
-  t.true(JSON.parse(body).status === 'intercepted')
-
-  server.close()
+  t.is(statusCode, 201)
+  t.equal(JSON.parse(body).status, 'intercepted')
+  scope.done()
 })
 
 test('allow unmocked option works with https', t => {


### PR DESCRIPTION
This test was flaky on my machine.

I’ve also refactored to use async and the tap assertions a little more cleanly.