### PR TITLE
Temporarily disable Node 8 CI to fix builds and unblock release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,6 @@ jobs:
     - node_js: 10
       # Avoid running lint and prettier again.
       script: npm run --silent unit && npm run mocha
-    - node_js: 8
-      # Avoid running lint and prettier again.
-      script: npm run --silent unit && npm run mocha
     - stage: release
       node_js: lts/*
       env: semantic-release


### PR DESCRIPTION
CI is broken for Node 8 beacuse semantic-release won't install. This isn't just breaking all the builds, it's also blocking release.

We're dealing with updating the CI this in #1870 and maybe we'll be able to fix this. If not, we should also prioritize #1871 so we don't accidentally ship a breaking change for Node 8.

I'm removing this for now, so we can get the patch for #1836 shipped.