### PR TITLE
refactor: remove chai as a prod dependency

### DIFF
--- a/lib/back.js
+++ b/lib/back.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const assert = require('assert')
 const _ = require('lodash')
 const recorder = require('./recorder')
 const {
@@ -12,7 +13,6 @@ const { loadDefs, define } = require('./scope')
 
 const { format } = require('util')
 const path = require('path')
-const { expect } = require('chai')
 const debug = require('debug')('nock.back')
 
 let _mode = null
@@ -245,16 +245,19 @@ function fixtureExists(fixture) {
 }
 
 function assertScopes(scopes, fixture) {
-  scopes.forEach(function(scope) {
-    expect(scope.isDone()).to.be.equal(
-      true,
+  const pending = scopes
+    .filter(scope => !scope.isDone())
+    .map(scope => scope.pendingMocks())
+
+  if (pending.length) {
+    assert.fail(
       format(
         '%j was not used, consider removing %s to rerecord fixture',
-        scope.pendingMocks(),
+        [].concat(...pending),
         fixture
       )
     )
-  })
+  }
 }
 
 const Modes = {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "main": "./index.js",
   "types": "types",
   "dependencies": {
-    "chai": "^4.1.2",
     "debug": "^4.1.0",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.13",
@@ -31,6 +30,7 @@
   },
   "devDependencies": {
     "assert-rejects": "^1.0.0",
+    "chai": "^4.1.2",
     "dirty-chai": "^2.0.1",
     "dtslint": "^1.0.2",
     "eslint": "^6.0.0",

--- a/tests/test_back.js
+++ b/tests/test_back.js
@@ -2,6 +2,7 @@
 
 const http = require('http')
 const fs = require('fs')
+const path = require('path')
 const { beforeEach, test } = require('tap')
 const proxyquire = require('proxyquire').preserveCache()
 const nock = require('..')
@@ -53,7 +54,7 @@ function nockBackWithFixture(t, scopesLoaded) {
 
   nockBack('goodRequest.json', function(done) {
     t.equal(this.scopes.length, scopesLength)
-    http.get('http://www.example.test/').end()
+    http.get('http://www.example.test/')
     this.assertScopesFinished()
     done()
     t.end()
@@ -485,6 +486,18 @@ test('nockBack lockdown tests', nw => {
   })
 
   nw.end()
+})
+
+test('assertScopesFinished throws exception when Back still has pending scopes', t => {
+  nockBack.setMode('record')
+  const fixtureName = 'goodRequest.json'
+  const fixturePath = path.join(nockBack.fixtures, fixtureName)
+  nockBack(fixtureName, function(done) {
+    const expected = `["GET http://www.example.test:80/"] was not used, consider removing ${fixturePath} to rerecord fixture`
+    t.throws(() => this.assertScopesFinished(), { message: expected })
+    done()
+    t.end()
+  })
 })
 
 test('nockBack dryrun throws the expected exception when fs is not available', t => {


### PR DESCRIPTION
While I'm a big fan of Chai for expressive tests, it's basically
syntactic sugar over assertion errors. In this case, the only place
were using Chai, outside of tests, was in one function that preformed
a truthy check with a custom message.