### PR TITLE
feat: add type for Nock Back `currentMode`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -244,6 +244,7 @@ declare namespace nock {
   type BackMode = 'wild' | 'dryrun' | 'record' | 'lockdown'
 
   interface Back {
+    currentMode: BackMode
     fixtures: string
     setMode(mode: BackMode): void
 


### PR DESCRIPTION
currentMode exists but isn't typed - https://github.com/nock/nock/blob/master/lib/back.js#L282

It's referenced in the docs here https://github.com/nock/nock#modes