### PR TITLE
refactor: Rewrite test_query using got, async, and chai

### DIFF
--- a/tests/test_query.js
+++ b/tests/test_query.js
@@ -1,37 +1,50 @@
 'use strict'
 
-const mikealRequest = require('request')
 const { test } = require('tap')
+const { expect } = require('chai')
+const sinon = require('sinon')
 const url = require('url')
 const nock = require('..')
 const got = require('./got_client')
+const assertRejects = require('assert-rejects')
 
 require('./cleanup_after_each')()
+require('./setup')
 
-test('query() matches a query string of the same name=value', t => {
-  nock('http://example.test')
+test('query() matches a query string of the same name=value', async t => {
+  const scope = nock('http://example.test')
     .get('/')
     .query({ foo: 'bar' })
-    .reply(200)
+    .reply()
 
-  mikealRequest('http://example.test/?foo=bar', function(err, res) {
-    if (err) throw err
-    t.equal(res.statusCode, 200)
-    t.end()
-  })
+  const { statusCode } = await got('http://example.test/?foo=bar')
+
+  expect(statusCode).to.equal(200)
+  scope.done()
 })
 
-test('query() matches multiple query strings of the same name=value', t => {
-  nock('http://example.test')
+test('query() matches multiple query strings of the same name=value', async t => {
+  const scope = nock('http://example.test')
     .get('/')
     .query({ foo: 'bar', baz: 'foz' })
-    .reply(200)
+    .reply()
 
-  mikealRequest('http://example.test/?foo=bar&baz=foz', function(err, res) {
-    if (err) throw err
-    t.equal(res.statusCode, 200)
-    t.end()
-  })
+  const { statusCode } = await got('http://example.test/?foo=bar&baz=foz')
+
+  expect(statusCode).to.equal(200)
+  scope.done()
+})
+
+test('query() matches multiple query strings of the same name=value regardless of order', async t => {
+  const scope = nock('http://example.test')
+    .get('/')
+    .query({ foo: 'bar', baz: 'foz' })
+    .reply()
+
+  const { statusCode } = await got('http://example.test/?baz=foz&foo=bar')
+
+  expect(statusCode).to.equal(200)
+  scope.done()
 })
 
 test('literal query params have the same behavior as calling query() directly', async t => {
@@ -41,74 +54,56 @@ test('literal query params have the same behavior as calling query() directly', 
 
   const { statusCode } = await got('http://example.test/foo?bar=baz')
 
-  t.is(statusCode, 200)
+  expect(statusCode).to.equal(200)
   scope.done()
 })
 
-test('query() matches multiple query strings of the same name=value regardless of order', t => {
-  nock('http://example.test')
-    .get('/')
-    .query({ foo: 'bar', baz: 'foz' })
-    .reply(200)
-
-  mikealRequest('http://example.test/?baz=foz&foo=bar', function(err, res) {
-    if (err) throw err
-    t.equal(res.statusCode, 200)
-    t.end()
-  })
-})
-
-test('query() matches query values regardless of their type of declaration', t => {
-  nock('http://example.test')
+test('query() matches query values regardless of their type of declaration', async t => {
+  const scope = nock('http://example.test')
     .get('/')
     .query({ num: 1, bool: true, empty: null, str: 'fou' })
-    .reply(200)
+    .reply()
 
-  mikealRequest('http://example.test/?num=1&bool=true&empty=&str=fou', function(
-    err,
-    res
-  ) {
-    if (err) throw err
-    t.equal(res.statusCode, 200)
-    t.end()
-  })
+  const { statusCode } = await got(
+    'http://example.test/?num=1&bool=true&empty=&str=fou'
+  )
+
+  expect(statusCode).to.equal(200)
+  scope.done()
 })
 
-test("query() doesn't match query values of requests without query string", t => {
-  nock('http://example.test')
+test("query() doesn't match query values of requests without query string", async t => {
+  const scope1 = nock('http://example.test')
     .get('/')
     .query({ num: 1, bool: true, empty: null, str: 'fou' })
     .reply(200, 'scope1')
 
-  nock('http://example.test')
+  const scope2 = nock('http://example.test')
     .get('/')
     .reply(200, 'scope2')
 
-  mikealRequest('http://example.test', function(err, res) {
-    if (err) throw err
-    t.equal(res.statusCode, 200)
-    t.equal(res.body, 'scope2')
-    t.end()
-  })
+  const { statusCode, body } = await got('http://example.test/')
+
+  expect(statusCode).to.equal(200)
+  expect(body).to.equal('scope2')
+  scope2.done()
+  expect(scope1.isDone()).to.be.false()
 })
 
-test('query() matches a query string using regexp', t => {
-  nock('http://example.test')
+test('query() matches a query string using regexp', async t => {
+  const scope = nock('http://example.test')
     .get('/')
     .query({ foo: /.*/ })
-    .reply(200)
+    .reply()
 
-  mikealRequest('http://example.test/?foo=bar', function(err, res) {
-    if (err) throw err
-    t.equal(res.statusCode, 200)
-    t.end()
-  })
+  const { statusCode } = await got('http://example.test/?foo=bar')
+
+  expect(statusCode).to.equal(200)
+  scope.done()
 })
 
 test('query() accepts URLSearchParams as input', async t => {
-  const params = new url.URLSearchParams({
-    foo: 'bar',
-  })
+  const params = new url.URLSearchParams({ foo: 'bar' })
 
   const scope = nock('http://example.test')
     .get('/')
@@ -117,261 +112,193 @@ test('query() accepts URLSearchParams as input', async t => {
 
   const { statusCode } = await got('http://example.test?foo=bar')
 
-  t.is(statusCode, 200)
+  expect(statusCode).to.equal(200)
   scope.done()
 })
 
-test('query() throws if query params have already been defined', async t => {
+test('query() throws if query params have already been defined', t => {
   const interceptor = nock('http://example.test').get('/?foo=bar')
 
-  t.throws(
-    () => {
-      interceptor.query({ foo: 'baz' })
-    },
-    {
-      message: 'Query parameters have already been defined',
-    }
-  )
+  expect(() => {
+    interceptor.query({ foo: 'baz' })
+  }).to.throw(Error, 'Query parameters have already been defined')
+
+  t.done()
 })
 
-test('query() throws if query() was already called', async t => {
+test('query() throws if query() was already called', t => {
   const interceptor = nock('http://example.test')
     .get('/')
     .query({ foo: 'bar' })
 
-  t.throws(
-    () => {
-      interceptor.query({ baz: 'qux' })
-    },
-    {
-      message: 'Query parameters have already been defined',
-    }
-  )
+  expect(() => {
+    interceptor.query({ baz: 'qux' })
+  }).to.throw(Error, 'Query parameters have already been defined')
+
+  t.done()
 })
 
 test('query() throws for invalid arguments', t => {
   const interceptor = nock('http://example.test').get('/')
 
-  t.throws(
-    () => {
-      interceptor.query('foo=bar')
-    },
-    {
-      message: 'Argument Error: foo=bar',
-    }
-  )
+  expect(() => {
+    interceptor.query('foo=bar')
+  }).to.throw(Error, 'Argument Error: foo=bar')
+
   t.done()
 })
 
-test('query() matches a query string that contains special RFC3986 characters', t => {
-  nock('http://example.test')
+test('query() matches a query string that contains special RFC3986 characters', async t => {
+  const scope = nock('http://example.test')
     .get('/')
     .query({ 'foo&bar': 'hello&world' })
-    .reply(200)
+    .reply()
 
-  const options = {
-    uri: 'http://example.test',
-    qs: {
-      'foo&bar': 'hello&world',
-    },
-  }
-
-  mikealRequest(options, function(err, res) {
-    if (err) throw err
-    t.equal(res.statusCode, 200)
-    t.end()
+  const { statusCode } = await got('http://example.test/', {
+    query: { 'foo&bar': 'hello&world' },
   })
+
+  expect(statusCode).to.equal(200)
+  scope.done()
 })
 
-test('query() expects unencoded query params', t => {
-  nock('http://example.test')
+test('query() expects unencoded query params', async t => {
+  const scope = nock('http://example.test')
     .get('/')
     .query({ foo: 'hello%20world' })
-    .reply(200)
+    .reply()
 
-  mikealRequest('http://example.test?foo=hello%20world', function(err, res) {
-    t.similar(err.toString(), /Error: Nock: No match for request/)
-    t.end()
-  })
+  await assertRejects(
+    got('http://example.test/?foo=hello%20world'),
+    Error,
+    'Nock: No match for request'
+  )
+
+  const { statusCode } = await got('http://example.test/?foo=hello%2520world')
+  expect(statusCode).to.equal(200)
+  scope.done()
 })
 
-test('query() matches a query string with pre-encoded values', t => {
-  nock('http://example.test', { encodedQueryParams: true })
+test('query() matches a query string with pre-encoded values', async t => {
+  const scope = nock('http://example.test', { encodedQueryParams: true })
     .get('/')
     .query({ foo: 'hello%20world' })
-    .reply(200)
+    .reply()
 
-  mikealRequest('http://example.test?foo=hello%20world', function(err, res) {
-    if (err) throw err
-    t.equal(res.statusCode, 200)
-    t.end()
-  })
+  const { statusCode } = await got('http://example.test/?foo=hello%20world')
+  expect(statusCode).to.equal(200)
+  scope.done()
 })
 
-test('query() with "true" will allow all query strings to pass', t => {
-  nock('http://example.test')
+test('query() with "true" will allow all query strings to pass', async t => {
+  const scope = nock('http://example.test')
     .get('/')
     .query(true)
-    .reply(200)
+    .reply()
 
-  mikealRequest('http://example.test/?foo=bar&a=1&b=2', function(err, res) {
-    if (err) throw err
-    t.equal(res.statusCode, 200)
-    t.end()
-  })
+  const { statusCode } = await got('http://example.test/?foo=hello%20world')
+  expect(statusCode).to.equal(200)
+  scope.done()
 })
 
-test('query() with "{}" will allow a match against ending in ?', t => {
-  nock('http://example.test')
+test('query() with "{}" will allow a match against ending in ?', async t => {
+  const scope = nock('http://example.test')
     .get('/noquerystring')
     .query({})
-    .reply(200)
+    .reply()
 
-  mikealRequest('http://example.test/noquerystring?', function(err, res) {
-    if (err) throw err
-    t.equal(res.statusCode, 200)
-    t.end()
-  })
+  const { statusCode } = await got('http://example.test/noquerystring?')
+  expect(statusCode).to.equal(200)
+  scope.done()
 })
 
-test('query() with a function, function called with actual queryObject', t => {
-  let queryObject
+test('query() with a function, function called with actual queryObject', async t => {
+  const queryFn = sinon.stub().returns(true)
+  const scope = nock('http://example.test')
+    .get('/')
+    .query(queryFn)
+    .reply()
 
-  const queryValidator = function(qs) {
-    queryObject = qs
-    return true
-  }
+  const { statusCode } = await got('http://example.test/?foo=bar&a=1&b=2')
+  expect(statusCode).to.equal(200)
 
+  expect(queryFn).to.have.been.calledOnceWithExactly({
+    foo: 'bar',
+    a: '1',
+    b: '2',
+  })
+
+  scope.done()
+})
+
+test('query() with a function, function return true the query treat as matched', async t => {
+  const scope = nock('http://example.test')
+    .get('/')
+    .query(() => true)
+    .reply()
+
+  const { statusCode } = await got(
+    'http://example.test/?ignore=the&actual=query'
+  )
+  expect(statusCode).to.equal(200)
+  scope.done()
+})
+
+test('query() with a function, function return false the query treat as Un-matched', async t => {
   nock('http://example.test')
     .get('/')
-    .query(queryValidator)
-    .reply(200)
+    .query(() => false)
+    .reply()
 
-  mikealRequest('http://example.test/?foo=bar&a=1&b=2', function(err, res) {
-    if (err) throw err
-    t.deepEqual(queryObject, { foo: 'bar', a: '1', b: '2' })
-    t.equal(res.statusCode, 200)
-    t.end()
-  })
+  await assertRejects(
+    got('http://example.test/?i=should&pass=?'),
+    Error,
+    'Nock: No match for request'
+  )
 })
 
-test('query() with a function, function return true the query treat as matched', t => {
-  const alwasyTrue = function() {
-    return true
-  }
-
+test('query() will not match when a query string does not match name=value', async t => {
   nock('http://example.test')
     .get('/')
-    .query(alwasyTrue)
-    .reply(200)
+    .query({ foo: 'bar' })
+    .reply()
 
-  mikealRequest('http://example.test/?igore=the&actual=query', function(
-    err,
-    res
-  ) {
-    if (err) throw err
-    t.equal(res.statusCode, 200)
-    t.end()
-  })
+  await assertRejects(
+    got('http://example.test/?foo=baz'),
+    Error,
+    'Nock: No match for request'
+  )
 })
 
-test('query() with a function, function return false the query treat as Un-matched', t => {
-  const alwayFalse = function() {
-    return false
-  }
-
+test('query() will not match when a query string is present that was not registered', async t => {
   nock('http://example.test')
     .get('/')
-    .query(alwayFalse)
-    .reply(200)
-
-  mikealRequest('http://example.test/?i=should&pass=?', function(err, res) {
-    t.equal(
-      err.message.trim(),
-      `Nock: No match for request ${JSON.stringify(
-        {
-          method: 'GET',
-          url: 'http://example.test/?i=should&pass=?',
-          headers: { host: 'example.test' },
-        },
-        null,
-        2
-      )}`
-    )
-    t.end()
-  })
-})
-
-test('query() will not match when a query string does not match name=value', t => {
-  nock('https://example.test')
-    .get('/b')
     .query({ foo: 'bar' })
-    .reply(200)
+    .reply()
 
-  mikealRequest('https://example.test/b?foo=baz', function(err, res) {
-    t.equal(
-      err.message.trim(),
-      `Nock: No match for request ${JSON.stringify(
-        {
-          method: 'GET',
-          url: 'https://example.test/b?foo=baz',
-          headers: { host: 'example.test' },
-        },
-        null,
-        2
-      )}`
-    )
-    t.end()
-  })
+  await assertRejects(
+    got('http://example.test/?foo=bar&baz=foz'),
+    Error,
+    'Nock: No match for request'
+  )
 })
 
-test('query() will not match when a query string is present that was not registered', t => {
-  nock('https://example.test')
-    .get('/c')
+test('query() will not match when a query string is malformed', async t => {
+  // This is a valid query string so it's not really malformed, just not
+  // matching. Should this test be removed?
+  nock('http://example.test')
+    .get('/')
     .query({ foo: 'bar' })
-    .reply(200)
+    .reply()
 
-  mikealRequest('https://example.test/c?foo=bar&baz=foz', function(err) {
-    t.equal(
-      err.message.trim(),
-      `Nock: No match for request ${JSON.stringify(
-        {
-          method: 'GET',
-          url: 'https://example.test/c?foo=bar&baz=foz',
-          headers: { host: 'example.test' },
-        },
-        null,
-        2
-      )}`
-    )
-    t.end()
-  })
+  await assertRejects(
+    got('http://example.test/?foobar'),
+    Error,
+    'Nock: No match for request'
+  )
 })
 
-test('query() will not match when a query string is malformed', t => {
-  nock('https://example.test')
-    .get('/d')
-    .query({ foo: 'bar' })
-    .reply(200)
-
-  mikealRequest('https://example.test/d?foobar', function(err, res) {
-    t.equal(
-      err.message.trim(),
-      `Nock: No match for request ${JSON.stringify(
-        {
-          method: 'GET',
-          url: 'https://example.test/d?foobar',
-          headers: { host: 'example.test' },
-        },
-        null,
-        2
-      )}`
-    )
-    t.end()
-  })
-})
-
-test('query() will not match when a query string has fewer correct values than expected', t => {
+test('query() will not match when a query string has fewer correct values than expected', async t => {
   nock('http://example.test')
     .get('/')
     .query({
@@ -380,40 +307,27 @@ test('query() will not match when a query string has fewer correct values than e
       empty: null,
       str: 'fou',
     })
-    .reply(200)
+    .reply()
 
-  mikealRequest('http://example.test/?num=1str=fou', function(err, res) {
-    t.equal(
-      err.message.trim(),
-      `Nock: No match for request ${JSON.stringify(
-        {
-          method: 'GET',
-          url: 'http://example.test/?num=1str=fou',
-          headers: { host: 'example.test' },
-        },
-        null,
-        2
-      )}`
-    )
-    t.end()
-  })
+  await assertRejects(
+    got('http://example.test/?num=1str=fou'),
+    Error,
+    'Nock: No match for request'
+  )
 })
 
-test('query(true) will match when the path has no query', t => {
-  nock('http://example.test')
+test('query(true) will match when the path has no query', async t => {
+  const scope = nock('http://example.test')
     .get('/')
     .query(true)
-    .reply(200)
+    .reply()
 
-  mikealRequest('http://example.test', function(err, res) {
-    t.ok(!err, 'no error')
-    t.ok(res)
-    t.equal(res.statusCode, 200)
-    t.end()
-  })
+  const { statusCode } = await got('http://example.test/')
+  expect(statusCode).to.equal(200)
+  scope.done()
 })
 
-test('query matching should not consider request arrays equal to comma-separated expectations', t => {
+test('query matching should not consider request arrays equal to comma-separated expectations', async t => {
   nock('http://example.test')
     .get('/')
     .query({
@@ -421,15 +335,14 @@ test('query matching should not consider request arrays equal to comma-separated
     })
     .reply()
 
-  t.rejects(got('http://example.test?foo[]=bar&foo[]=baz'), {
-    name: 'RequestError',
-    message: 'Nock: No match for request',
-  })
-
-  t.done()
+  await assertRejects(
+    got('http://example.test?foo[]=bar&foo[]=baz'),
+    got.RequestError,
+    'Nock: No match for request'
+  )
 })
 
-test('query matching should not consider comma-separated requests equal to array expectations', t => {
+test('query matching should not consider comma-separated requests equal to array expectations', async t => {
   nock('http://example.test')
     .get('/')
     .query({
@@ -437,10 +350,9 @@ test('query matching should not consider comma-separated requests equal to array
     })
     .reply()
 
-  t.rejects(got('http://example.test?foo=bar%2Cbaz'), {
-    name: 'RequestError',
-    message: 'Nock: No match for request',
-  })
-
-  t.done()
+  await assertRejects(
+    got('http://example.test?foo=bar%2Cbaz'),
+    got.RequestError,
+    'Nock: No match for request'
+  )
 })


### PR DESCRIPTION
These tests needed rewriting in async which was a big job, so I updated the assertions along the way. It cleaned up nicely.