### PR TITLE
refactor(test): Chai assert allow unmocked

### DIFF
--- a/tests/test_allow_unmocked.js
+++ b/tests/test_allow_unmocked.js
@@ -2,22 +2,21 @@
 
 const http = require('http')
 const { expect } = require('chai')
-const url = require('url')
-const mikealRequest = require('request')
 const { test } = require('tap')
 const nock = require('..')
 const got = require('./got_client')
 
 require('./cleanup_after_each')()
+require('./setup')
 
-test('with allowUnmocked, mocked request still works', async t => {
+test('with allowUnmocked, mocked request still works', async () => {
   const scope = nock('http://example.test', { allowUnmocked: true })
     .post('/')
     .reply(200, '99problems')
 
   const { body, statusCode } = await got.post('http://example.test/')
-  t.equal(statusCode, 200)
-  t.equal(body, '99problems')
+  expect(statusCode).to.equal(200)
+  expect(body).to.equal('99problems')
 
   scope.done()
 })
@@ -37,17 +36,13 @@ test('allow unmocked works after one interceptor is removed', async t => {
     .get('/')
     .reply(200, 'Mocked')
 
-  t.equal((await got(url)).body, 'Mocked')
-  t.equal((await got(url)).body, 'live')
+  expect((await got(url)).body).to.equal('Mocked')
+  expect((await got(url)).body).to.equal('live')
 })
 
-test('allow unmocked option works', t => {
-  t.plan(7)
-
+test('allow unmocked option allows traffic to server', async t => {
   const server = http.createServer((request, response) => {
-    t.pass('server received a request')
-
-    switch (url.parse(request.url).pathname) {
+    switch (request.url) {
       case '/':
         response.writeHead(200)
         response.write('server served a response')
@@ -64,174 +59,100 @@ test('allow unmocked option works', t => {
     response.end()
   })
 
-  server.listen(() => {
-    const scope = nock(`http://localhost:${server.address().port}`, {
-      allowUnmocked: true,
-    })
-      .get('/abc')
-      .reply(304, 'served from our mock')
-      .get('/wont/get/here')
-      .reply(304, 'served from our mock')
+  await new Promise(resolve => server.listen(resolve))
+  t.once('end', () => server.close())
 
-    function secondIsDone() {
-      t.ok(!scope.isDone())
+  const baseUrl = `http://localhost:${server.address().port}`
+  const scope = nock(baseUrl, { allowUnmocked: true })
+    .get('/abc')
+    .reply(304, 'served from our mock')
+    .get('/wont/get/here')
+    .reply(304, 'served from our mock')
+  const client = got.extend({ baseUrl, throwHttpErrors: false })
 
-      http
-        .request(
-          {
-            host: 'localhost',
-            path: '/',
-            port: server.address().port,
-          },
-          response => {
-            response.destroy()
+  const response1 = await client(`${baseUrl}/abc`)
+  expect(response1.statusCode).to.equal(304)
+  expect(response1.body).to.equal('served from our mock')
+  expect(scope.isDone()).to.equal(false)
 
-            t.is(response.statusCode, 200, 'Do not intercept /')
+  const response2 = await client(`${baseUrl}/not/available`)
+  expect(response2.statusCode).to.equal(404)
+  expect(scope.isDone()).to.equal(false)
 
-            server.close(t.end)
-          }
-        )
-        .end()
-    }
-
-    function firstIsDone() {
-      t.ok(!scope.isDone())
-
-      http
-        .request(
-          {
-            host: 'localhost',
-            path: '/not/available',
-            port: server.address().port,
-          },
-          response => {
-            t.assert(
-              response.statusCode === 404,
-              'Server says it does not exist'
-            )
-
-            response.on('data', function() {})
-            response.on('end', secondIsDone)
-          }
-        )
-        .end()
-    }
-
-    const request = http.request(
-      {
-        host: 'localhost',
-        path: '/abc',
-        port: server.address().port,
-      },
-      response => {
-        t.is(response.statusCode, 304, 'Intercept /abc')
-
-        response.on('end', firstIsDone)
-        // Streams start in 'paused' mode and must be started.
-        // See https://nodejs.org/api/stream.html#stream_class_stream_readable
-        response.resume()
-      }
-    )
-
-    request.on('error', t.error)
-    request.end()
-  })
+  const response3 = await client(`${baseUrl}/`)
+  expect(response3.statusCode).to.equal(200)
+  expect(response3.body).to.equal('server served a response')
+  expect(scope.isDone()).to.equal(false)
 })
 
-test('allow unmocked post with json data', t => {
-  t.plan(3)
-  t.once('end', function() {
-    server.close()
-  })
-
+test('allow unmocked post with json data', async t => {
   const server = http.createServer((request, response) => {
-    t.pass('server received a request')
     response.writeHead(200)
+    response.write('{"message":"server response"}')
     response.end()
   })
 
-  server.listen(() => {
-    nock(`http://localhost:${server.address().port}`, { allowUnmocked: true })
-      .get('/')
-      .reply(200, 'Hey!')
+  await new Promise(resolve => server.listen(resolve))
+  t.once('end', () => server.close())
 
-    const options = {
-      method: 'POST',
-      uri: `http://localhost:${server.address().port}`,
-      json: { some: 'data' },
-    }
+  const url = `http://localhost:${server.address().port}`
+  nock(url, { allowUnmocked: true })
+    .get('/not/accessed')
+    .reply(200, '{"message":"mocked response"}')
 
-    mikealRequest(options, function(err, resp) {
-      t.error(err)
-      t.equal(200, resp.statusCode)
-      t.end()
-    })
+  const { body, statusCode } = await got.post(url, {
+    json: true,
+    body: { some: 'data' },
   })
+  expect(statusCode).to.equal(200)
+  expect(body).to.deep.equal({ message: 'server response' })
 })
 
-test('allow unmocked passthrough with mismatched bodies', t => {
-  t.plan(3)
-  t.once('end', function() {
-    server.close()
-  })
-
+test('allow unmocked passthrough with mismatched bodies', async t => {
   const server = http.createServer((request, response) => {
-    t.pass('server received a request')
     response.writeHead(200)
+    response.write('{"message":"server response"}')
     response.end()
   })
 
-  server.listen(() => {
-    nock(`http://localhost:${server.address().port}`, { allowUnmocked: true })
-      .post('/post', { some: 'other data' })
-      .reply(404, 'Hey!')
+  await new Promise(resolve => server.listen(resolve))
+  t.once('end', () => server.close())
 
-    const options = {
-      method: 'POST',
-      uri: `http://localhost:${server.address().port}/post`,
-      json: { some: 'data' },
-    }
+  const url = `http://localhost:${server.address().port}`
+  nock(url, { allowUnmocked: true })
+    .post('/post', { some: 'other data' })
+    .reply(404, '{"message":"server response"}')
 
-    mikealRequest(options, function(err, resp) {
-      t.error(err)
-      t.equal(200, resp.statusCode)
-      t.end()
-    })
+  const { body, statusCode } = await got.post(`${url}/post`, {
+    json: true,
+    body: { some: 'data' },
   })
+  expect(statusCode).to.equal(200)
+  expect(body).to.deep.equal({ message: 'server response' })
 })
 
-test('match path using regexp with allowUnmocked', t => {
-  nock('http://example.test', { allowUnmocked: true })
+test('match path using regexp with allowUnmocked', async () => {
+  const scope = nock('http://example.test', { allowUnmocked: true })
     .get(/regex$/)
     .reply(200, 'Match regex')
 
-  mikealRequest.get('http://example.test/resources/regex', function(
-    err,
-    res,
-    body
-  ) {
-    t.type(err, 'null')
-    t.equal(res.statusCode, 200)
-    t.equal(body, 'Match regex')
-    t.end()
-  })
+  const { body, statusCode } = await got('http://example.test/resources/regex')
+  expect(statusCode).to.equal(200)
+  expect(body).to.equal('Match regex')
+
+  scope.done()
 })
 
-test('match hostname using regexp with allowUnmocked (issue-1076)', t => {
-  nock(/localhost/, { allowUnmocked: true })
+test('match hostname using regexp with allowUnmocked (issue-1076)', async () => {
+  const scope = nock(/localhost/, { allowUnmocked: true })
     .get('/no/regex/here')
     .reply(200, 'Match regex')
 
-  mikealRequest.get('http://localhost:3000/no/regex/here', function(
-    err,
-    res,
-    body
-  ) {
-    t.type(err, 'null')
-    t.equal(res.statusCode, 200)
-    t.equal(body, 'Match regex')
-    t.end()
-  })
+  const { body, statusCode } = await got('http://localhost:3000/no/regex/here')
+  expect(statusCode).to.equal(200)
+  expect(body).to.equal('Match regex')
+
+  scope.done()
 })
 
 // https://github.com/nock/nock/issues/1867
@@ -264,9 +185,9 @@ test('match multiple paths to domain using regexp with allowUnmocked', async t =
     .get(/bravo/)
     .reply(200, 'bravo, bravo!')
 
-  t.equal((await got(`${url}`)).body, 'live')
-  t.equal((await got(`${url}/alphalicious`)).body, 'this is alpha')
-  t.equal((await got(`${url}/bravo-company`)).body, 'bravo, bravo!')
+  expect((await got(`${url}`)).body).to.equal('live')
+  expect((await got(`${url}/alphalicious`)).body).to.equal('this is alpha')
+  expect((await got(`${url}/bravo-company`)).body).to.equal('bravo, bravo!')
 
   scope1.done()
   scope2.done()
@@ -279,29 +200,22 @@ test('match domain and path with literal query params and allowUnmocked', async 
 
   const { statusCode } = await got('http://example.test/foo?bar=baz')
 
-  t.is(statusCode, 200)
+  expect(statusCode).to.equal(200)
   scope.done()
 })
 
-test('match domain and path using regexp with query params and allowUnmocked', t => {
+test('match domain and path using regexp with query params and allowUnmocked', async t => {
   const imgResponse = 'Matched Images Page'
-  const opts = { allowUnmocked: true }
 
-  const scope = nock(/example/, opts)
+  const scope = nock(/example/, { allowUnmocked: true })
     .get(/imghp\?hl=en/)
     .reply(200, imgResponse)
 
-  mikealRequest.get('http://example.test/imghp?hl=en', function(
-    err,
-    res,
-    body
-  ) {
-    scope.done()
-    t.type(err, 'null')
-    t.equal(res.statusCode, 200)
-    t.equal(body, imgResponse)
-    t.end()
-  })
+  const { body, statusCode } = await got('http://example.test/imghp?hl=en')
+  expect(statusCode).to.equal(200)
+  expect(body).to.equal(imgResponse)
+
+  scope.done()
 })
 
 // https://github.com/nock/nock/issues/490
@@ -319,8 +233,8 @@ test('match when query is specified with allowUnmocked', async t => {
     .query({ q: 'cat pictures' })
     .reply(200, '😻')
 
-  t.equal((await got(url)).body, 'live')
-  t.equal((await got(`${url}/search?q=cat%20pictures`)).body, '😻')
+  expect((await got(url)).body).to.equal('live')
+  expect((await got(`${url}/search?q=cat%20pictures`)).body).to.equal('😻')
 
   scope.done()
 })


### PR DESCRIPTION
Convert assertions to Chai, prefer await over callback when appropriate, and replace Mikeal's Request with Got.
All in the name of prepping for Mocha DSL (https://github.com/nock/nock/issues/1305).