### PR TITLE
add: link to replit run

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "cd examples && node delay-response.js"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Greenkeeper](https://badges.greenkeeper.io/nock/nock.svg)](https://greenkeeper.io/)
 [![Backers on Open Collective](https://opencollective.com/nock/backers/badge.svg)](#backers)
 [![Sponsors on Open Collective](https://opencollective.com/nock/sponsors/badge.svg)](#sponsors)
+[![run on repl.it](http://repl.it/badge/github/nock/nock)](https://repl.it/github/nock/nock)
 
 [npmjs]: https://www.npmjs.com/package/nock
 [build]: https://travis-ci.org/nock/nock


### PR DESCRIPTION
i think it would be pretty cool to let people see how this code works (and edit / preview the program) right in their browser, without any manual downloads or installation. i'm thinking we can add a 'run on repl.it' button, which redirects to something like [this](https://repl.it/@eankeen/run-nock):

![image](https://i.imgur.com/WzVDMFu.png)
