### PR TITLE
fix(types): Scope accepts legacy Url not WHATWG

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -22,7 +22,7 @@ try {
 }
 
 /**
- * @param  {string|RegExp} basePath
+ * @param  {string|RegExp|url.url} basePath
  * @param  {Object}   options
  * @param  {boolean}  options.allowUnmocked
  * @param  {string[]} options.badheaders

--- a/tests/test_scope.js
+++ b/tests/test_scope.js
@@ -4,6 +4,7 @@ const path = require('path')
 const { expect } = require('chai')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire').preserveCache()
+const url = require('url')
 const Interceptor = require('../lib/interceptor')
 const nock = require('..')
 const got = require('./got_client')
@@ -21,6 +22,34 @@ it('scope exposes interceptors', () => {
       expect(interceptor).to.be.an.instanceOf(Interceptor)
       interceptor.delayConnection(100)
     })
+  })
+})
+
+describe('`Scope#constructor`', () => {
+  it('accepts the output of url.parse', async () => {
+    const scope = nock(url.parse('http://example.test'))
+      .get('/')
+      .reply()
+
+    const { statusCode } = await got('http://example.test')
+    expect(statusCode).to.equal(200)
+    scope.done()
+  })
+
+  it.skip('accepts a WHATWG URL instance', async () => {
+    const scope = nock(new url.URL('http://example.test'))
+      .get('/')
+      .reply()
+
+    const { statusCode } = await got('http://example.test')
+    expect(statusCode).to.equal(200)
+    scope.done()
+  })
+
+  it('fails when provided a WHATWG URL instance', () => {
+    // This test just proves the lack of current support. When this feature is added,
+    // this test should be removed and the test above un-skipped.
+    expect(() => nock(new url.URL('http://example.test'))).to.throw()
   })
 })
 

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -1,6 +1,6 @@
 import nock from 'nock'
 import * as fs from 'fs'
-import { URL, URLSearchParams } from 'url'
+import url, { URLSearchParams } from 'url'
 
 let scope: nock.Scope = nock('http://example.test')
 let inst: nock.Interceptor
@@ -159,7 +159,13 @@ nock('http://example.test')
   })
 
 // Using URL as input
-scope = nock(new URL('https://example.test/'))
+// Not supported yet
+// scope = nock(new URL('https://example.test/'))
+//   .get('/resource')
+//   .reply(200, 'url matched')
+
+// specifying URL from url.parse output
+scope = nock(url.parse('https://example.test/'))
   .get('/resource')
   .reply(200, 'url matched')
 


### PR DESCRIPTION
Updates the types to properly reflect that a Scope can be created with
the output of `url.parse`. Previously, it denoted that it accepted a
`url.URL` instance. To clarify, tests were also added proving that one
works while the other throws an error.

This issue seems to be blocking the build of other PRs (https://github.com/nock/nock/pull/1878), probably because dtslint got a little smarter recently. 

https://github.com/nock/nock/pull/1692 may be enough to add `url.URL` support. 