### PR TITLE
refactor: Correct the inverted logic of isUtf8Representable

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ For instance, if a module performs HTTP requests to a CouchDB server or makes HT
 - [Expectations](#expectations)
   - [.isDone()](#isdone)
   - [.cleanAll()](#cleanall)
+  - [.abortPendingRequests()](#abortpendingrequests)
   - [.persist()](#persist)
   - [.pendingMocks()](#pendingmocks)
   - [.activeMocks()](#activemocks)

--- a/lib/common.js
+++ b/lib/common.js
@@ -37,23 +37,20 @@ function normalizeRequestOptions(options) {
 }
 
 /**
- * Returns false if the data contained in buffer can be reconstructed
+ * Returns true if the data contained in buffer can be reconstructed
  * from its utf8 representation.
- *
- * TODO: Reverse the semantics of this method and refactor calling code
- * accordingly. We've inadvertently gotten it flipped.
  *
  * @param  {Object} buffer - a Buffer object
  * @returns {boolean}
  */
 function isUtf8Representable(buffer) {
   if (!Buffer.isBuffer(buffer)) {
-    return false
+    throw Error('Expected a buffer')
   }
 
   const utfEncodedBuffer = buffer.toString('utf8')
   const reconstructedBuffer = Buffer.from(utfEncodedBuffer, 'utf8')
-  return !reconstructedBuffer.equals(buffer)
+  return reconstructedBuffer.equals(buffer)
 }
 
 //  Array where all information about all the overridden requests are held.

--- a/lib/common.js
+++ b/lib/common.js
@@ -44,10 +44,6 @@ function normalizeRequestOptions(options) {
  * @returns {boolean}
  */
 function isUtf8Representable(buffer) {
-  if (!Buffer.isBuffer(buffer)) {
-    throw Error('Expected a buffer')
-  }
-
   const utfEncodedBuffer = buffer.toString('utf8')
   const reconstructedBuffer = Buffer.from(utfEncodedBuffer, 'utf8')
   return reconstructedBuffer.equals(buffer)

--- a/lib/intercepted_request_router.js
+++ b/lib/intercepted_request_router.js
@@ -246,9 +246,11 @@ class InterceptedRequestRouter {
     const requestBodyBuffer = Buffer.concat(this.requestBodyBuffers)
     // When request body is a binary buffer we internally use in its hexadecimal
     // representation.
-    const isUtf8Representable = common.isUtf8Representable(requestBodyBuffer)
+    const requestBodyIsUtf8Representable = common.isUtf8Representable(
+      requestBodyBuffer
+    )
     const requestBodyString = requestBodyBuffer.toString(
-      isUtf8Representable ? 'utf8' : 'hex'
+      requestBodyIsUtf8Representable ? 'utf8' : 'hex'
     )
 
     const matchedInterceptor = interceptors.find(i =>
@@ -263,7 +265,7 @@ class InterceptedRequestRouter {
         socket,
         options,
         requestBodyString,
-        isUtf8Representable,
+        requestBodyIsUtf8Representable,
         response,
         interceptor: matchedInterceptor,
       })

--- a/lib/intercepted_request_router.js
+++ b/lib/intercepted_request_router.js
@@ -246,11 +246,9 @@ class InterceptedRequestRouter {
     const requestBodyBuffer = Buffer.concat(this.requestBodyBuffers)
     // When request body is a binary buffer we internally use in its hexadecimal
     // representation.
-    const isBinaryRequestBodyBuffer = common.isUtf8Representable(
-      requestBodyBuffer
-    )
+    const isUtf8Representable = common.isUtf8Representable(requestBodyBuffer)
     const requestBodyString = requestBodyBuffer.toString(
-      isBinaryRequestBodyBuffer ? 'hex' : 'utf8'
+      isUtf8Representable ? 'utf8' : 'hex'
     )
 
     const matchedInterceptor = interceptors.find(i =>
@@ -265,7 +263,7 @@ class InterceptedRequestRouter {
         socket,
         options,
         requestBodyString,
-        isBinaryRequestBodyBuffer,
+        isUtf8Representable,
         response,
         interceptor: matchedInterceptor,
       })

--- a/lib/match_body.js
+++ b/lib/match_body.js
@@ -11,11 +11,8 @@ module.exports = function matchBody(options, spec, body) {
   }
 
   if (Buffer.isBuffer(spec)) {
-    if (common.isUtf8Representable(spec)) {
-      spec = spec.toString('hex')
-    } else {
-      spec = spec.toString('utf8')
-    }
+    const encoding = common.isUtf8Representable(spec) ? 'utf8' : 'hex'
+    spec = spec.toString(encoding)
   }
 
   const contentType = (

--- a/lib/playback_interceptor.js
+++ b/lib/playback_interceptor.js
@@ -81,7 +81,7 @@ function playbackInterceptor({
   socket,
   options,
   requestBodyString,
-  isBinaryRequestBodyBuffer,
+  isUtf8Representable,
   response,
   interceptor,
 }) {
@@ -179,10 +179,10 @@ function playbackInterceptor({
     // will eventually be JSON stringified.
     let responseBody = interceptor.body
 
-    // If the request was binary then we assume that the response will be binary
-    // as well. In that case we send the response as a Buffer object as that's
-    // what the client will expect.
-    if (isBinaryRequestBodyBuffer && typeof responseBody === 'string') {
+    // If the request was not UTF8-representable then we assume that the
+    // response won't be either. In that case we send the response as a Buffer
+    // object as that's what the client will expect.
+    if (!isUtf8Representable && typeof responseBody === 'string') {
       // Try to create the buffer from the interceptor's body response as hex.
       responseBody = Buffer.from(responseBody, 'hex')
 

--- a/lib/playback_interceptor.js
+++ b/lib/playback_interceptor.js
@@ -81,7 +81,7 @@ function playbackInterceptor({
   socket,
   options,
   requestBodyString,
-  isUtf8Representable,
+  requestBodyIsUtf8Representable,
   response,
   interceptor,
 }) {
@@ -182,7 +182,7 @@ function playbackInterceptor({
     // If the request was not UTF8-representable then we assume that the
     // response won't be either. In that case we send the response as a Buffer
     // object as that's what the client will expect.
-    if (!isUtf8Representable && typeof responseBody === 'string') {
+    if (!requestBodyIsUtf8Representable && typeof responseBody === 'string') {
       // Try to create the buffer from the interceptor's body response as hex.
       responseBody = Buffer.from(responseBody, 'hex')
 

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -21,9 +21,9 @@ function getMethod(options) {
 }
 
 function getBodyFromChunks(chunks, headers) {
-  //  If we have headers and there is content-encoding it means that
-  //  the body shouldn't be merged but instead persisted as an array
-  //  of hex strings so that the responses can be mocked one by one.
+  // If we have headers and there is content-encoding it means that the body
+  // shouldn't be merged but instead persisted as an array of hex strings so
+  // that the response chunks can be mocked one by one.
   if (headers && common.isContentEncoded(headers)) {
     return {
       body: chunks.map(chunk => chunk.toString('hex')),
@@ -32,29 +32,28 @@ function getBodyFromChunks(chunks, headers) {
 
   const mergedBuffer = Buffer.concat(chunks)
 
-  //  The merged buffer can be one of three things:
-  //    1.  A binary buffer which then has to be recorded as a hex string.
-  //    2.  A string buffer which represents a JSON object.
-  //    3.  A string buffer which doesn't represent a JSON object.
-
-  const isBinary = common.isUtf8Representable(mergedBuffer)
-  if (isBinary) {
-    return {
-      body: mergedBuffer.toString('hex'),
-      isBinary: true,
-    }
-  } else {
+  // The merged buffer can be one of three things:
+  // 1. A UTF-8-representable string buffer which represents a JSON object.
+  // 2. A UTF-8-representable buffer which doesn't represent a JSON object.
+  // 3. A non-UTF-8-representable buffer which then has to be recorded as a hex string.
+  const isUtf8Representable = common.isUtf8Representable(mergedBuffer)
+  if (isUtf8Representable) {
     const maybeStringifiedJson = mergedBuffer.toString('utf8')
     try {
       return {
+        isUtf8Representable,
         body: JSON.parse(maybeStringifiedJson),
-        isBinary: false,
       }
     } catch (err) {
       return {
+        isUtf8Representable,
         body: maybeStringifiedJson,
-        isBinary: false,
       }
+    }
+  } else {
+    return {
+      isUtf8Representable,
+      body: mergedBuffer.toString('hex'),
     }
   }
 }
@@ -67,28 +66,26 @@ function generateRequestAndResponseObject({
   dataChunks,
   reqheaders,
 }) {
-  const response = getBodyFromChunks(dataChunks, res.headers)
+  const { body, isUtf8Representable } = getBodyFromChunks(
+    dataChunks,
+    res.headers
+  )
   options.path = req.path
 
-  const nockDef = {
+  return {
     scope: getScope(options),
     method: getMethod(options),
     path: options.path,
+    // Is it deliberate that `getBodyFromChunks()` is called a second time?
     body: getBodyFromChunks(bodyChunks).body,
     status: res.statusCode,
-    response: response.body,
+    response: body,
     rawHeaders: res.rawHeaders,
+    reqheaders: reqheaders || undefined,
+    // When content-encoding is enabled, isUtf8Representable is `undefined`,
+    // so we explicitly check for `false`.
+    responseIsBinary: isUtf8Representable === false,
   }
-
-  if (reqheaders) {
-    nockDef.reqheaders = reqheaders
-  }
-
-  if (response.isBinary) {
-    nockDef.responseIsBinary = true
-  }
-
-  return nockDef
 }
 
 function generateRequestAndResponse({

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -347,11 +347,12 @@ function define(nockDefs) {
       body = undefined
     }
 
-    //  Response is not always JSON as it could be a string or binary data or
-    //  even an array of binary buffers (e.g. when content is encoded)
+    // Response is not always JSON as it could be a string or binary data or
+    // even an array of binary buffers (e.g. when content is encoded).
     let response
     if (!nockDef.response) {
       response = ''
+      // TODO: Rename `responseIsBinary` to `reponseIsUtf8Representable`.
     } else if (nockDef.responseIsBinary) {
       response = Buffer.from(nockDef.response, 'hex')
     } else {

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -104,15 +104,19 @@ test('normalizeRequestOptions', t => {
 })
 
 test('isUtf8Representable works', t => {
-  //  Returns false for non-buffers.
-  t.false(common.isUtf8Representable())
-  t.false(common.isUtf8Representable(''))
+  // Throws for non-buffers.
+  t.throws(() => common.isUtf8Representable(undefined), {
+    message: 'Expected a buffer',
+  })
+  t.throws(() => common.isUtf8Representable(''), {
+    message: 'Expected a buffer',
+  })
 
-  //  Returns true for buffers that aren't utf8 representable.
-  t.true(common.isUtf8Representable(Buffer.from('8001', 'hex')))
+  // Returns false for buffers that aren't utf8 representable.
+  t.false(common.isUtf8Representable(Buffer.from('8001', 'hex')))
 
-  //  Returns false for buffers containing strings.
-  t.false(common.isUtf8Representable(Buffer.from('8001', 'utf8')))
+  // Returns true for buffers containing strings.
+  t.true(common.isUtf8Representable(Buffer.from('8001', 'utf8')))
 
   t.end()
 })

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -104,14 +104,6 @@ test('normalizeRequestOptions', t => {
 })
 
 test('isUtf8Representable works', t => {
-  // Throws for non-buffers.
-  t.throws(() => common.isUtf8Representable(undefined), {
-    message: 'Expected a buffer',
-  })
-  t.throws(() => common.isUtf8Representable(''), {
-    message: 'Expected a buffer',
-  })
-
   // Returns false for buffers that aren't utf8 representable.
   t.false(common.isUtf8Representable(Buffer.from('8001', 'hex')))
 


### PR DESCRIPTION
In 9da400f98aa2d7fe06e813b01403877fed4f2065 – which isn’t linked to the PR for some reason –`isBinaryBuffer()` was given a better name `isUtf8Representable`. The rename should have also inverted the logic, as a so-called “binary buffer” was one that was _not_ representable in UTF-8.

This completes the refactor, replacing all references to “binary” with “utf8-representable”. That is, except the parameter to `nock.define()`, which is still using `responseIsBinary`.

That one would be a breaking change (or backward compatibility would need to be maintained).