### PR TITLE
refactor: Rewrite a gnarly nested loop

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -90,7 +90,7 @@ function isOff() {
 
 function addInterceptor(key, interceptor, scope, scopeOptions, host) {
   if (!(key in allInterceptors)) {
-    allInterceptors[key] = { key, scopes: [] }
+    allInterceptors[key] = { key, interceptors: [] }
   }
   interceptor.__nock_scope = scope
 
@@ -103,7 +103,7 @@ function addInterceptor(key, interceptor, scope, scopeOptions, host) {
 
   if (scopeOptions.allowUnmocked) allInterceptors[key].allowUnmocked = true
 
-  allInterceptors[key].scopes.push(interceptor)
+  allInterceptors[key].interceptors.push(interceptor)
 }
 
 function remove(interceptor) {
@@ -113,7 +113,7 @@ function remove(interceptor) {
 
   const { basePath } = interceptor
   const interceptors =
-    (allInterceptors[basePath] && allInterceptors[basePath].scopes) || []
+    (allInterceptors[basePath] && allInterceptors[basePath].interceptors) || []
 
   // TODO: There is a clearer way to write that we want to delete the first
   // matching instance. I'm also not sure why we couldn't delete _all_
@@ -125,7 +125,7 @@ function remove(interceptor) {
 
 function removeAll() {
   Object.keys(allInterceptors).forEach(function(key) {
-    allInterceptors[key].scopes.forEach(function(interceptor) {
+    allInterceptors[key].interceptors.forEach(function(interceptor) {
       interceptor.scope.keyedInterceptors = {}
     })
   })
@@ -146,32 +146,29 @@ function interceptorsFor(options) {
 
   debug('filtering interceptors for basepath', basePath)
 
-  //  First try to use filteringScope if any of the interceptors has it defined.
-  let matchingInterceptor
-  _.each(allInterceptors, function(interceptor) {
-    _.each(interceptor.scopes, function(scope) {
-      const { filteringScope } = scope.__nock_scopeOptions
+  // First try to use filteringScope if any of the interceptors has it defined.
+  for (const { key, interceptors, allowUnmocked } of Object.values(
+    allInterceptors
+  )) {
+    for (const interceptor of interceptors) {
+      const { filteringScope } = interceptor.__nock_scopeOptions
 
-      //  If scope filtering function is defined and returns a truthy value
-      //  then we have to treat this as a match.
+      // If scope filtering function is defined and returns a truthy value then
+      // we have to treat this as a match.
       if (filteringScope && filteringScope(basePath)) {
         debug('found matching scope interceptor')
 
-        //  Keep the filtered scope (its key) to signal the rest of the module
-        //  that this wasn't an exact but filtered match.
-        scope.__nock_filteredScope = scope.__nock_scopeKey
-        matchingInterceptor = interceptor.scopes
-        //  Break out of _.each for scopes.
-        return false
+        // Keep the filtered scope (its key) to signal the rest of the module
+        // that this wasn't an exact but filtered match.
+        interceptor.__nock_filteredScope = interceptor.__nock_scopeKey
+        return interceptors
       }
-    })
+    }
 
-    if (
-      !matchingInterceptor &&
-      common.matchStringOrRegexp(basePath, interceptor.key)
-    ) {
-      if (interceptor.scopes.length === 0 && interceptor.allowUnmocked) {
-        matchingInterceptor = [
+    if (common.matchStringOrRegexp(basePath, key)) {
+      if (allowUnmocked && interceptors.length === 0) {
+        debug('matched base path with allowUnmocked (no matching interceptors)')
+        return [
           {
             options: { allowUnmocked: true },
             matchAddress() {
@@ -180,18 +177,17 @@ function interceptorsFor(options) {
           },
         ]
       } else {
-        matchingInterceptor = interceptor.scopes
+        debug(
+          `matched base path (${interceptors.length} interceptor${
+            interceptors.length > 1 ? 's' : ''
+          })`
+        )
+        return interceptors
       }
-      // false to short circuit the .each
-      return false
     }
+  }
 
-    //  Returning falsy value here (which will happen if we have found our matching interceptor)
-    //  will break out of _.each for all interceptors.
-    return !matchingInterceptor
-  })
-
-  return matchingInterceptor
+  return undefined
 }
 
 function removeInterceptor(options) {
@@ -211,11 +207,14 @@ function removeInterceptor(options) {
     key = `${method} ${baseUrl}${options.path || '/'}`
   }
 
-  if (allInterceptors[baseUrl] && allInterceptors[baseUrl].scopes.length > 0) {
-    for (let i = 0; i < allInterceptors[baseUrl].scopes.length; i++) {
-      const interceptor = allInterceptors[baseUrl].scopes[i]
+  if (
+    allInterceptors[baseUrl] &&
+    allInterceptors[baseUrl].interceptors.length > 0
+  ) {
+    for (let i = 0; i < allInterceptors[baseUrl].interceptors.length; i++) {
+      const interceptor = allInterceptors[baseUrl].interceptors[i]
       if (interceptor._key === key) {
-        allInterceptors[baseUrl].scopes.splice(i, 1)
+        allInterceptors[baseUrl].interceptors.splice(i, 1)
         interceptor.scope.remove(key, interceptor)
         break
       }
@@ -337,7 +336,9 @@ function isActive() {
 }
 
 function interceptorScopes() {
-  const nestedInterceptors = Object.values(allInterceptors).map(i => i.scopes)
+  const nestedInterceptors = Object.values(allInterceptors).map(
+    i => i.interceptors
+  )
   return [].concat(...nestedInterceptors).map(i => i.scope)
 }
 


### PR DESCRIPTION
This also renames the `scopes` property to `interceptors`, which is more appropriate since it holds instances of `Interceptor`.