### PR TITLE
test: Get all tests passing in Mocha too, and run in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,10 @@ jobs:
       node_js: 12
     - node_js: 10
       # Avoid running lint and prettier again.
-      script: npm run --silent unit
+      script: npm run --silent unit && npm run mocha
     - node_js: 8
       # Avoid running lint and prettier again.
-      script: npm run --silent unit
+      script: npm run --silent unit && npm run mocha
     - stage: release
       node_js: lts/*
       env: semantic-release

--- a/tests/test_back.js
+++ b/tests/test_back.js
@@ -3,7 +3,7 @@
 const http = require('http')
 const fs = require('fs')
 const { beforeEach, test } = require('tap')
-const proxyquire = require('proxyquire').noPreserveCache()
+const proxyquire = require('proxyquire').preserveCache()
 const nock = require('..')
 
 require('./cleanup_after_each')()

--- a/tests/test_reply_with_file.js
+++ b/tests/test_reply_with_file.js
@@ -4,7 +4,7 @@
 
 const path = require('path')
 const { expect } = require('chai')
-const proxyquire = require('proxyquire').noPreserveCache()
+const proxyquire = require('proxyquire').preserveCache()
 const nock = require('..')
 const got = require('./got_client')
 
@@ -43,7 +43,9 @@ describe('`.replyWithFile()', () => {
 
   describe('with no fs', () => {
     const { Scope } = proxyquire('../lib/scope', {
-      './interceptor': proxyquire('../lib/interceptor', { fs: null }),
+      './interceptor': proxyquire('../lib/interceptor', {
+        fs: null,
+      }),
     })
 
     it('throws the expected error', () => {

--- a/tests/test_scope.js
+++ b/tests/test_scope.js
@@ -3,7 +3,7 @@
 const path = require('path')
 const { expect } = require('chai')
 const sinon = require('sinon')
-const proxyquire = require('proxyquire').noPreserveCache()
+const proxyquire = require('proxyquire').preserveCache()
 const Interceptor = require('../lib/interceptor')
 const nock = require('..')
 const got = require('./got_client')


### PR DESCRIPTION
I noticed a handful of the tests would fail when I ran them in Mocha locally (though not in Tap). After banging my head against it for a while I traced it to proxyquire. I'm not completely sure that changing `.noPreserveCache()` to `.preserveCache()` is the correct thing to do, but it does seem to get all the tests passing in both runners.