### PR TITLE
fix: allowMocked when using a callback for the path

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -355,7 +355,7 @@ module.exports = class Interceptor {
    * match the provided options.
    */
   matchOrigin(options) {
-    const isPathFn = typeof this.path === 'function';
+    const isPathFn = typeof this.path === 'function'
     const isRegex = this.path instanceof RegExp
     const isRegexBasePath = this.scope.basePath instanceof RegExp
 
@@ -374,7 +374,7 @@ module.exports = class Interceptor {
     const comparisonKey = isPathFn || isRegex ? this.__nock_scopeKey : this._key
     const matchKey = `${method} ${proto}://${options.host}${path}`
 
-    if(isPathFn) {
+    if (isPathFn) {
       return !!(matchKey.match(comparisonKey) && this.path(path))
     }
 

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -355,6 +355,7 @@ module.exports = class Interceptor {
    * match the provided options.
    */
   matchOrigin(options) {
+    const isPathFn = typeof this.path === 'function';
     const isRegex = this.path instanceof RegExp
     const isRegexBasePath = this.scope.basePath instanceof RegExp
 
@@ -370,8 +371,12 @@ module.exports = class Interceptor {
     if (this.scope.transformPathFunction) {
       path = this.scope.transformPathFunction(path)
     }
-    const comparisonKey = isRegex ? this.__nock_scopeKey : this._key
+    const comparisonKey = isPathFn || isRegex ? this.__nock_scopeKey : this._key
     const matchKey = `${method} ${proto}://${options.host}${path}`
+
+    if(isPathFn) {
+      return !!(matchKey.match(comparisonKey) && this.path(path))
+    }
 
     if (isRegex && !isRegexBasePath) {
       return !!matchKey.match(comparisonKey) && this.path.test(path)

--- a/tests/test_allow_unmocked.js
+++ b/tests/test_allow_unmocked.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const http = require('http')
+const { expect } = require('chai')
 const url = require('url')
 const mikealRequest = require('request')
 const { test } = require('tap')
@@ -231,6 +232,18 @@ test('match hostname using regexp with allowUnmocked (issue-1076)', t => {
     t.equal(body, 'Match regex')
     t.end()
   })
+})
+
+// https://github.com/nock/nock/issues/1867
+test('match path using callback with allowUnmocked', async t => {
+  const scope = nock('http://example.test', { allowUnmocked: true })
+    .get((uri => uri.endsWith('bar')))
+    .reply()
+
+  const { statusCode } = await got('http://example.test/foo/bar')
+  expect(statusCode).to.equal(200)
+
+  scope.done()
 })
 
 // https://github.com/nock/nock/issues/835

--- a/tests/test_allow_unmocked.js
+++ b/tests/test_allow_unmocked.js
@@ -237,7 +237,7 @@ test('match hostname using regexp with allowUnmocked (issue-1076)', t => {
 // https://github.com/nock/nock/issues/1867
 test('match path using callback with allowUnmocked', async t => {
   const scope = nock('http://example.test', { allowUnmocked: true })
-    .get((uri => uri.endsWith('bar')))
+    .get(uri => uri.endsWith('bar'))
     .reply()
 
   const { statusCode } = await got('http://example.test/foo/bar')


### PR DESCRIPTION
When an Interceptor was created with a comparator for the path, the
`matchOrigin` function was comparing the string equivalent of the function
instead of evaluating it.

I'm not a fan of the fact that the function `matchOrigin` is comparing the
pathname, but that's a refactor for another day.

Fixes: #1867