### PR TITLE
refactor: Convert a few files to the Mocha DSL

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "test": "npm run -s unit",
     "posttest": "npm run -s prettier:check",
     "coverage": "tap --coverage-report=html && open coverage/lcov-report/index.html",
-    "mocha": "nyc mocha $(grep -lr '^it(' tests)",
+    "mocha": "nyc mocha $(grep -lr '^\\s*it(' tests)",
     "lint": "eslint \"**/*.js\"",
     "prettier": "prettier --write \"**/*.@(js|json|md|ts|yml)\"",
     "prettier:check": "prettier --check \"**/*.@(js|json|md|ts|yml)\"",

--- a/tests/test_request_overrider.js
+++ b/tests/test_request_overrider.js
@@ -570,7 +570,7 @@ test("mocked requests have 'method' property", t => {
 })
 
 // https://github.com/nock/nock/issues/1493
-test("response have 'complete' property and it's true after end", t => {
+test("response has 'complete' property and it's true after end", t => {
   const scope = nock('http://example.test')
     .get('/')
     .reply(200, 'Hello World!')

--- a/tests/test_scope.js
+++ b/tests/test_scope.js
@@ -8,6 +8,8 @@ const Interceptor = require('../lib/interceptor')
 const nock = require('..')
 const got = require('./got_client')
 
+require('./setup')
+
 it('scope exposes interceptors', () => {
   const scopes = nock.load(path.join(__dirname, 'fixtures', 'goodRequest.json'))
 

--- a/tests/test_scope.js
+++ b/tests/test_scope.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const path = require('path')
-const { test } = require('tap')
 const { expect } = require('chai')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire').noPreserveCache()
@@ -9,10 +8,7 @@ const Interceptor = require('../lib/interceptor')
 const nock = require('..')
 const got = require('./got_client')
 
-require('./cleanup_after_each')()
-require('./setup')
-
-test('scope exposes interceptors', t => {
+it('scope exposes interceptors', () => {
   const scopes = nock.load(path.join(__dirname, 'fixtures', 'goodRequest.json'))
 
   expect(scopes).to.be.an.instanceOf(Array)
@@ -24,150 +20,144 @@ test('scope exposes interceptors', t => {
       interceptor.delayConnection(100)
     })
   })
-
-  t.end()
 })
 
-test('scope#remove() works', t => {
-  const scope = nock('http://example.test')
-    .get('/')
-    .reply(200)
-  const key = 'GET http://example.test:80/'
+describe('scope#remove()', () => {
+  it('scope#remove() works', () => {
+    const scope = nock('http://example.test')
+      .get('/')
+      .reply(200)
+    const key = 'GET http://example.test:80/'
 
-  // Confidence check.
-  expect(scope.activeMocks()).to.deep.equal([key])
+    // Confidence check.
+    expect(scope.activeMocks()).to.deep.equal([key])
 
-  // Act.
-  scope.remove(key, scope.interceptors[0])
+    // Act.
+    scope.remove(key, scope.interceptors[0])
 
-  // Assert.
-  expect(scope.activeMocks()).to.deep.equal([])
+    // Assert.
+    expect(scope.activeMocks()).to.deep.equal([])
+  })
 
-  t.end()
+  it('scope#remove() is a no-op on a persisted mock', () => {
+    const scope = nock('http://example.test')
+      .persist()
+      .get('/')
+      .reply(200)
+    const key = 'GET http://example.test:80/'
+
+    // Confidence check.
+    expect(scope.activeMocks()).to.deep.equal([key])
+
+    // Act.
+    scope.remove(key, scope.interceptors[0])
+
+    // Assert.
+    expect(scope.activeMocks()).to.deep.equal([key])
+  })
+
+  it('scope#remove() is a no-op on a nonexistent key', () => {
+    const scope = nock('http://example.test')
+      .get('/')
+      .reply(200)
+    const key = 'GET http://example.test:80/'
+
+    // Confidence check.
+    expect(scope.activeMocks()).to.deep.equal([key])
+
+    // Act.
+    scope.remove('GET http://bogus.test:80/', scope.interceptors[0])
+
+    // Assert.
+    expect(scope.activeMocks()).to.deep.equal([key])
+  })
 })
 
-test('scope#remove() is a no-op on a persisted mock', t => {
-  const scope = nock('http://example.test')
-    .persist()
-    .get('/')
-    .reply(200)
-  const key = 'GET http://example.test:80/'
-
-  // Confidence check.
-  expect(scope.activeMocks()).to.deep.equal([key])
-
-  // Act.
-  scope.remove(key, scope.interceptors[0])
-
-  // Assert.
-  expect(scope.activeMocks()).to.deep.equal([key])
-
-  t.end()
-})
-
-test('scope#remove() is a no-op on a nonexistent key', t => {
-  const scope = nock('http://example.test')
-    .get('/')
-    .reply(200)
-  const key = 'GET http://example.test:80/'
-
-  // Confidence check.
-  expect(scope.activeMocks()).to.deep.equal([key])
-
-  // Act.
-  scope.remove('GET http://bogus.test:80/', scope.interceptors[0])
-
-  // Assert.
-  expect(scope.activeMocks()).to.deep.equal([key])
-
-  t.end()
-})
-
-test('loadDefs throws expected when fs is not available', t => {
+it('loadDefs throws expected when fs is not available', () => {
   const { loadDefs } = proxyquire('../lib/scope', { fs: null })
 
   expect(() => loadDefs()).to.throw(Error, 'No fs')
-
-  t.end()
 })
 
-test('filter path with function', async t => {
-  const scope = nock('http://example.test')
-    .filteringPath(() => '/?a=2&b=1')
-    .get('/?a=2&b=1')
-    .reply()
+describe('filteringPath()', function() {
+  it('filter path with function', async function() {
+    const scope = nock('http://example.test')
+      .filteringPath(() => '/?a=2&b=1')
+      .get('/?a=2&b=1')
+      .reply()
 
-  const { statusCode } = await got('http://example.test/', {
-    query: { a: '1', b: '2' },
-  })
-
-  expect(statusCode).to.equal(200)
-  scope.done()
-})
-
-test('filter path with regexp', async t => {
-  const scope = nock('http://example.test')
-    .filteringPath(/\d/g, '3')
-    .get('/?a=3&b=3')
-    .reply()
-
-  const { statusCode } = await got('http://example.test/', {
-    query: { a: '1', b: '2' },
-  })
-
-  expect(statusCode).to.equal(200)
-  scope.done()
-})
-
-test('filteringPath with invalid argument throws expected', t => {
-  expect(() => nock('http://example.test').filteringPath('abc123')).to.throw(
-    Error,
-    'Invalid arguments: filtering path should be a function or a regular expression'
-  )
-  t.end()
-})
-
-test('filter body with function', async t => {
-  const onFilteringRequestBody = sinon.spy()
-
-  const scope = nock('http://example.test')
-    .filteringRequestBody(body => {
-      onFilteringRequestBody()
-      expect(body).to.equal('mamma mia')
-      return 'mamma tua'
+    const { statusCode } = await got('http://example.test/', {
+      query: { a: '1', b: '2' },
     })
-    .post('/', 'mamma tua')
-    .reply()
 
-  const { statusCode } = await got('http://example.test/', {
-    body: 'mamma mia',
+    expect(statusCode).to.equal(200)
+    scope.done()
   })
 
-  expect(statusCode).to.equal(200)
-  expect(onFilteringRequestBody).to.have.been.calledOnce()
-  scope.done()
-})
+  it('filter path with regexp', async () => {
+    const scope = nock('http://example.test')
+      .filteringPath(/\d/g, '3')
+      .get('/?a=3&b=3')
+      .reply()
 
-test('filter body with regexp', async t => {
-  const scope = nock('http://example.test')
-    .filteringRequestBody(/mia/, 'nostra')
-    .post('/', 'mamma nostra')
-    .reply(200, 'Hello World!')
+    const { statusCode } = await got('http://example.test/', {
+      query: { a: '1', b: '2' },
+    })
 
-  const { statusCode } = await got('http://example.test/', {
-    body: 'mamma mia',
+    expect(statusCode).to.equal(200)
+    scope.done()
   })
 
-  expect(statusCode).to.equal(200)
-  scope.done()
+  it('filteringPath with invalid argument throws expected', () => {
+    expect(() => nock('http://example.test').filteringPath('abc123')).to.throw(
+      Error,
+      'Invalid arguments: filtering path should be a function or a regular expression'
+    )
+  })
 })
 
-test('filteringRequestBody with invalid argument throws expected', t => {
-  expect(() =>
-    nock('http://example.test').filteringRequestBody('abc123')
-  ).to.throw(
-    Error,
-    'Invalid arguments: filtering request body should be a function or a regular expression'
-  )
-  t.end()
+describe('filteringRequestBody()', () => {
+  it('filter body with function', async () => {
+    const onFilteringRequestBody = sinon.spy()
+
+    const scope = nock('http://example.test')
+      .filteringRequestBody(body => {
+        onFilteringRequestBody()
+        expect(body).to.equal('mamma mia')
+        return 'mamma tua'
+      })
+      .post('/', 'mamma tua')
+      .reply()
+
+    const { statusCode } = await got('http://example.test/', {
+      body: 'mamma mia',
+    })
+
+    expect(statusCode).to.equal(200)
+    expect(onFilteringRequestBody).to.have.been.calledOnce()
+    scope.done()
+  })
+
+  it('filter body with regexp', async () => {
+    const scope = nock('http://example.test')
+      .filteringRequestBody(/mia/, 'nostra')
+      .post('/', 'mamma nostra')
+      .reply(200, 'Hello World!')
+
+    const { statusCode } = await got('http://example.test/', {
+      body: 'mamma mia',
+    })
+
+    expect(statusCode).to.equal(200)
+    scope.done()
+  })
+
+  it('filteringRequestBody with invalid argument throws expected', () => {
+    expect(() =>
+      nock('http://example.test').filteringRequestBody('abc123')
+    ).to.throw(
+      Error,
+      'Invalid arguments: filtering request body should be a function or a regular expression'
+    )
+  })
 })

--- a/tests/test_socketdelay.js
+++ b/tests/test_socketdelay.js
@@ -1,119 +1,118 @@
 'use strict'
 
 const http = require('http')
-const { test } = require('tap')
 const { expect } = require('chai')
 const sinon = require('sinon')
 const nock = require('..')
 
-require('./cleanup_after_each')()
-require('./setup')
+describe('socketDelay()', () => {
+  it('socketDelay', done => {
+    nock('http://example.test')
+      .get('/')
+      .socketDelay(200)
+      .reply(200, '<html></html>')
 
-test('socketDelay', t => {
-  nock('http://example.test')
-    .get('/')
-    .socketDelay(200)
-    .reply(200, '<html></html>')
+    const req = http.get('http://example.test')
 
-  const req = http.get('http://example.test')
+    const onTimeout = sinon.spy()
 
-  const onTimeout = sinon.spy()
+    req.on('socket', socket => {
+      if (!socket.connecting) {
+        req.setTimeout(100, onTimeout)
+        return
+      }
 
-  req.on('socket', socket => {
-    if (!socket.connecting) {
-      req.setTimeout(100, onTimeout)
-      return
+      socket.on('connect', () => {
+        req.setTimeout(100, onTimeout)
+      })
+    })
+
+    req.on('response', () => {
+      expect(onTimeout).to.have.been.calledOnce()
+      done()
+    })
+  })
+
+  it('emits a timeout', done => {
+    nock('http://example.test')
+      .get('/')
+      .socketDelay(10000)
+      .reply(200, 'OK')
+
+    const onEnd = sinon.spy()
+
+    const req = http.request('http://example.test', res => {
+      res.setEncoding('utf8')
+      res.once('end', onEnd)
+    })
+
+    req.setTimeout(5000, () => {
+      expect(onEnd).not.to.have.been.called()
+      done()
+    })
+
+    req.end()
+  })
+
+  it('emits a timeout if not idle for long enough', done => {
+    const responseText = 'okeydoke!'
+    const scope = nock('http://example.test')
+      .get('/')
+      .socketDelay(10000)
+      .reply(200, responseText)
+
+    const req = http.request('http://example.test', res => {
+      res.setEncoding('utf8')
+
+      let body = ''
+
+      res.on('data', chunk => {
+        body += chunk
+      })
+
+      res.once('end', () => {
+        expect(body).to.equal(responseText)
+        done()
+      })
+    })
+
+    req.setTimeout(60000, () => {
+      expect.fail('socket timed out unexpectedly')
+    })
+
+    req.end()
+    scope.done()
+  })
+})
+
+describe('Socket#setTimeout()', () => {
+  it('adds callback as a one-time listener for parity with a real socket', done => {
+    nock('http://example.test')
+      .get('/')
+      .socketDelay(100)
+      .reply(200, '<html></html>')
+
+    const onTimeout = () => {
+      done()
     }
 
-    socket.on('connect', () => {
-      req.setTimeout(100, onTimeout)
+    http.get('http://example.test').on('socket', socket => {
+      socket.setTimeout(50, onTimeout)
     })
   })
 
-  req.on('response', () => {
-    expect(onTimeout).to.have.been.calledOnce()
-    t.end()
-  })
-})
+  it('can be called without a callback', done => {
+    nock('http://example.test')
+      .get('/')
+      .socketDelay(100)
+      .reply()
 
-test('calling socketDelay will emit a timeout', t => {
-  nock('http://example.test')
-    .get('/')
-    .socketDelay(10000)
-    .reply(200, 'OK')
+    http.get('http://example.test').on('socket', socket => {
+      socket.setTimeout(50)
 
-  const onEnd = sinon.spy()
-
-  const req = http.request('http://example.test', res => {
-    res.setEncoding('utf8')
-    res.once('end', onEnd)
-  })
-
-  req.setTimeout(5000, () => {
-    expect(onEnd).not.to.have.been.called()
-    t.end()
-  })
-
-  req.end()
-})
-
-test('calling socketDelay not emit a timeout if not idle for long enough', t => {
-  const responseText = 'okeydoke!'
-  const scope = nock('http://example.test')
-    .get('/')
-    .socketDelay(10000)
-    .reply(200, responseText)
-
-  const req = http.request('http://example.test', res => {
-    res.setEncoding('utf8')
-
-    let body = ''
-
-    res.on('data', chunk => {
-      body += chunk
-    })
-
-    res.once('end', () => {
-      expect(body).to.equal(responseText)
-      t.end()
-    })
-  })
-
-  req.setTimeout(60000, () => {
-    expect.fail('socket timed out unexpectedly')
-    t.end()
-  })
-
-  req.end()
-  scope.done()
-})
-
-test('Socket#setTimeout adds callback as a one-time listener for parity with a real socket', t => {
-  nock('http://example.test')
-    .get('/')
-    .socketDelay(100)
-    .reply(200, '<html></html>')
-
-  const onTimeout = () => {
-    t.end()
-  }
-
-  http.get('http://example.test').on('socket', socket => {
-    socket.setTimeout(50, onTimeout)
-  })
-})
-
-test('Socket#setTimeout can be called without a callback', t => {
-  nock('http://example.test')
-    .get('/')
-    .socketDelay(100)
-    .reply()
-
-  http.get('http://example.test').on('socket', socket => {
-    socket.setTimeout(50)
-
-    socket.on('timeout', () => {
-      t.end()
+      socket.on('timeout', () => {
+        done()
+      })
     })
   })
 })

--- a/tests/test_socketdelay.js
+++ b/tests/test_socketdelay.js
@@ -5,6 +5,8 @@ const { expect } = require('chai')
 const sinon = require('sinon')
 const nock = require('..')
 
+require('./setup')
+
 describe('socketDelay()', () => {
   it('socketDelay', done => {
     nock('http://example.test')

--- a/tests/test_stream.js
+++ b/tests/test_stream.js
@@ -10,6 +10,8 @@ const sinon = require('sinon')
 const nock = require('..')
 const got = require('./got_client')
 
+require('./setup')
+
 const textFile = path.join(__dirname, '..', 'assets', 'reply_file_1.txt')
 
 it('reply with file and pipe response', done => {

--- a/tests/test_stream.js
+++ b/tests/test_stream.js
@@ -5,25 +5,17 @@ const http = require('http')
 const path = require('path')
 const stream = require('stream')
 const util = require('util')
-const { test } = require('tap')
 const { expect } = require('chai')
 const sinon = require('sinon')
 const nock = require('..')
 const got = require('./got_client')
 
-require('./cleanup_after_each')()
-require('./setup')
-
 const textFile = path.join(__dirname, '..', 'assets', 'reply_file_1.txt')
 
-test('reply with file and pipe response', t => {
+it('reply with file and pipe response', done => {
   const scope = nock('http://example.test')
     .get('/')
     .replyWithFile(200, textFile)
-
-  t.once('end', () => {
-    scope.done()
-  })
 
   let text = ''
   const fakeStream = new stream.Stream()
@@ -33,14 +25,15 @@ test('reply with file and pipe response', t => {
   }
   fakeStream.end = () => {
     expect(text).to.equal('Hello from the file!')
-    t.end()
+    scope.done()
+    done()
   }
 
   got.stream('http://example.test/').pipe(fakeStream)
 })
 
 // TODO Convert to async / got.
-test('pause response after data', t => {
+it('pause response after data', done => {
   const response = new stream.PassThrough()
   const scope = nock('http://example.test')
     .get('/')
@@ -66,7 +59,7 @@ test('pause response after data', t => {
       res.on('end', () => {
         expect(didTimeout).to.have.been.calledOnce()
         scope.done()
-        t.end()
+        done()
       })
     }
   )
@@ -80,7 +73,7 @@ test('pause response after data', t => {
 })
 
 // https://github.com/nock/nock/issues/1493
-test("response have 'complete' property and it's true after end", t => {
+it("response has 'complete' property and it's true after end", done => {
   const response = new stream.PassThrough()
   const scope = nock('http://example.test')
     .get('/')
@@ -102,7 +95,7 @@ test("response have 'complete' property and it's true after end", t => {
         expect(onData).to.have.been.called()
         expect(res.complete).to.be.true()
         scope.done()
-        t.end()
+        done()
       })
     }
   )
@@ -115,7 +108,7 @@ test("response have 'complete' property and it's true after end", t => {
 })
 
 // TODO Convert to async / got.
-test('response pipe', t => {
+it('response pipe', done => {
   const dest = (() => {
     function Constructor() {
       events.EventEmitter.call(this)
@@ -162,7 +155,7 @@ test('response pipe', t => {
         scope.done()
         expect(onPipeEvent).to.have.been.calledOnce()
         expect(dest.buffer.toString()).to.equal('nobody')
-        t.end()
+        done()
       })
 
       res.pipe(dest)
@@ -171,7 +164,7 @@ test('response pipe', t => {
 })
 
 // TODO Convert to async / got.
-test('response pipe without implicit end', t => {
+it('response pipe without implicit end', done => {
   const dest = (() => {
     function Constructor() {
       events.EventEmitter.call(this)
@@ -214,7 +207,7 @@ test('response pipe without implicit end', t => {
 
       res.on('end', () => {
         scope.done()
-        t.end()
+        done()
       })
 
       res.pipe(
@@ -225,7 +218,7 @@ test('response pipe without implicit end', t => {
   )
 })
 
-test('response is streams2 compatible', t => {
+it('response is streams2 compatible', done => {
   const responseText = 'streams2 streams2 streams2'
   nock('http://example.test')
     .get('/somepath')
@@ -249,52 +242,48 @@ test('response is streams2 compatible', t => {
 
         res.once('end', function() {
           expect(body).to.equal(responseText)
-          t.end()
+          done()
         })
       }
     )
     .end()
 })
 
-test(
-  'when a stream is used for the response body, it will not be read until after the response event',
-  { skip: !stream.Readable },
-  t => {
-    let responseEvent = false
-    const responseText = 'Hello World\n'
+it('when a stream is used for the response body, it will not be read until after the response event', done => {
+  let responseEvent = false
+  const responseText = 'Hello World\n'
 
-    class SimpleStream extends stream.Readable {
-      _read() {
-        expect(responseEvent).to.be.true()
-        this.push(responseText)
-        this.push(null)
-      }
+  class SimpleStream extends stream.Readable {
+    _read() {
+      expect(responseEvent).to.be.true()
+      this.push(responseText)
+      this.push(null)
     }
-
-    nock('http://localhost')
-      .get('/')
-      .reply(201, () => new SimpleStream())
-
-    http.get('http://localhost/', res => {
-      responseEvent = true
-      res.setEncoding('utf8')
-
-      let body = ''
-      expect(res.statusCode).to.equal(201)
-
-      res.on('data', function(chunk) {
-        body += chunk
-      })
-
-      res.once('end', function() {
-        expect(body).to.equal(responseText)
-        t.end()
-      })
-    })
   }
-)
 
-test('response readable pull stream works as expected', t => {
+  nock('http://localhost')
+    .get('/')
+    .reply(201, () => new SimpleStream())
+
+  http.get('http://localhost/', res => {
+    responseEvent = true
+    res.setEncoding('utf8')
+
+    let body = ''
+    expect(res.statusCode).to.equal(201)
+
+    res.on('data', function(chunk) {
+      body += chunk
+    })
+
+    res.once('end', function() {
+      expect(body).to.equal(responseText)
+      done()
+    })
+  })
+})
+
+it('response readable pull stream works as expected', done => {
   nock('http://example.test')
     .get('/ssstream')
     .reply(200, 'this is the response body yeah')
@@ -317,7 +306,7 @@ test('response readable pull stream works as expected', t => {
         if (chunk === null && !ended) {
           ended = true
           expect(responseBody).to.equal('this is the response body yeah')
-          t.end()
+          done()
         }
       })
     }
@@ -326,7 +315,7 @@ test('response readable pull stream works as expected', t => {
   req.end()
 })
 
-test('error events on reply streams proxy to the response', async t => {
+it('error events on reply streams proxy to the response', done => {
   // This test could probably be written to use got, however, that lib has a lot
   // of built in error handling and this test would get convoluted.
 
@@ -344,7 +333,7 @@ test('error events on reply streams proxy to the response', async t => {
     res => {
       res.on('error', err => {
         expect(err).to.equal('oh no!')
-        t.done()
+        done()
       })
     }
   )

--- a/tests/test_url_encoding.js
+++ b/tests/test_url_encoding.js
@@ -4,6 +4,8 @@ const { expect } = require('chai')
 const nock = require('..')
 const got = require('./got_client')
 
+require('./setup')
+
 it('url encoding', async () => {
   const scope = nock('http://example.test')
     .get('/key?a=[1]')

--- a/tests/test_url_encoding.js
+++ b/tests/test_url_encoding.js
@@ -1,13 +1,10 @@
 'use strict'
 
-const { test } = require('tap')
 const { expect } = require('chai')
 const nock = require('..')
 const got = require('./got_client')
 
-require('./cleanup_after_each')()
-
-test('url encoding', async t => {
+it('url encoding', async () => {
   const scope = nock('http://example.test')
     .get('/key?a=[1]')
     .reply(200)


### PR DESCRIPTION
This adds a few `describe()` blocks. I didn't put everything into `describe()`s, only the tests I was able to logically group.