### PR TITLE
fix(socketDelay): support options.timeout

### DIFF
--- a/lib/intercepted_request_router.js
+++ b/lib/intercepted_request_router.js
@@ -31,6 +31,9 @@ class InterceptedRequestRouter {
     this.interceptors = interceptors
 
     this.socket = new Socket(options)
+    if (options.timeout) {
+      this.socket.setTimeout(options.timeout)
+    }
     this.response = new IncomingMessage(this.socket)
     this.playbackStarted = false
     this.requestBodyBuffers = []

--- a/lib/intercepted_request_router.js
+++ b/lib/intercepted_request_router.js
@@ -31,9 +31,13 @@ class InterceptedRequestRouter {
     this.interceptors = interceptors
 
     this.socket = new Socket(options)
+
+    // support setting `timeout` using request `options`
+    // https://nodejs.org/docs/latest-v12.x/api/http.html#http_http_request_url_options_callback
     if (options.timeout) {
       this.socket.setTimeout(options.timeout)
     }
+
     this.response = new IncomingMessage(this.socket)
     this.playbackStarted = false
     this.requestBodyBuffers = []

--- a/tests/test_socketdelay.js
+++ b/tests/test_socketdelay.js
@@ -77,7 +77,7 @@ describe('`socketDelay()`', () => {
     req.end()
   })
 
-  it('emits a timeout if not idle for long enough', done => {
+  it('does not emit a timeout when timeout > socketDelay', done => {
     const responseText = 'okeydoke!'
     const scope = nock('http://example.test')
       .get('/')

--- a/tests/test_socketdelay.js
+++ b/tests/test_socketdelay.js
@@ -35,7 +35,7 @@ describe('`socketDelay()`', () => {
     })
   })
 
-  it('emits a timeout', done => {
+  it('emits a timeout - with setTimeout', done => {
     nock('http://example.test')
       .get('/')
       .socketDelay(10000)
@@ -49,6 +49,27 @@ describe('`socketDelay()`', () => {
     })
 
     req.setTimeout(5000, () => {
+      expect(onEnd).not.to.have.been.called()
+      done()
+    })
+
+    req.end()
+  })
+
+  it('emits a timeout - with options.timeout', done => {
+    nock('http://example.test')
+      .get('/')
+      .socketDelay(10000)
+      .reply(200, 'OK')
+
+    const onEnd = sinon.spy()
+
+    const req = http.request('http://example.test', { timeout: 5000 }, res => {
+      res.setEncoding('utf8')
+      res.once('end', onEnd)
+    })
+
+    req.on('timeout', function() {
       expect(onEnd).not.to.have.been.called()
       done()
     })


### PR DESCRIPTION
The current implementation only supports `req.setTimeout`, but Node.js
allows for `options.timeout` to accomplish the same.

https://nodejs.org/docs/latest-v12.x/api/http.html#http_http_request_url_options_callback

