### PR TITLE
feat: allow passing a function to `enableNetConnect()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1154,7 +1154,7 @@ For enabling any real HTTP requests (the default behavior):
 nock.enableNetConnect()
 ```
 
-You could allow real HTTP requests for certain host names by providing a string or a regular expression for the hostname:
+You could allow real HTTP requests for certain host names by providing a string or a regular expression for the hostname, or a function that accepts the hostname and returns true or false:
 
 ```js
 // Using a string
@@ -1162,6 +1162,9 @@ nock.enableNetConnect('amazon.com')
 
 // Or a RegExp
 nock.enableNetConnect(/(amazon|github)\.com/)
+
+// Or a Function
+nock.enableNetConnect(host => host.includes('amazon.com') || host.includes('github.com'))
 
 http.get('http://www.amazon.com/')
 http.get('http://github.com/')

--- a/README.md
+++ b/README.md
@@ -1164,7 +1164,9 @@ nock.enableNetConnect('amazon.com')
 nock.enableNetConnect(/(amazon|github)\.com/)
 
 // Or a Function
-nock.enableNetConnect(host => host.includes('amazon.com') || host.includes('github.com'))
+nock.enableNetConnect(
+  host => host.includes('amazon.com') || host.includes('github.com')
+)
 
 http.get('http://www.amazon.com/')
 http.get('http://github.com/')

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -60,7 +60,7 @@ function enableNetConnect(matcher) {
     allowNetConnect = new RegExp(matcher)
   } else if (matcher instanceof RegExp) {
     allowNetConnect = matcher
-  } else if (matcher instanceof Function) {
+  } else if (typeof matcher === 'function') {
     allowNetConnect = { test: matcher }
   } else {
     allowNetConnect = /.*/

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -50,6 +50,9 @@ let allowNetConnect
  * @example
  * // Enables real requests for url that matches google and amazon
  * nock.enableNetConnect(/(google|amazon)/);
+ * @example
+ * // Enables real requests for url that includes google
+ * nock.enableNetConnect(host => host.includes('google'));
  */
 function enableNetConnect(matcher) {
   // TODO-12.x: Replace with `typeof matcher === 'string'`.
@@ -57,6 +60,8 @@ function enableNetConnect(matcher) {
     allowNetConnect = new RegExp(matcher)
   } else if (matcher instanceof RegExp) {
     allowNetConnect = matcher
+  } else if (matcher instanceof Function) {
+    allowNetConnect = { test: matcher }
   } else {
     allowNetConnect = /.*/
   }

--- a/tests/test_net_connect.js
+++ b/tests/test_net_connect.js
@@ -115,4 +115,13 @@ describe('`enableNetConnect()`', () => {
       /Nock: Disallowed net connect for "example.test:443\/"/
     )
   })
+
+  it('passes the domain to be tested, via function', async () => {
+    const matcher = sinon.stub().returns(false)
+    nock.enableNetConnect(matcher)
+
+    await got('https://example.test/').catch(() => undefined) // ignore rejection, expected
+
+    expect(matcher).to.have.been.calledOnceWithExactly('example.test:443')
+  })
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,7 +21,7 @@ declare namespace nock {
   function activeMocks(): string[]
   function removeInterceptor(interceptor: Interceptor | ReqOptions): boolean
   function disableNetConnect(): void
-  function enableNetConnect(matcher?: string | RegExp): void
+  function enableNetConnect(matcher?: string | RegExp | ((host: string) => boolean)): void
   function load(path: string): Scope[]
   function loadDefs(path: string): Definition[]
   function define(defs: Definition[]): Scope[]

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,7 +21,9 @@ declare namespace nock {
   function activeMocks(): string[]
   function removeInterceptor(interceptor: Interceptor | ReqOptions): boolean
   function disableNetConnect(): void
-  function enableNetConnect(matcher?: string | RegExp | ((host: string) => boolean)): void
+  function enableNetConnect(
+    matcher?: string | RegExp | ((host: string) => boolean)
+  ): void
   function load(path: string): Scope[]
   function loadDefs(path: string): Definition[]
   function define(defs: Definition[]): Scope[]

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -703,6 +703,9 @@ nock.enableNetConnect('example.test')
 // or a RegExp
 nock.enableNetConnect(/example\.(com|test)/)
 
+// or a Function
+nock.enableNetConnect(host => host.includes('example.com'))
+
 nock.disableNetConnect()
 nock.enableNetConnect('127.0.0.1') // Allow localhost connections so we can test local routes and mock servers.
 


### PR DESCRIPTION
Fixes https://github.com/nock/nock/issues/1861

I've also uncovered a bug in the usage of `assertRejects` - the third parameter is not used by the library to match on the error message, but rather the message to print when the expected rejection does not happen. I will create a separate PR to fix all usages of `assertRejects` in the project.