### PR TITLE
Start validating the types used + the actual JSDoc comments

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -11,9 +11,16 @@ extends:
   - 'eslint:recommended'
   - standard
   - prettier
+  - plugin:jsdoc/recommended
 
 plugins:
   - mocha
+
+settings:
+  jsdoc:
+    mode: 'typescript'
+    tagNamePreference:
+      returns: 'return'
 
 overrides:
   - files:
@@ -26,6 +33,14 @@ overrides:
 rules:
   # TODO These are included in standard and should be cleaned up and turned on.
   node/no-deprecated-api: 'off' # we still make heavy use of url.parse
+
+  # JSDoc modifications
+  jsdoc/check-types: 'off'
+  jsdoc/no-undefined-types: 'off'
+  jsdoc/require-jsdoc: 'off'
+  jsdoc/require-param-description: 'off'
+  jsdoc/require-returns-description: 'off'
+  jsdoc/valid-types: 'off'
 
   # Nock additions.
   strict: ['error', 'safe']

--- a/lib/common.js
+++ b/lib/common.js
@@ -42,7 +42,7 @@ function normalizeRequestOptions(options) {
  * from its utf8 representation.
  *
  * @param  {Object} buffer - a Buffer object
- * @returns {boolean}
+ * @return {boolean}
  */
 function isUtf8Representable(buffer) {
   const utfEncodedBuffer = buffer.toString('utf8')
@@ -128,6 +128,10 @@ function restoreOverriddenRequests() {
 /**
  * In WHATWG URL vernacular, this returns the origin portion of a URL.
  * However, the port is not included if it's standard and not already present on the host.
+ *
+ * @param proto
+ * @param host
+ * @param port
  */
 function normalizeOrigin(proto, host, port) {
   const hostHasPort = host.includes(':')
@@ -141,6 +145,7 @@ function normalizeOrigin(proto, host, port) {
 
 /**
  * Get high level information about request as string
+ *
  * @param  {Object} options
  * @param  {string} options.method
  * @param  {number|string} options.port
@@ -187,8 +192,10 @@ function isJSONContent(headers) {
 
 /**
  * Return a new object with all field names of the headers lower-cased.
- *
+ * 
  * Duplicates throw an error.
+ *
+ * @param headers
  */
 function headersFieldNamesToLowerCase(headers) {
   if (!_.isPlainObject(headers)) {
@@ -215,13 +222,15 @@ const headersFieldsArrayToLowerCase = headers => [
 
 /**
  * Converts the various accepted formats of headers into a flat array representing "raw headers".
- *
+ * 
  * Nock allows headers to be provided as a raw array, a plain object, or a Map.
- *
+ * 
  * While all the header names are expected to be strings, the values are left intact as they can
  * be functions, strings, or arrays of strings.
+ * 
+ * https://nodejs.org/api/http.html#http_message_rawheaders
  *
- *  https://nodejs.org/api/http.html#http_message_rawheaders
+ * @param headers
  */
 function headersInputToRawArray(headers) {
   if (headers === undefined) {
@@ -255,8 +264,10 @@ function headersInputToRawArray(headers) {
 
 /**
  * Converts an array of raw headers to an object, using the same rules as Nodes `http.IncomingMessage.headers`.
- *
+ * 
  * Header names/keys are lower-cased.
+ *
+ * @param rawHeaders
  */
 function headersArrayToObject(rawHeaders) {
   if (!Array.isArray(rawHeaders)) {
@@ -294,24 +305,28 @@ const noDuplicatesHeaders = new Set([
 
 /**
  * Set key/value data in accordance with Node's logic for folding duplicate headers.
- *
+ * 
  * The `value` param should be a function, string, or array of strings.
- *
+ * 
  * Node's docs and source:
  * https://nodejs.org/api/http.html#http_message_headers
  * https://github.com/nodejs/node/blob/908292cf1f551c614a733d858528ffb13fb3a524/lib/_http_incoming.js#L245
- *
+ * 
  * Header names are lower-cased.
  * Duplicates in raw headers are handled in the following ways, depending on the header name:
  * - Duplicates of field names listed in `noDuplicatesHeaders` (above) are discarded.
  * - `set-cookie` is always an array. Duplicates are added to the array.
  * - For duplicate `cookie` headers, the values are joined together with '; '.
  * - For all other headers, the values are joined together with ', '.
- *
+ * 
  * Node's implementation is larger because it highly optimizes for not having to call `toLowerCase()`.
  * We've opted to always call `toLowerCase` in exchange for a more concise function.
- *
+ * 
  * While Node has the luxury of knowing `value` is always a string, we do an extra step of coercion at the top.
+ *
+ * @param headers
+ * @param name
+ * @param value
  */
 function addHeaderLine(headers, name, value) {
   let values // code below expects `values` to be an array of strings
@@ -352,8 +367,10 @@ function addHeaderLine(headers, name, value) {
  * Deletes the given `fieldName` property from `headers` object by performing
  * case-insensitive search through keys.
  *
- * @headers   {Object} headers - object of header field names and values
+ * @headers {Object} headers - object of header field names and values
  * @fieldName {String} field name - string with the case-insensitive field name
+ * @param headers
+ * @param fieldNameToDelete
  */
 function deleteHeadersField(headers, fieldNameToDelete) {
   if (!_.isPlainObject(headers)) {
@@ -375,11 +392,14 @@ function deleteHeadersField(headers, fieldNameToDelete) {
 
 /**
  * Utility for iterating over a raw headers array.
- *
+ * 
  * The callback is called with:
- *  - The header value. string, array of strings, or a function
- *  - The header field name. string
- *  - Index of the header field in the raw header array.
+ * - The header value. string, array of strings, or a function
+ * - The header field name. string
+ * - Index of the header field in the raw header array.
+ *
+ * @param rawHeaders
+ * @param callback
  */
 function forEachHeader(rawHeaders, callback) {
   for (let i = 0; i < rawHeaders.length; i += 2) {
@@ -397,11 +417,13 @@ function percentDecode(str) {
 
 /**
  * URI encode the provided string, stringently adhering to RFC 3986.
- *
+ * 
  * RFC 3986 reserves !, ', (, ), and * but encodeURIComponent does not encode them so we do it manually.
- *
+ * 
  * https://tools.ietf.org/html/rfc3986
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
+ *
+ * @param str
  */
 function percentEncode(str) {
   return encodeURIComponent(str).replace(/[!'()*]/g, function(c) {
@@ -429,7 +451,7 @@ function matchStringOrRegexp(target, pattern) {
  * @param stringFormattingFn The function used to format string values. Can
  *                           be used to encode or decode the query value.
  *
- * @returns *[] the formatted [key, value] pair.
+ * @return *[] the formatted [key, value] pair.
  */
 function formatQueryValue(key, value, stringFormattingFn) {
   // TODO: Probably refactor code to replace `switch(true)` with `if`/`else`.
@@ -483,11 +505,15 @@ function isStream(obj) {
 /**
  * Converts the arguments from the various signatures of http[s].request into a standard
  * options object and an optional callback function.
- *
+ * 
  * https://nodejs.org/api/http.html#http_http_request_url_options_callback
- *
+ * 
  * Taken from the beginning of the native `ClientRequest`.
  * https://github.com/nodejs/node/blob/908292cf1f551c614a733d858528ffb13fb3a524/lib/_http_client.js#L68
+ *
+ * @param input
+ * @param options
+ * @param cb
  */
 function normalizeClientRequestArgs(input, options, cb) {
   if (typeof input === 'string') {
@@ -513,9 +539,11 @@ function normalizeClientRequestArgs(input, options, cb) {
 /**
  * Utility function that converts a URL object into an ordinary
  * options object as expected by the http.request and https.request APIs.
- *
+ * 
  * This was copied from Node's source
  * https://github.com/nodejs/node/blob/908292cf1f551c614a733d858528ffb13fb3a524/lib/internal/url.js#L1257
+ *
+ * @param url
  */
 function urlToOptions(url) {
   const options = {
@@ -541,32 +569,39 @@ function urlToOptions(url) {
 
 /**
  * Determines if request data matches the expected schema.
- *
+ * 
  * Used for comparing decoded search parameters, request body JSON objects,
  * and URL decoded request form bodies.
- *
+ * 
  * Performs a general recursive strict comparision with two caveats:
- *  - The expected data can use regexp to compare values
- *  - JSON path notation and nested objects are considered equal
+ * - The expected data can use regexp to compare values
+ * - JSON path notation and nested objects are considered equal
+ *
+ * @param expected
+ * @param actual
  */
 const dataEqual = (expected, actual) =>
   deepEqual(expand(expected), expand(actual))
 
 /**
  * Converts flat objects whose keys use JSON path notation to nested objects.
- *
+ * 
  * The input object is not mutated.
  *
- * @example
+ * @example 
  * { 'foo[bar][0]': 'baz' } -> { foo: { bar: [ 'baz' ] } }
+ * @param input
  */
 const expand = input =>
   Object.entries(input).reduce((acc, [k, v]) => _.set(acc, k, v), {})
 
 /**
  * Performs a recursive strict comparison between two values.
- *
+ * 
  * Expected values or leaf nodes of expected object values that are RegExp use test() for comparison.
+ *
+ * @param expected
+ * @param actual
  */
 function deepEqual(expected, actual) {
   debug('deepEqual comparing', typeof expected, expected, typeof actual, actual)

--- a/lib/delayed_body.js
+++ b/lib/delayed_body.js
@@ -5,7 +5,7 @@
  * delay is set. The stream outputs the intended body and EOF after the delay.
  *
  * @param  {String|Buffer|Stream} body - the body to write/pipe out
- * @param  {Integer} ms - The delay in milliseconds
+ * @param  {number} ms - The delay in milliseconds
  * @constructor
  */
 

--- a/lib/delayed_body.js
+++ b/lib/delayed_body.js
@@ -6,7 +6,7 @@
  *
  * @param  {String|Buffer|Stream} body - the body to write/pipe out
  * @param  {number} ms - The delay in milliseconds
- * @constructor
+ * @class
  */
 
 const { Transform } = require('stream')

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -15,12 +15,14 @@ const globalEmitter = require('./global_emitter')
 /**
  * @name NetConnectNotAllowedError
  * @private
- * @desc Error trying to make a connection when disabled external access.
+ * @description Error trying to make a connection when disabled external access.
  * @class
- * @example
+ * @example 
  * nock.disableNetConnect();
  * http.get('http://zombo.com');
  * // throw NetConnectNotAllowedError
+ * @param host
+ * @param path
  */
 function NetConnectNotAllowedError(host, path) {
   Error.call(this)
@@ -39,15 +41,17 @@ let allowNetConnect
 
 /**
  * Enabled real request.
+ *
  * @public
+ * @param matcher
  * @param {String|RegExp} matcher=RegExp.new('.*') Expression to match
- * @example
+ * @example 
  * // Enables all real requests
  * nock.enableNetConnect();
- * @example
+ * @example 
  * // Enables real requests for url that matches google
  * nock.enableNetConnect('google');
- * @example
+ * @example 
  * // Enables real requests for url that matches google and amazon
  * nock.enableNetConnect(/(google|amazon)/);
  */
@@ -72,6 +76,7 @@ function isEnabledForNetConnect(options) {
 
 /**
  * Disable all real requests.
+ *
  * @public
  * @example
  * nock.disableNetConnect();
@@ -135,7 +140,8 @@ function removeAll() {
 /**
  * Return all the Interceptors whose Scopes match against the base path of the provided options.
  *
- * @returns {Interceptor[]}
+ * @return {Interceptor[]}
+ * @param options
  */
 function interceptorsFor(options) {
   common.normalizeRequestOptions(options)

--- a/lib/intercepted_request_router.js
+++ b/lib/intercepted_request_router.js
@@ -195,6 +195,8 @@ class InterceptedRequestRouter {
    * routing phase, in case header filters were specified, and during the
    * interceptor-playback phase, to correctly pass mocked request headers.
    * TODO There are some problems with this; see https://github.com/nock/nock/issues/1718
+   *
+   * @param interceptor
    */
   setHostHeaderUsingInterceptor(interceptor) {
     const { req, options } = this

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -19,14 +19,19 @@ try {
 
 module.exports = class Interceptor {
   /**
-   *
    * Valid argument types for `uri`:
-   *  - A string used for strict comparisons with pathname.
-   *    The search portion of the URI may also be postfixed, in which case the search params
-   *    are striped and added via the `query` method.
-   *  - A RegExp instance that tests against only the pathname of requests.
-   *  - A synchronous function bound to this Interceptor instance. It's provided the pathname
-   *    of requests and must return a boolean denoting if the request is considered a match.
+   * - A string used for strict comparisons with pathname.
+   * The search portion of the URI may also be postfixed, in which case the search params
+   * are striped and added via the `query` method.
+   * - A RegExp instance that tests against only the pathname of requests.
+   * - A synchronous function bound to this Interceptor instance. It's provided the pathname
+   * of requests and must return a boolean denoting if the request is considered a match.
+   *
+   * @param scope
+   * @param uri
+   * @param method
+   * @param requestBody
+   * @param interceptorOptions
    */
   constructor(scope, uri, method, requestBody, interceptorOptions) {
     const uriIsStr = typeof uri === 'string'
@@ -353,6 +358,8 @@ module.exports = class Interceptor {
   /**
    * Return true when the interceptor's method, protocol, host, port, and path
    * match the provided options.
+   *
+   * @param options
    */
   matchOrigin(options) {
     const isRegex = this.path instanceof RegExp
@@ -440,6 +447,7 @@ module.exports = class Interceptor {
 
   /**
    * Set query strings for the interceptor
+   *
    * @name query
    * @param queries Object of query string name,values (accepts regexp values)
    * @public
@@ -488,6 +496,7 @@ module.exports = class Interceptor {
 
   /**
    * Set number of times will repeat the interceptor
+   *
    * @name times
    * @param newCounter Number of times to repeat (should be > 0)
    * @public
@@ -507,6 +516,7 @@ module.exports = class Interceptor {
 
   /**
    * An sugar syntax for times(1)
+   *
    * @name once
    * @see {@link times}
    * @public
@@ -519,6 +529,7 @@ module.exports = class Interceptor {
 
   /**
    * An sugar syntax for times(2)
+   *
    * @name twice
    * @see {@link times}
    * @public
@@ -531,6 +542,7 @@ module.exports = class Interceptor {
 
   /**
    * An sugar syntax for times(3).
+   *
    * @name thrice
    * @see {@link times}
    * @public
@@ -589,7 +601,7 @@ module.exports = class Interceptor {
 
   /**
    * @private
-   * @returns {number}
+   * @return {number}
    */
   getTotalDelay() {
     return this.delayInMs + this.delayConnectionInMs

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -544,9 +544,9 @@ module.exports = class Interceptor {
   /**
    * Delay the response by a certain number of ms.
    *
-   * @param {(integer|object)} opts - Number of milliseconds to wait, or an object
-   * @param {integer} [opts.head] - Number of milliseconds to wait before response is sent
-   * @param {integer} [opts.body] - Number of milliseconds to wait before response body is sent
+   * @param {(number|object)} opts - Number of milliseconds to wait, or an object
+   * @param {number} [opts.head] - Number of milliseconds to wait before response is sent
+   * @param {number} [opts.body] - Number of milliseconds to wait before response body is sent
    * @return {Interceptor} - the current interceptor for chaining
    */
   delay(opts) {
@@ -568,7 +568,7 @@ module.exports = class Interceptor {
   /**
    * Delay the response body by a certain number of ms.
    *
-   * @param {integer} ms - Number of milliseconds to wait before response is sent
+   * @param {number} ms - Number of milliseconds to wait before response is sent
    * @return {Interceptor} - the current interceptor for chaining
    */
   delayBody(ms) {
@@ -579,7 +579,7 @@ module.exports = class Interceptor {
   /**
    * Delay the connection by a certain number of ms.
    *
-   * @param  {integer} ms - Number of milliseconds to wait
+   * @param  {number} ms - Number of milliseconds to wait
    * @return {Interceptor} - the current interceptor for chaining
    */
   delayConnection(ms) {
@@ -598,7 +598,7 @@ module.exports = class Interceptor {
   /**
    * Make the socket idle for a certain number of ms (simulated).
    *
-   * @param  {integer} ms - Number of milliseconds to wait
+   * @param  {number} ms - Number of milliseconds to wait
    * @return {Interceptor} - the current interceptor for chaining
    */
   socketDelay(ms) {

--- a/lib/match_body.js
+++ b/lib/match_body.js
@@ -65,6 +65,9 @@ module.exports = function matchBody(options, spec, body) {
 /**
  * Based on lodash issue discussion
  * https://github.com/lodash/lodash/issues/1244
+ *
+ * @param obj
+ * @param cb
  */
 function mapValuesDeep(obj, cb) {
   if (Array.isArray(obj)) {

--- a/lib/playback_interceptor.js
+++ b/lib/playback_interceptor.js
@@ -48,8 +48,11 @@ function parseFullReplyResult(response, fullReplyResult) {
 
 /**
  * Determine which of the default headers should be added to the response.
- *
+ * 
  * Don't include any defaults whose case-insensitive keys are already on the response.
+ *
+ * @param existingHeaders
+ * @param defaultHeaders
  */
 function selectDefaultHeaders(existingHeaders, defaultHeaders) {
   if (!defaultHeaders.length) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -30,7 +30,7 @@ try {
  * @param  {boolean}  options.encodedQueryParams
  * @param  {function} options.filteringScope
  * @param  {Object}   options.reqheaders
- * @constructor
+ * @class
  */
 class Scope extends EventEmitter {
   constructor(basePath, options) {
@@ -235,7 +235,7 @@ class Scope extends EventEmitter {
 
   /**
    * @private
-   * @returns {boolean}
+   * @return {boolean}
    */
   shouldPersist() {
     return this._persist

--- a/package-lock.json
+++ b/package-lock.json
@@ -253,9 +253,9 @@
       }
     },
     "@semantic-release/commit-analyzer": {
-      "version": "7.0.0-beta-.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-7.0.0-beta-.2.tgz",
-      "integrity": "sha512-tburFNeooqb8WrqTfkXroUpvb1jbRP15xugOcWdvnNOlDLHL5D//8BK2Q6TOY+G3RhrL1qaZIuoQ7paqia3x1A==",
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-7.0.0-beta.2.tgz",
+      "integrity": "sha512-8xEXff5Ok5NVhYvsNhvTPZTAKv+JMxXobWZNnBJ1wpAB6QWu9przAy9h9KgBGPbbKdQTTJIPosyPq4psqJPffQ==",
       "dev": true,
       "requires": {
         "conventional-changelog-angular": "^5.0.0",
@@ -1495,6 +1495,12 @@
       "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
       "dev": true
     },
+    "comment-parser": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.2.tgz",
+      "integrity": "sha512-4Rjb1FnxtOcv9qsfuaNuVsmmVn4ooVoBHzYfyKteiXwIU84PClyGA5jASoFMwPV93+FPh9spwueXauxFJZkGAg==",
+      "dev": true
+    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -2079,7 +2085,7 @@
         "request": "^2.88.0",
         "strip-json-comments": "^2.0.1",
         "tslint": "5.14.0",
-        "typescript": "^3.8.0-dev.20191030"
+        "typescript": "^3.7.4"
       }
     },
     "duplexer3": {
@@ -2392,6 +2398,22 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
+      }
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-19.2.0.tgz",
+      "integrity": "sha512-QdNifBFLXCDGdy+26RXxcrqzEZarFWNybCZQVqJQYEYPlxd6lm+LPkrs6mCOhaGc2wqC6zqpedBQFX8nQJuKSw==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "^0.7.2",
+        "debug": "^4.1.1",
+        "jsdoctypeparser": "^6.1.0",
+        "lodash": "^4.17.15",
+        "object.entries-ponyfill": "^1.0.1",
+        "regextras": "^0.7.0",
+        "semver": "^6.3.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "eslint-plugin-mocha": {
@@ -4064,6 +4086,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "jsdoctypeparser": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-6.1.0.tgz",
+      "integrity": "sha512-UCQBZ3xCUBv/PLfwKAJhp6jmGOSLFNKzrotXGNgbKhWvz27wPsCsVeP7gIcHPElQw2agBmynAitXqhxR58XAmA==",
       "dev": true
     },
     "jsesc": {
@@ -8506,6 +8534,12 @@
         "object-keys": "^1.0.11"
       }
     },
+    "object.entries-ponyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.entries-ponyfill/-/object.entries-ponyfill-1.0.1.tgz",
+      "integrity": "sha1-Kavfd8v70mVm3RqiTp2I9lQz0lY=",
+      "dev": true
+    },
     "object.getownpropertydescriptors": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
@@ -9247,6 +9281,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
+    "regextras": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.7.0.tgz",
+      "integrity": "sha512-ds+fL+Vhl918gbAUb0k2gVKbTZLsg84Re3DI6p85Et0U0tYME3hyW4nMK8Px4dtDaBA2qNjvG5uWyW7eK5gfmw==",
       "dev": true
     },
     "registry-auth-token": {
@@ -11851,9 +11891,9 @@
       }
     },
     "typescript": {
-      "version": "3.8.0-dev.20191030",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20191030.tgz",
-      "integrity": "sha512-H4ICJQz3KmUy1V7MyBK+YjTDNTHPGuSIbCYxgJbhn/klrgs2P3jBuuS9neb5hpRNe4WU+dtXzPbfrl19czJgiw==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",
+      "integrity": "sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-config-prettier": "^6.0.0",
     "eslint-config-standard": "^14.0.0",
     "eslint-plugin-import": "^2.16.0",
+    "eslint-plugin-jsdoc": "^19.2.0",
     "eslint-plugin-mocha": "^6.2.0",
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-promise": "^4.1.1",
@@ -54,7 +55,8 @@
     "sinon": "^7.5.0",
     "sinon-chai": "^3.3.0",
     "superagent": "^5.0.2",
-    "tap": "^14.0.0"
+    "tap": "^14.0.0",
+    "typescript": "^3.7.4"
   },
   "scripts": {
     "unit": "tap --100 --coverage --coverage-report=text ./tests/test_*.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "files": [
+    "index.js"
+  ],
+  "include": [
+    "lib/**/*.js"
+  ],
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "ES2016",
+    "module": "commonjs",
+    "allowJs": true,
+    "checkJs": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+
+    /* Strict Type-Checking Options */
+    "strict": true,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false,
+
+    /* Additional Checks */
+    "noUnusedLocals": true
+  }
+}


### PR DESCRIPTION
This is a bigger task, so I'm just adding a draft PR here to show with actual code what I'm referring to.

This is a follow up to #1846.

Such mistakes in the type definitions is likely to be the symptom of not validating the type definitions against the actual project.

Running TypeScript on the JS-code would help fix that.

Also enforcing best practices on the JSDoc comments will help.

On top of that, if you like, one can now generate the type definitions from ones JSDoc comments: https://dev.to/voxpelli/how-to-use-typescript-3-7-to-generate-declarations-from-jsdoc-a95 That way one can keep it more DRY, at the disadvantage of some more complex type expressions not being possible to define in JSDoc alone. Then one can combine the two though I believe.