### PR TITLE
test: fix assertRejects usage

### DIFF
--- a/tests/test_basic_auth.js
+++ b/tests/test_basic_auth.js
@@ -27,8 +27,7 @@ test('basic auth with username and password', async t => {
   await t.test('fails when it doesnt match', async tt => {
     await assertRejects(
       got('http://example.test/test'),
-      Error,
-      'Nock: No match for request'
+      /Nock: No match for request/
     )
   })
 })
@@ -51,8 +50,7 @@ test('basic auth with username only', async t => {
   await t.test('fails when it doesnt match', async tt => {
     await assertRejects(
       got('http://example.test/test'),
-      Error,
-      'Nock: No match for request'
+      /Nock: No match for request/
     )
   })
 })

--- a/tests/test_delay.js
+++ b/tests/test_delay.js
@@ -359,11 +359,7 @@ test('delay with replyWithError: response is delayed', async t => {
   await resolvesInAtLeast(
     t,
     async () =>
-      assertRejects(
-        got('http://example.test'),
-        Error,
-        'this is an error message'
-      ),
+      assertRejects(got('http://example.test'), /this is an error message/),
     100
   )
 })

--- a/tests/test_header_matching.js
+++ b/tests/test_header_matching.js
@@ -158,8 +158,7 @@ test('match header on scope with function: does not match when match declined', 
     got('http://example.test/', {
       headers: { 'X-My-Headers': 456 },
     }),
-    Error,
-    'Nock: No match for request'
+    /Nock: No match for request/
   )
 })
 
@@ -173,8 +172,7 @@ test('match header on scope with function: does not consume mock request when ma
     got('http://example.test/', {
       headers: { '-My-Headers': 456 },
     }),
-    Error,
-    'Nock: No match for request'
+    /Nock: No match for request/
   )
   t.throws(() => scope.done(), {
     message: 'Mocks not yet satisfied',
@@ -251,8 +249,7 @@ test('match header on interceptor with function: does not match when match decli
     got('http://example.test/', {
       headers: { 'X-My-Headers': 456 },
     }),
-    Error,
-    'Nock: No match for request'
+    /Nock: No match for request/
   )
 })
 
@@ -268,8 +265,7 @@ test('match header on interceptor with function: does not consume mock request w
     got('http://example.test/', {
       headers: { '-My-Headers': 456 },
     }),
-    Error,
-    'Nock: No match for request'
+    /Nock: No match for request/
   )
   t.throws(() => scope.done(), {
     message: 'Mocks not yet satisfied',
@@ -342,8 +338,7 @@ test('done fails when specified request header is missing', async t => {
     got.post('http://example.test/', {
       headers: { 'X-App-Token': 'apptoken' },
     }),
-    Error,
-    'Nock: No match for request'
+    /Nock: No match for request/
   )
 })
 
@@ -375,8 +370,7 @@ test('does not match when request header does not match regular expression', asy
     got.post('http://example.test/', {
       headers: { 'X-My-Super-Power': 'mullet growing' },
     }),
-    Error,
-    'Nock: No match'
+    /Nock: No match/
   )
 
   t.false(scope.isDone())
@@ -440,8 +434,7 @@ test("doesn't match when request header does not satisfy the header function", a
     got.post('http://example.test/', {
       headers: { 'X-My-Super-Power': 'mullet growing' },
     }),
-    Error,
-    'Nock: No match'
+    /Nock: No match/
   )
 
   t.false(scope.isDone())
@@ -479,8 +472,7 @@ test('when badheaders are present, badheaders prevents match', async t => {
     got('http://example.test/', {
       headers: { Cookie: 'cookie', Donut: 'donut' },
     }),
-    Error,
-    'Nock: No match for request'
+    /Nock: No match for request/
   )
 
   t.false(scope.isDone())
@@ -652,7 +644,6 @@ test('Host header is used to reject a match if defined on the scope and request'
     got('http://example.test/', {
       headers: { Host: 'some.other.domain.test' },
     }),
-    Error,
-    'Nock: No match for request'
+    /Nock: No match for request/
   )
 })

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -767,11 +767,7 @@ test('do not match when conditionally = false but should match after trying agai
     .get('/')
     .reply(200)
 
-  await assertRejects(
-    got('http://example.test/'),
-    Error,
-    'Nock: No match for request'
-  )
+  await assertRejects(got('http://example.test/'), /Nock: No match for request/)
   expect(scope.isDone()).to.be.false()
 
   enabled = true
@@ -1045,8 +1041,7 @@ test('match path using function', async t => {
 
   await assertRejects(
     got.head('http://example.test/do/not/match'),
-    got.RequestError,
-    'Nock: No match for request'
+    /Nock: No match for request/
   )
 })
 
@@ -1061,8 +1056,7 @@ test('you must setup an interceptor for each request', async t => {
 
   await assertRejects(
     got('http://example.test/hey'),
-    Error,
-    'Nock: No match for request'
+    /Nock: No match for request/
   )
 })
 

--- a/tests/test_net_connect.js
+++ b/tests/test_net_connect.js
@@ -19,15 +19,14 @@ describe('`disableNetConnect()`', () => {
 
     await assertRejects(
       got('https://other.example.test/'),
-      Error,
-      'Nock: Disallowed net connect for "other.example.test:443/"'
+      /Nock: Disallowed net connect for "other.example.test:443\/"/
     )
   })
 
   it('prevents connections when no hosts are mocked', async () => {
     nock.disableNetConnect()
 
-    await assertRejects(got('http://example.test'), Error, err => {
+    await assertRejects(got('http://example.test'), err => {
       expect(err).to.include({
         code: 'ENETUNREACH',
         message: 'Nock: Disallowed net connect for "example.test:80/"',
@@ -61,8 +60,7 @@ describe('`enableNetConnect()`', () => {
 
     await assertRejects(
       got('https://example.test/'),
-      Error,
-      'Nock: Disallowed net connect for "example.test:80/"'
+      /Nock: Disallowed net connect for "example.test:443\/"/
     )
   })
 
@@ -88,8 +86,7 @@ describe('`enableNetConnect()`', () => {
 
     await assertRejects(
       got('https://example.test/'),
-      Error,
-      'Nock: Disallowed net connect for "example.test:80/"'
+      /Nock: Disallowed net connect for "example.test:443\/"/
     )
   })
 })

--- a/tests/test_persist_optionally.js
+++ b/tests/test_persist_optionally.js
@@ -225,8 +225,7 @@ describe('`persist()`', () => {
 
     await assertRejects(
       got('http://example.test/'),
-      Error,
-      'Nock: No match for request'
+      /Nock: No match for request/
     )
   })
 

--- a/tests/test_query.js
+++ b/tests/test_query.js
@@ -145,8 +145,7 @@ describe('`query()`', () => {
 
       await assertRejects(
         got('http://example.test/?foo=hello%20world'),
-        Error,
-        'Nock: No match for request'
+        /Nock: No match for request/
       )
 
       const { statusCode } = await got(
@@ -186,8 +185,7 @@ describe('`query()`', () => {
 
       await assertRejects(
         got('http://example.test/?foo=baz'),
-        Error,
-        'Nock: No match for request'
+        /Nock: No match for request/
       )
     })
 
@@ -199,8 +197,7 @@ describe('`query()`', () => {
 
       await assertRejects(
         got('http://example.test/?foo=bar&baz=foz'),
-        Error,
-        'Nock: No match for request'
+        /Nock: No match for request/
       )
     })
 
@@ -214,8 +211,7 @@ describe('`query()`', () => {
 
       await assertRejects(
         got('http://example.test/?foobar'),
-        Error,
-        'Nock: No match for request'
+        /Nock: No match for request/
       )
     })
 
@@ -232,8 +228,7 @@ describe('`query()`', () => {
 
       await assertRejects(
         got('http://example.test/?num=1str=fou'),
-        Error,
-        'Nock: No match for request'
+        /Nock: No match for request/
       )
     })
 
@@ -245,8 +240,7 @@ describe('`query()`', () => {
 
       await assertRejects(
         got('http://example.test?foo[]=bar&foo[]=baz'),
-        got.RequestError,
-        'Nock: No match for request'
+        /Nock: No match for request/
       )
     })
 
@@ -258,8 +252,7 @@ describe('`query()`', () => {
 
       await assertRejects(
         got('http://example.test?foo=bar%2Cbaz'),
-        got.RequestError,
-        'Nock: No match for request'
+        /Nock: No match for request/
       )
     })
   })
@@ -355,8 +348,7 @@ describe('`query()`', () => {
 
       await assertRejects(
         got('http://example.test/?i=should&pass=?'),
-        Error,
-        'Nock: No match for request'
+        /Nock: No match for request/
       )
     })
   })

--- a/tests/test_repeating.js
+++ b/tests/test_repeating.js
@@ -19,8 +19,7 @@ describe('repeating', () => {
 
     await assertRejects(
       got('http://example.test/'),
-      Error,
-      'Nock: No match for request'
+      /Nock: No match for request/
     )
 
     scope.done()
@@ -40,8 +39,7 @@ describe('repeating', () => {
 
     await assertRejects(
       got('http://example.test/'),
-      Error,
-      'Nock: No match for request'
+      /Nock: No match for request/
     )
 
     scope.done()
@@ -61,8 +59,7 @@ describe('repeating', () => {
 
     await assertRejects(
       got('http://example.test/'),
-      Error,
-      'Nock: No match for request'
+      /Nock: No match for request/
     )
 
     scope.done()
@@ -83,8 +80,7 @@ describe('repeating', () => {
 
       await assertRejects(
         got('http://example.test/'),
-        Error,
-        'Nock: No match for request'
+        /Nock: No match for request/
       )
 
       scope.done()
@@ -101,8 +97,7 @@ describe('repeating', () => {
 
       await assertRejects(
         got('http://example.test/'),
-        Error,
-        'Nock: No match for request'
+        /Nock: No match for request/
       )
 
       scope.done()

--- a/tests/test_reply_function_async.js
+++ b/tests/test_reply_function_async.js
@@ -60,11 +60,7 @@ describe('asynchronous `reply()` function', () => {
           callback(new Error('Database failed'))
         )
 
-      await assertRejects(
-        got('http://example.test'),
-        got.RequestError,
-        'Database failed'
-      )
+      await assertRejects(got('http://example.test'), /Database failed/)
     })
 
     it('an error passed to the callback propagates when [err, fullResponseArray] is expected', async () => {
@@ -74,7 +70,7 @@ describe('asynchronous `reply()` function', () => {
           callback(Error('boom'))
         })
 
-      await assertRejects(got('http://example.test'), got.RequestError, 'boom')
+      await assertRejects(got('http://example.test'), /boom/)
     })
 
     it('subsequent calls to the reply callback are ignored', async () => {
@@ -137,11 +133,7 @@ describe('asynchronous `reply()` function', () => {
           throw Error('oh no!')
         })
 
-      await assertRejects(
-        got('http://example.test'),
-        got.RequestError,
-        'oh no!'
-      )
+      await assertRejects(got('http://example.test'), /oh no!/)
     })
 
     it('when reply is called with an async function that throws, it propagates the error', async () => {
@@ -151,11 +143,7 @@ describe('asynchronous `reply()` function', () => {
           throw Error('oh no!')
         })
 
-      await assertRejects(
-        got('http://example.test'),
-        got.RequestError,
-        'oh no!'
-      )
+      await assertRejects(got('http://example.test'), /oh no!/)
     })
   })
 })


### PR DESCRIPTION
As mentioned in https://github.com/nock/nock/pull/1889, it appears that `assertRejects` is not currently used correctly - the third parameter is the message that the assertion emits if it fails, not a matcher for the exception text.

This PR fixes all usages of `assertRejects` to correct expect on the error message. It might also be worth considering migrating to something like `chai-as-promised` for a more standard chai based approach.

[Runkit](https://runkit.com/embed/6ywp0lq4dfhr) with an example.