### PR TITLE
refactor(test): use Mocha DSL for allow unmocked

### DIFF
--- a/tests/test_allow_unmocked.js
+++ b/tests/test_allow_unmocked.js
@@ -2,239 +2,238 @@
 
 const http = require('http')
 const { expect } = require('chai')
-const { test } = require('tap')
 const nock = require('..')
 const got = require('./got_client')
 
-require('./cleanup_after_each')()
 require('./setup')
 
-test('with allowUnmocked, mocked request still works', async () => {
-  const scope = nock('http://example.test', { allowUnmocked: true })
-    .post('/')
-    .reply(200, '99problems')
+describe('allowUnmocked option', () => {
+  let _server
 
-  const { body, statusCode } = await got.post('http://example.test/')
-  expect(statusCode).to.equal(200)
-  expect(body).to.equal('99problems')
-
-  scope.done()
-})
-
-test('allow unmocked works after one interceptor is removed', async t => {
-  const server = http.createServer((request, response) => {
-    response.write('live')
-    response.end()
-  })
-  t.once('end', () => server.close())
-
-  await new Promise(resolve => server.listen(resolve))
-
-  const url = `http://localhost:${server.address().port}`
-
-  nock(url, { allowUnmocked: true })
-    .get('/')
-    .reply(200, 'Mocked')
-
-  expect((await got(url)).body).to.equal('Mocked')
-  expect((await got(url)).body).to.equal('live')
-})
-
-test('allow unmocked option allows traffic to server', async t => {
-  const server = http.createServer((request, response) => {
-    switch (request.url) {
-      case '/':
-        response.writeHead(200)
-        response.write('server served a response')
-        break
-      case '/not/available':
-        response.writeHead(404)
-        break
-      case '/abc':
-        response.writeHead(200)
-        response.write('server served a response')
-        break
+  afterEach(() => {
+    if (_server) {
+      _server.close()
+      _server = null
     }
-
-    response.end()
   })
 
-  await new Promise(resolve => server.listen(resolve))
-  t.once('end', () => server.close())
+  const createServer = async requestListener => {
+    const server = http.createServer(requestListener)
+    await new Promise(resolve => server.listen(resolve))
+    _server = server
 
-  const baseUrl = `http://localhost:${server.address().port}`
-  const scope = nock(baseUrl, { allowUnmocked: true })
-    .get('/abc')
-    .reply(304, 'served from our mock')
-    .get('/wont/get/here')
-    .reply(304, 'served from our mock')
-  const client = got.extend({ baseUrl, throwHttpErrors: false })
+    const url = `http://localhost:${server.address().port}`
+    return { server, url }
+  }
 
-  const response1 = await client(`${baseUrl}/abc`)
-  expect(response1.statusCode).to.equal(304)
-  expect(response1.body).to.equal('served from our mock')
-  expect(scope.isDone()).to.equal(false)
+  it('with allowUnmocked, mocked request still works', async () => {
+    const scope = nock('http://example.test', { allowUnmocked: true })
+      .post('/')
+      .reply(200, '99problems')
 
-  const response2 = await client(`${baseUrl}/not/available`)
-  expect(response2.statusCode).to.equal(404)
-  expect(scope.isDone()).to.equal(false)
+    const { body, statusCode } = await got.post('http://example.test/')
+    expect(statusCode).to.equal(200)
+    expect(body).to.equal('99problems')
 
-  const response3 = await client(`${baseUrl}/`)
-  expect(response3.statusCode).to.equal(200)
-  expect(response3.body).to.equal('server served a response')
-  expect(scope.isDone()).to.equal(false)
-})
-
-test('allow unmocked post with json data', async t => {
-  const server = http.createServer((request, response) => {
-    response.writeHead(200)
-    response.write('{"message":"server response"}')
-    response.end()
+    scope.done()
   })
 
-  await new Promise(resolve => server.listen(resolve))
-  t.once('end', () => server.close())
+  it('allow unmocked works after one interceptor is removed', async () => {
+    const { url } = await createServer((request, response) => {
+      response.write('live')
+      response.end()
+    })
 
-  const url = `http://localhost:${server.address().port}`
-  nock(url, { allowUnmocked: true })
-    .get('/not/accessed')
-    .reply(200, '{"message":"mocked response"}')
+    nock(url, { allowUnmocked: true })
+      .get('/')
+      .reply(200, 'Mocked')
 
-  const { body, statusCode } = await got.post(url, {
-    json: true,
-    body: { some: 'data' },
-  })
-  expect(statusCode).to.equal(200)
-  expect(body).to.deep.equal({ message: 'server response' })
-})
-
-test('allow unmocked passthrough with mismatched bodies', async t => {
-  const server = http.createServer((request, response) => {
-    response.writeHead(200)
-    response.write('{"message":"server response"}')
-    response.end()
+    expect((await got(url)).body).to.equal('Mocked')
+    expect((await got(url)).body).to.equal('live')
   })
 
-  await new Promise(resolve => server.listen(resolve))
-  t.once('end', () => server.close())
+  it('allow unmocked option allows traffic to server', async () => {
+    const { url } = await createServer((request, response) => {
+      switch (request.url) {
+        case '/':
+          response.writeHead(200)
+          response.write('server served a response')
+          break
+        case '/not/available':
+          response.writeHead(404)
+          break
+        case '/abc':
+          response.writeHead(200)
+          response.write('server served a response')
+          break
+      }
 
-  const url = `http://localhost:${server.address().port}`
-  nock(url, { allowUnmocked: true })
-    .post('/post', { some: 'other data' })
-    .reply(404, '{"message":"server response"}')
+      response.end()
+    })
 
-  const { body, statusCode } = await got.post(`${url}/post`, {
-    json: true,
-    body: { some: 'data' },
+    const scope = nock(url, { allowUnmocked: true })
+      .get('/abc')
+      .reply(304, 'served from our mock')
+      .get('/wont/get/here')
+      .reply(304, 'served from our mock')
+    const client = got.extend({ baseUrl: url, throwHttpErrors: false })
+
+    const response1 = await client(`${url}/abc`)
+    expect(response1.statusCode).to.equal(304)
+    expect(response1.body).to.equal('served from our mock')
+    expect(scope.isDone()).to.equal(false)
+
+    const response2 = await client(`${url}/not/available`)
+    expect(response2.statusCode).to.equal(404)
+    expect(scope.isDone()).to.equal(false)
+
+    const response3 = await client(`${url}/`)
+    expect(response3.statusCode).to.equal(200)
+    expect(response3.body).to.equal('server served a response')
+    expect(scope.isDone()).to.equal(false)
   })
-  expect(statusCode).to.equal(200)
-  expect(body).to.deep.equal({ message: 'server response' })
-})
 
-test('match path using regexp with allowUnmocked', async () => {
-  const scope = nock('http://example.test', { allowUnmocked: true })
-    .get(/regex$/)
-    .reply(200, 'Match regex')
+  it('allow unmocked post with json data', async () => {
+    const { url } = await createServer((request, response) => {
+      response.writeHead(200)
+      response.write('{"message":"server response"}')
+      response.end()
+    })
 
-  const { body, statusCode } = await got('http://example.test/resources/regex')
-  expect(statusCode).to.equal(200)
-  expect(body).to.equal('Match regex')
+    nock(url, { allowUnmocked: true })
+      .get('/not/accessed')
+      .reply(200, '{"message":"mocked response"}')
 
-  scope.done()
-})
-
-test('match hostname using regexp with allowUnmocked (issue-1076)', async () => {
-  const scope = nock(/localhost/, { allowUnmocked: true })
-    .get('/no/regex/here')
-    .reply(200, 'Match regex')
-
-  const { body, statusCode } = await got('http://localhost:3000/no/regex/here')
-  expect(statusCode).to.equal(200)
-  expect(body).to.equal('Match regex')
-
-  scope.done()
-})
-
-// https://github.com/nock/nock/issues/1867
-test('match path using callback with allowUnmocked', async t => {
-  const scope = nock('http://example.test', { allowUnmocked: true })
-    .get(uri => uri.endsWith('bar'))
-    .reply()
-
-  const { statusCode } = await got('http://example.test/foo/bar')
-  expect(statusCode).to.equal(200)
-
-  scope.done()
-})
-
-// https://github.com/nock/nock/issues/835
-test('match multiple paths to domain using regexp with allowUnmocked', async t => {
-  const server = http.createServer((request, response) => {
-    response.write('live')
-    response.end()
+    const { body, statusCode } = await got.post(url, {
+      json: true,
+      body: { some: 'data' },
+    })
+    expect(statusCode).to.equal(200)
+    expect(body).to.deep.equal({ message: 'server response' })
   })
-  t.once('end', () => server.close())
-  await new Promise(resolve => server.listen(resolve))
-  const url = `http://localhost:${server.address().port}`
 
-  const scope1 = nock(/localhost/, { allowUnmocked: true })
-    .get(/alpha/)
-    .reply(200, 'this is alpha')
+  it('allow unmocked passthrough with mismatched bodies', async () => {
+    const { url } = await createServer((request, response) => {
+      response.writeHead(200)
+      response.write('{"message":"server response"}')
+      response.end()
+    })
 
-  const scope2 = nock(/localhost/, { allowUnmocked: true })
-    .get(/bravo/)
-    .reply(200, 'bravo, bravo!')
+    nock(url, { allowUnmocked: true })
+      .post('/post', { some: 'other data' })
+      .reply(404, '{"message":"server response"}')
 
-  expect((await got(`${url}`)).body).to.equal('live')
-  expect((await got(`${url}/alphalicious`)).body).to.equal('this is alpha')
-  expect((await got(`${url}/bravo-company`)).body).to.equal('bravo, bravo!')
-
-  scope1.done()
-  scope2.done()
-})
-
-test('match domain and path with literal query params and allowUnmocked', async t => {
-  const scope = nock('http://example.test', { allowUnmocked: true })
-    .get('/foo?bar=baz')
-    .reply()
-
-  const { statusCode } = await got('http://example.test/foo?bar=baz')
-
-  expect(statusCode).to.equal(200)
-  scope.done()
-})
-
-test('match domain and path using regexp with query params and allowUnmocked', async t => {
-  const imgResponse = 'Matched Images Page'
-
-  const scope = nock(/example/, { allowUnmocked: true })
-    .get(/imghp\?hl=en/)
-    .reply(200, imgResponse)
-
-  const { body, statusCode } = await got('http://example.test/imghp?hl=en')
-  expect(statusCode).to.equal(200)
-  expect(body).to.equal(imgResponse)
-
-  scope.done()
-})
-
-// https://github.com/nock/nock/issues/490
-test('match when query is specified with allowUnmocked', async t => {
-  const server = http.createServer((request, response) => {
-    response.write('live')
-    response.end()
+    const { body, statusCode } = await got.post(`${url}/post`, {
+      json: true,
+      body: { some: 'data' },
+    })
+    expect(statusCode).to.equal(200)
+    expect(body).to.deep.equal({ message: 'server response' })
   })
-  t.once('end', () => server.close())
-  await new Promise(resolve => server.listen(resolve))
-  const url = `http://localhost:${server.address().port}`
 
-  const scope = nock(url, { allowUnmocked: true })
-    .get('/search')
-    .query({ q: 'cat pictures' })
-    .reply(200, '😻')
+  it('match path using regexp with allowUnmocked', async () => {
+    const scope = nock('http://example.test', { allowUnmocked: true })
+      .get(/regex$/)
+      .reply(200, 'Match regex')
 
-  expect((await got(url)).body).to.equal('live')
-  expect((await got(`${url}/search?q=cat%20pictures`)).body).to.equal('😻')
+    const { body, statusCode } = await got(
+      'http://example.test/resources/regex'
+    )
+    expect(statusCode).to.equal(200)
+    expect(body).to.equal('Match regex')
 
-  scope.done()
+    scope.done()
+  })
+
+  it('match hostname using regexp with allowUnmocked (issue-1076)', async () => {
+    const scope = nock(/localhost/, { allowUnmocked: true })
+      .get('/no/regex/here')
+      .reply(200, 'Match regex')
+
+    const { body, statusCode } = await got(
+      'http://localhost:3000/no/regex/here'
+    )
+    expect(statusCode).to.equal(200)
+    expect(body).to.equal('Match regex')
+
+    scope.done()
+  })
+
+  // https://github.com/nock/nock/issues/1867
+  it('match path using callback with allowUnmocked', async () => {
+    const scope = nock('http://example.test', { allowUnmocked: true })
+      .get(uri => uri.endsWith('bar'))
+      .reply()
+
+    const { statusCode } = await got('http://example.test/foo/bar')
+    expect(statusCode).to.equal(200)
+
+    scope.done()
+  })
+
+  // https://github.com/nock/nock/issues/835
+  it('match multiple paths to domain using regexp with allowUnmocked', async () => {
+    const { url } = await createServer((request, response) => {
+      response.write('live')
+      response.end()
+    })
+
+    const scope1 = nock(/localhost/, { allowUnmocked: true })
+      .get(/alpha/)
+      .reply(200, 'this is alpha')
+
+    const scope2 = nock(/localhost/, { allowUnmocked: true })
+      .get(/bravo/)
+      .reply(200, 'bravo, bravo!')
+
+    expect((await got(`${url}`)).body).to.equal('live')
+    expect((await got(`${url}/alphalicious`)).body).to.equal('this is alpha')
+    expect((await got(`${url}/bravo-company`)).body).to.equal('bravo, bravo!')
+
+    scope1.done()
+    scope2.done()
+  })
+
+  it('match domain and path with literal query params and allowUnmocked', async () => {
+    const scope = nock('http://example.test', { allowUnmocked: true })
+      .get('/foo?bar=baz')
+      .reply()
+
+    const { statusCode } = await got('http://example.test/foo?bar=baz')
+
+    expect(statusCode).to.equal(200)
+    scope.done()
+  })
+
+  it('match domain and path using regexp with query params and allowUnmocked', async () => {
+    const imgResponse = 'Matched Images Page'
+
+    const scope = nock(/example/, { allowUnmocked: true })
+      .get(/imghp\?hl=en/)
+      .reply(200, imgResponse)
+
+    const { body, statusCode } = await got('http://example.test/imghp?hl=en')
+    expect(statusCode).to.equal(200)
+    expect(body).to.equal(imgResponse)
+
+    scope.done()
+  })
+
+  // https://github.com/nock/nock/issues/490
+  it('match when query is specified with allowUnmocked', async () => {
+    const { url } = await createServer((request, response) => {
+      response.write('live')
+      response.end()
+    })
+
+    const scope = nock(url, { allowUnmocked: true })
+      .get('/search')
+      .query({ q: 'cat pictures' })
+      .reply(200, '😻')
+
+    expect((await got(url)).body).to.equal('live')
+    expect((await got(`${url}/search?q=cat%20pictures`)).body).to.equal('😻')
+
+    scope.done()
+  })
 })

--- a/tests/test_allow_unmocked.js
+++ b/tests/test_allow_unmocked.js
@@ -17,7 +17,7 @@ describe('allowUnmocked option', () => {
     }
   })
 
-  const createServer = async requestListener => {
+  async function createServer(requestListener) {
     const server = http.createServer(requestListener)
     await new Promise(resolve => server.listen(resolve))
     _server = server
@@ -145,7 +145,8 @@ describe('allowUnmocked option', () => {
     scope.done()
   })
 
-  it('match hostname using regexp with allowUnmocked (issue-1076)', async () => {
+  // https://github.com/nock/nock/issues/1076
+  it('match hostname using regexp with allowUnmocked', async () => {
     const scope = nock(/localhost/, { allowUnmocked: true })
       .get('/no/regex/here')
       .reply(200, 'Match regex')

--- a/tests/test_allow_unmocked_https.js
+++ b/tests/test_allow_unmocked_https.js
@@ -1,114 +1,107 @@
 'use strict'
 
-const { test } = require('tap')
 const { expect } = require('chai')
-const fs = require('fs')
-const https = require('https')
 const nock = require('..')
 const ssl = require('./ssl')
 const got = require('./got_client')
 
-require('./cleanup_after_each')()
 require('./setup')
 
-test('Nock with allowUnmocked and an url match', async t => {
-  const server = https.createServer(
-    {
-      key: fs.readFileSync('tests/ssl/ca.key'),
-      cert: fs.readFileSync('tests/ssl/ca.crt'),
-    },
-    (req, res) => {
+describe('allowUnmocked option (https)', () => {
+  let server
+
+  afterEach(() => {
+    if (server) {
+      server.close()
+      server = null
+    }
+  })
+
+  it('Nock with allowUnmocked and an url match', async () => {
+    server = await ssl.startServer((req, res) => {
       res.writeHead(200)
       res.end({ status: 'default' })
-    }
-  )
-  t.on('end', () => server.close())
+    })
+    const url = `https://127.0.0.1:${server.address().port}`
 
-  await new Promise(resolve => server.listen(resolve))
+    const scope = nock(url, { allowUnmocked: true })
+      .get('/urlMatch')
+      .reply(201, JSON.stringify({ status: 'intercepted' }))
 
-  const url = `https://127.0.0.1:${server.address().port}`
+    const { body, statusCode } = await got(`${url}/urlMatch`, { ca: ssl.ca })
 
-  const scope = nock(url, { allowUnmocked: true })
-    .get('/urlMatch')
-    .reply(201, JSON.stringify({ status: 'intercepted' }))
+    expect(statusCode).to.equal(201)
+    expect(body).to.equal('{"status":"intercepted"}')
 
-  const { body, statusCode } = await got(`${url}/urlMatch`, {
-    rejectUnauthorized: false,
+    scope.done()
   })
 
-  expect(statusCode).to.equal(201)
-  expect(body).to.equal('{"status":"intercepted"}')
+  it('allow unmocked option works with https', async () => {
+    server = await ssl.startServer((request, response) => {
+      if (request.url === '/does/not/exist') {
+        response.writeHead(404)
+        response.end()
+        return
+      }
 
-  scope.done()
-})
-
-test('allow unmocked option works with https', async t => {
-  const server = await ssl.startServer((request, response) => {
-    if (request.url === '/does/not/exist') {
-      response.writeHead(404)
+      response.writeHead(200)
+      response.write('server response')
       response.end()
-      return
-    }
+    })
 
-    response.writeHead(200)
-    response.write('server response')
-    response.end()
-  })
-  t.once('end', () => server.close())
+    const { port } = server.address()
+    const url = `https://localhost:${port}`
+    const client = got.extend({
+      baseUrl: url,
+      ca: ssl.ca,
+      throwHttpErrors: false,
+    })
 
-  const { port } = server.address()
-  const url = `https://localhost:${port}`
-  const client = got.extend({
-    baseUrl: url,
-    ca: ssl.ca,
-    throwHttpErrors: false,
-  })
+    const scope = nock(url, { allowUnmocked: true })
+      .get('/abc')
+      .reply(200, 'mocked response')
+      .get('/wont/get/here')
+      .reply(500)
 
-  const scope = nock(url, { allowUnmocked: true })
-    .get('/abc')
-    .reply(200, 'mocked response')
-    .get('/wont/get/here')
-    .reply(500)
+    const response1 = await client('/abc')
+    expect(response1.statusCode).to.equal(200)
+    expect(response1.body).to.equal('mocked response')
+    expect(scope.isDone()).to.equal(false)
+    const response2 = await client('/does/not/exist')
 
-  const response1 = await client('/abc')
-  expect(response1.statusCode).to.equal(200)
-  expect(response1.body).to.equal('mocked response')
-  expect(scope.isDone()).to.equal(false)
-  const response2 = await client('/does/not/exist')
+    expect(response2.statusCode).to.equal(404)
+    expect(scope.isDone()).to.equal(false)
+    const response3 = await client('/')
 
-  expect(response2.statusCode).to.equal(404)
-  expect(scope.isDone()).to.equal(false)
-  const response3 = await client('/')
-
-  expect(response3.statusCode).to.equal(200)
-  expect(response3.body).to.equal('server response')
-  expect(scope.isDone()).to.equal(false)
-})
-
-test('allow unmocked option works with https for a partial match', async () => {
-  // The `allowUnmocked` option is processed in two places. Once in the intercept when there
-  // are no interceptors that come close to matching the request. And again in the overrider when
-  // there are interceptors that partially match, eg just path, but don't completely match.
-  // This explicitly tests the later case in the overrider by making an HTTPS request for a path
-  // that has an interceptor but fails to match the query constraint.
-  const server = await ssl.startServer((request, response) => {
-    response.writeHead(201)
-    response.write('foo')
-    response.end()
+    expect(response3.statusCode).to.equal(200)
+    expect(response3.body).to.equal('server response')
+    expect(scope.isDone()).to.equal(false)
   })
 
-  const { port } = server.address()
-  const origin = `https://localhost:${port}`
+  it('allow unmocked option works with https for a partial match', async () => {
+    // The `allowUnmocked` option is processed in two places. Once in the intercept when there
+    // are no interceptors that come close to matching the request. And again in the overrider when
+    // there are interceptors that partially match, eg just path, but don't completely match.
+    // This explicitly tests the later case in the overrider by making an HTTPS request for a path
+    // that has an interceptor but fails to match the query constraint.
+    server = await ssl.startServer((request, response) => {
+      response.writeHead(201)
+      response.write('foo')
+      response.end()
+    })
 
-  nock(origin, { allowUnmocked: true })
-    .get('/foo')
-    .query({ foo: 'bar' })
-    .reply(418)
+    const { port } = server.address()
+    const origin = `https://localhost:${port}`
 
-  // no query so wont match the interceptor
-  const { statusCode, body } = await got(`${origin}/foo`, { ca: ssl.ca })
+    nock(origin, { allowUnmocked: true })
+      .get('/foo')
+      .query({ foo: 'bar' })
+      .reply(418)
 
-  expect(statusCode).to.equal(201)
-  expect(body).to.equal('foo')
-  server.close()
+    // no query so wont match the interceptor
+    const { statusCode, body } = await got(`${origin}/foo`, { ca: ssl.ca })
+
+    expect(statusCode).to.equal(201)
+    expect(body).to.equal('foo')
+  })
 })


### PR DESCRIPTION
For: #1305

Because of the indention changes, reviewing this PR without whitespace is much easier:
https://github.com/nock/nock/pull/1894/files?w=1