### PR TITLE
Revert breaking changes from v11.9.0

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -121,5 +121,5 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10, 12, 13]
+        node-version: [8, 10, 12, 13]
         os: [macos-latest, ubuntu-latest, windows-latest]

--- a/README.md
+++ b/README.md
@@ -1154,7 +1154,7 @@ For enabling any real HTTP requests (the default behavior):
 nock.enableNetConnect()
 ```
 
-You could allow real HTTP requests for certain host names by providing a string or a regular expression for the hostname, or a function that accepts the hostname and returns true or false:
+You could allow real HTTP requests for certain host names by providing a string or a regular expression for the hostname:
 
 ```js
 // Using a string
@@ -1162,11 +1162,6 @@ nock.enableNetConnect('amazon.com')
 
 // Or a RegExp
 nock.enableNetConnect(/(amazon|github)\.com/)
-
-// Or a Function
-nock.enableNetConnect(
-  host => host.includes('amazon.com') || host.includes('github.com')
-)
 
 http.get('http://www.amazon.com/')
 http.get('http://github.com/')

--- a/index.js
+++ b/index.js
@@ -29,7 +29,14 @@ Object.assign(module.exports, {
   removeInterceptor,
   disableNetConnect,
   enableNetConnect,
-  cleanAll: removeAll,
+  // TODO-12.x Historically `nock.cleanAll()` has returned the nock global.
+  // The other global methods do not do this, so it's not clear this was
+  // deliberate or is even helpful. This shim is included for backward
+  // compatibility and should be replaced with an alias to `removeAll()`.
+  cleanAll() {
+    removeAll()
+    return module.exports
+  },
   abortPendingRequests,
   load,
   loadDefs,

--- a/lib/back.js
+++ b/lib/back.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('assert')
+const _ = require('lodash')
 const recorder = require('./recorder')
 const {
   activate,
@@ -60,7 +61,8 @@ function Back(fixtureName, options, nockedFn) {
     )
   }
 
-  if (typeof fixtureName !== 'string') {
+  // TODO-12.x: Replace with `typeof fixtureName === 'string'`.
+  if (!_.isString(fixtureName)) {
     throw new Error('Parameter fixtureName must be a string')
   }
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -174,7 +174,8 @@ function stringifyRequest(options, body) {
 
 function isContentEncoded(headers) {
   const contentEncoding = headers['content-encoding']
-  return typeof contentEncoding === 'string' && contentEncoding !== ''
+  // TODO-12.x: Replace with `typeof contentEncoding === 'string'`.
+  return _.isString(contentEncoding) && contentEncoding !== ''
 }
 
 function contentEncoding(headers, encoder) {
@@ -363,7 +364,8 @@ function deleteHeadersField(headers, fieldNameToDelete) {
     throw Error('headers must be an object')
   }
 
-  if (typeof fieldNameToDelete !== 'string') {
+  // TODO-12.x: Replace with `typeof fieldNameToDelete !== 'string'`.
+  if (!_.isString(fieldNameToDelete)) {
     throw Error('field name must be a string')
   }
 
@@ -444,7 +446,8 @@ function formatQueryValue(key, value, stringFormattingFn) {
     case value === undefined:
       value = ''
       break
-    case typeof value === 'string':
+    // TODO-12.x: Replace with `typeof value === 'string'`.
+    case _.isString(value):
       if (stringFormattingFn) {
         value = stringFormattingFn(value)
       }

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -8,6 +8,7 @@ const { InterceptedRequestRouter } = require('./intercepted_request_router')
 const common = require('./common')
 const { inherits } = require('util')
 const http = require('http')
+const _ = require('lodash')
 const debug = require('debug')('nock.intercept')
 const globalEmitter = require('./global_emitter')
 
@@ -49,17 +50,13 @@ let allowNetConnect
  * @example
  * // Enables real requests for url that matches google and amazon
  * nock.enableNetConnect(/(google|amazon)/);
- * @example
- * // Enables real requests for url that includes google
- * nock.enableNetConnect(host => host.includes('google'));
  */
 function enableNetConnect(matcher) {
-  if (typeof matcher === 'string') {
+  // TODO-12.x: Replace with `typeof matcher === 'string'`.
+  if (_.isString(matcher)) {
     allowNetConnect = new RegExp(matcher)
   } else if (matcher instanceof RegExp) {
     allowNetConnect = matcher
-  } else if (typeof matcher === 'function') {
-    allowNetConnect = { test: matcher }
   } else {
     allowNetConnect = /.*/
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -691,9 +691,9 @@
       }
     },
     "@sindresorhus/is": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-1.2.0.tgz",
-      "integrity": "sha512-mwhXGkRV5dlvQc4EgPDxDxO6WuMBVymGFd1CA+2Y+z5dG9MNspoQ+AWjl/Ld1MnpCL8AKbosZlDVohqcIwuWsw==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true
     },
     "@sinonjs/commons": {
@@ -742,12 +742,12 @@
       "dev": true
     },
     "@szmarczak/http-timer": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
-      "integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
       "dev": true,
       "requires": {
-        "defer-to-connect": "^2.0.0"
+        "defer-to-connect": "^1.0.1"
       }
     },
     "@tootallnate/once": {
@@ -756,38 +756,11 @@
       "integrity": "sha512-KYyTT/T6ALPkIRd2Ge080X/BsXvy9O0hcWTtMWkPvwAwF99+vn6Dv4GzrFT/Nn1LePr+FFDbRXXlqmsy9lw2zA==",
       "dev": true
     },
-    "@types/cacheable-request": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
-      "integrity": "sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==",
-      "dev": true,
-      "requires": {
-        "@types/http-cache-semantics": "*",
-        "@types/keyv": "*",
-        "@types/node": "*",
-        "@types/responselike": "*"
-      }
-    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
-    },
-    "@types/http-cache-semantics": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
-      "integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==",
-      "dev": true
-    },
-    "@types/keyv": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
-      "integrity": "sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/node": {
       "version": "13.7.0",
@@ -812,15 +785,6 @@
       "resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.10.1.tgz",
       "integrity": "sha512-MoF2IC9oGSgArJwlxdst4XsvWuoYfNUWtBw0kpnCi6K05kV+Ecl7siEeJ40tgCbI9uqEMGQL/NlPMRv6KVkY5Q==",
       "dev": true
-    },
-    "@types/responselike": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
-      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/retry": {
       "version": "0.12.0",
@@ -1203,28 +1167,19 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
-    "cacheable-lookup": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-2.0.0.tgz",
-      "integrity": "sha512-s2piO6LvA7xnL1AR03wuEdSx3BZT3tIJpZ56/lcJwzO/6DTJZlTs7X3lrvPxk6d1PlDe6PrVe2TjlUIZNFglAQ==",
-      "dev": true,
-      "requires": {
-        "keyv": "^4.0.0"
-      }
-    },
     "cacheable-request": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
-      "integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
       "dev": true,
       "requires": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
         "http-cache-semantics": "^4.0.0",
-        "keyv": "^4.0.0",
+        "keyv": "^3.0.0",
         "lowercase-keys": "^2.0.0",
         "normalize-url": "^4.1.0",
-        "responselike": "^2.0.0"
+        "responselike": "^1.0.2"
       },
       "dependencies": {
         "get-stream": {
@@ -1235,6 +1190,12 @@
           "requires": {
             "pump": "^3.0.0"
           }
+        },
+        "lowercase-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+          "dev": true
         }
       }
     },
@@ -1424,14 +1385,6 @@
       "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
-      },
-      "dependencies": {
-        "mimic-response": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-          "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-          "dev": true
-        }
       }
     },
     "code-point-at": {
@@ -1463,7 +1416,7 @@
     },
     "colors": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
       "dev": true
     },
@@ -1779,12 +1732,12 @@
       }
     },
     "decompress-response": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-5.0.0.tgz",
-      "integrity": "sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "dev": true,
       "requires": {
-        "mimic-response": "^2.0.0"
+        "mimic-response": "^1.0.0"
       }
     },
     "deep-eql": {
@@ -1826,9 +1779,9 @@
       }
     },
     "defer-to-connect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
-      "integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
       "dev": true
     },
     "define-properties": {
@@ -2153,6 +2106,7 @@
         "levn": "^0.3.0",
         "lodash": "^4.17.14",
         "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
         "optionator": "^0.8.3",
         "progress": "^2.0.0",
@@ -2994,43 +2948,22 @@
       }
     },
     "got": {
-      "version": "10.5.5",
-      "resolved": "https://registry.npmjs.org/got/-/got-10.5.5.tgz",
-      "integrity": "sha512-B13HHkCkTA7KxyxTrFoZfrurBX1fZxjMTKpmIfoVzh0Xfs9aZV7xEfI6EKuERQOIPbomh5LE4xDkfK6o2VXksw==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
       "dev": true,
       "requires": {
-        "@sindresorhus/is": "^1.0.0",
-        "@szmarczak/http-timer": "^4.0.0",
-        "@types/cacheable-request": "^6.0.1",
-        "cacheable-lookup": "^2.0.0",
-        "cacheable-request": "^7.0.1",
-        "decompress-response": "^5.0.0",
+        "@sindresorhus/is": "^0.14.0",
+        "@szmarczak/http-timer": "^1.1.2",
+        "cacheable-request": "^6.0.0",
+        "decompress-response": "^3.3.0",
         "duplexer3": "^0.1.4",
-        "get-stream": "^5.0.0",
-        "lowercase-keys": "^2.0.0",
-        "mimic-response": "^2.0.0",
-        "p-cancelable": "^2.0.0",
-        "p-event": "^4.0.0",
-        "responselike": "^2.0.0",
-        "to-readable-stream": "^2.0.0",
-        "type-fest": "^0.9.0"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "type-fest": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.9.0.tgz",
-          "integrity": "sha512-j55pzONIdg7rdtJTRZPKIbV0FosUqYdhHK1aAYJIrUvejv1VVyBokrILE8KQDT4emW/1Ev9tx+yZG+AxuSBMmA==",
-          "dev": true
-        }
+        "get-stream": "^4.1.0",
+        "lowercase-keys": "^1.0.1",
+        "mimic-response": "^1.0.1",
+        "p-cancelable": "^1.0.0",
+        "to-readable-stream": "^1.0.0",
+        "url-parse-lax": "^3.0.0"
       }
     },
     "graceful-fs": {
@@ -3162,9 +3095,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-      "integrity": "sha512-Z2EICWNJou7Tr9Bd2M2UqDJq3A9F2ePG9w3lIpjoyuSyXFP9QbniJVu3XQYytuw5ebmG7dXSXO9PgAjJG8DDKA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
+      "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==",
       "dev": true
     },
     "http-proxy-agent": {
@@ -3441,7 +3374,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -3755,9 +3688,9 @@
       "dev": true
     },
     "json-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
       "dev": true
     },
     "json-parse-better-errors": {
@@ -3840,12 +3773,12 @@
       "dev": true
     },
     "keyv": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.0.tgz",
-      "integrity": "sha512-U7ioE8AimvRVLfw4LffyOIRhL2xVgmE8T22L6i0BucSnBUyv4w+I7VN/zVZwRKHOI6ZRUcdMdWHQ8KSUvGpEog==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
       "dev": true,
       "requires": {
-        "json-buffer": "3.0.1"
+        "json-buffer": "3.0.0"
       }
     },
     "lcid": {
@@ -4007,9 +3940,9 @@
       }
     },
     "lowercase-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
     },
     "lru-cache": {
@@ -4360,15 +4293,15 @@
       "dev": true
     },
     "mimic-response": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.0.0.tgz",
-      "integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -4377,8 +4310,7 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minimist-options": {
       "version": "3.0.2",
@@ -4401,9 +4333,12 @@
       }
     },
     "mkdirp": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.2.tgz",
-      "integrity": "sha512-N2REVrJ/X/jGPfit2d7zea2J1pf7EAR5chIUcfHffAZ7gmlam5U65sAm76+o4ntQbSRdTjYf7qZz3chuHlwXEA=="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
     },
     "mocha": {
       "version": "7.0.1",
@@ -4424,6 +4359,7 @@
         "js-yaml": "3.13.1",
         "log-symbols": "2.2.0",
         "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
         "ms": "2.1.1",
         "node-environment-flags": "1.0.6",
         "object.assign": "4.1.0",
@@ -8675,7 +8611,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -8695,9 +8631,9 @@
       }
     },
     "p-cancelable": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
-      "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
       "dev": true
     },
     "p-defer": {
@@ -8711,15 +8647,6 @@
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
       "integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==",
       "dev": true
-    },
-    "p-event": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.1.0.tgz",
-      "integrity": "sha512-4vAd06GCsgflX4wHN1JqrMzBh/8QZ4j+rzp0cd2scXRwuBEv+QR3wrVA5aLhWDLw4y2WgDKvzWF3CCLmVM1UgA==",
-      "dev": true,
-      "requires": {
-        "p-timeout": "^2.0.1"
-      }
     },
     "p-filter": {
       "version": "2.1.0",
@@ -8791,15 +8718,6 @@
       "requires": {
         "@types/retry": "^0.12.0",
         "retry": "^0.12.0"
-      }
-    },
-    "p-timeout": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
-      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
-      "dev": true,
-      "requires": {
-        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
@@ -9074,6 +8992,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prepend-http": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
       "dev": true
     },
     "prettier": {
@@ -9402,12 +9326,12 @@
       "dev": true
     },
     "responselike": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
-      "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
       "dev": true,
       "requires": {
-        "lowercase-keys": "^2.0.0"
+        "lowercase-keys": "^1.0.0"
       }
     },
     "restore-cursor": {
@@ -12138,7 +12062,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -12167,9 +12091,9 @@
       "dev": true
     },
     "to-readable-stream": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-2.1.0.tgz",
-      "integrity": "sha512-o3Qa6DGg1CEXshSdvWNX2sN4QHqg03SPq7U6jPXRahlQdl5dK8oXjkU/2/sGrnOZKeGV1zLSO8qPwyKklPPE7w==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
       "dev": true
     },
     "to-regex-range": {
@@ -12264,6 +12188,7 @@
         "glob": "^7.1.1",
         "js-yaml": "^3.7.0",
         "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
         "tslib": "^1.8.0",
@@ -12430,6 +12355,15 @@
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true
     },
+    "url-parse-lax": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "dev": true,
+      "requires": {
+        "prepend-http": "^2.0.0"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -12577,7 +12511,10 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
       "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     },
     "write-file-atomic": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "http://github.com/nock/nock/issues"
   },
   "engines": {
-    "node": ">= 10.13"
+    "node": ">= 8.0"
   },
   "main": "./index.js",
   "types": "types",
@@ -25,7 +25,7 @@
     "debug": "^4.1.0",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.13",
-    "mkdirp": "^1.0.0",
+    "mkdirp": "^0.5.0",
     "propagate": "^2.0.0"
   },
   "devDependencies": {
@@ -41,7 +41,7 @@
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-promise": "^4.1.1",
     "eslint-plugin-standard": "^4.0.0",
-    "got": "^10.5.2",
+    "got": "^9.6.0",
     "@sinonjs/fake-timers": "^6.0.0",
     "mocha": "^7.0.1",
     "npm-run-all": "^4.1.5",

--- a/tests/test_allow_unmocked.js
+++ b/tests/test_allow_unmocked.js
@@ -76,18 +76,18 @@ describe('allowUnmocked option', () => {
       .reply(304, 'served from our mock')
       .get('/wont/get/here')
       .reply(304, 'served from our mock')
-    const client = got.extend({ prefixUrl: url, throwHttpErrors: false })
+    const client = got.extend({ baseUrl: url, throwHttpErrors: false })
 
-    const response1 = await client('abc')
+    const response1 = await client(`${url}/abc`)
     expect(response1.statusCode).to.equal(304)
     expect(response1.body).to.equal('served from our mock')
     expect(scope.isDone()).to.equal(false)
 
-    const response2 = await client('not/available')
+    const response2 = await client(`${url}/not/available`)
     expect(response2.statusCode).to.equal(404)
     expect(scope.isDone()).to.equal(false)
 
-    const response3 = await client('')
+    const response3 = await client(`${url}/`)
     expect(response3.statusCode).to.equal(200)
     expect(response3.body).to.equal('server served a response')
     expect(scope.isDone()).to.equal(false)
@@ -105,8 +105,8 @@ describe('allowUnmocked option', () => {
       .reply(200, '{"message":"mocked response"}')
 
     const { body, statusCode } = await got.post(url, {
-      json: { some: 'data' },
-      responseType: 'json',
+      json: true,
+      body: { some: 'data' },
     })
     expect(statusCode).to.equal(200)
     expect(body).to.deep.equal({ message: 'server response' })
@@ -124,8 +124,8 @@ describe('allowUnmocked option', () => {
       .reply(404, '{"message":"server response"}')
 
     const { body, statusCode } = await got.post(`${url}/post`, {
-      json: { some: 'data' },
-      responseType: 'json',
+      json: true,
+      body: { some: 'data' },
     })
     expect(statusCode).to.equal(200)
     expect(body).to.deep.equal({ message: 'server response' })

--- a/tests/test_allow_unmocked_https.js
+++ b/tests/test_allow_unmocked_https.js
@@ -52,7 +52,7 @@ describe('allowUnmocked option (https)', () => {
     const { port } = server.address()
     const url = `https://localhost:${port}`
     const client = got.extend({
-      prefixUrl: url,
+      baseUrl: url,
       ca: ssl.ca,
       throwHttpErrors: false,
     })
@@ -63,15 +63,15 @@ describe('allowUnmocked option (https)', () => {
       .get('/wont/get/here')
       .reply(500)
 
-    const response1 = await client('abc')
+    const response1 = await client('/abc')
     expect(response1.statusCode).to.equal(200)
     expect(response1.body).to.equal('mocked response')
     expect(scope.isDone()).to.equal(false)
-    const response2 = await client('does/not/exist')
+    const response2 = await client('/does/not/exist')
 
     expect(response2.statusCode).to.equal(404)
     expect(scope.isDone()).to.equal(false)
-    const response3 = await client('')
+    const response3 = await client('/')
 
     expect(response3.statusCode).to.equal(200)
     expect(response3.body).to.equal('server response')

--- a/tests/test_basic_auth.js
+++ b/tests/test_basic_auth.js
@@ -18,8 +18,7 @@ test('basic auth with username and password', async t => {
 
   await t.test('succeeds when it matches', async tt => {
     const response = await got('http://example.test/test', {
-      username: 'foo',
-      password: 'bar',
+      auth: 'foo:bar',
     })
     tt.equal(response.statusCode, 200)
     tt.equal(response.body, 'Here is the content')
@@ -43,10 +42,7 @@ test('basic auth with username only', async t => {
   })
 
   await t.test('succeeds when it matches', async tt => {
-    const response = await got('http://example.test/test', {
-      username: 'foo',
-      password: '',
-    })
+    const response = await got('http://example.test/test', { auth: 'foo:' })
     tt.equal(response.statusCode, 200)
     tt.equal(response.body, 'Here is the content')
   })

--- a/tests/test_body_match.js
+++ b/tests/test_body_match.js
@@ -27,7 +27,8 @@ test('match form body reagardless of field ordering', async t => {
     .reply(200, 'Heyyyy!')
 
   const { body } = await got.post('http://example.test/', {
-    form: { bar: 'foo', foo: 'bar' },
+    form: true,
+    body: { bar: 'foo', foo: 'bar' },
   })
 
   t.equal(body, 'Heyyyy!')

--- a/tests/test_define.js
+++ b/tests/test_define.js
@@ -23,13 +23,10 @@ test('define() is backward compatible', async t => {
     ])
   )
 
-  await assertRejects(
-    got('http://example.test:12345/'),
-    ({ response: { statusCode } }) => {
-      t.is(statusCode, 500)
-      return true
-    }
-  )
+  await assertRejects(got('http://example.test:12345/'), ({ statusCode }) => {
+    t.is(statusCode, 500)
+    return true
+  })
 })
 
 test('define() throws when reply is not a numeric string', t => {
@@ -153,19 +150,19 @@ test('define() works with non-JSON responses', async t => {
   )
 
   const { statusCode, body } = await got.post('http://example.test/', {
+    encoding: false,
     body: exampleBody,
-    responseType: 'buffer',
   })
 
   t.equal(statusCode, 200)
-  t.type(body, Buffer)
-  t.equal(body.toString(), exampleResponseBody)
+  // TODO: because `{ encoding: false }` is passed to `got`, `body` should be
+  // a buffer, but it's a string. Is this a bug in nock or got?
+  t.equal(body, exampleResponseBody)
 })
 
 // TODO: There seems to be a bug here. When testing via `got` with
 // `{ encoding: false }` the body that comes back should be a buffer, but is
 // not. It's difficult to get this test to pass after porting it.
-// I think this bug has been fixed in Got v10, so this should be unblocked.
 test('define() works with binary buffers', t => {
   const exampleBody = '8001'
   const exampleResponse = '8001'

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -43,7 +43,7 @@ test('get gets mocked', async t => {
     .reply(200, 'Hello World!')
 
   const { statusCode, body } = await got('http://example.test/', {
-    responseType: 'buffer',
+    encoding: null,
   })
 
   t.equal(statusCode, 200)
@@ -58,7 +58,7 @@ test('get gets mocked with relative base path', async t => {
     .reply(200, 'Hello World!')
 
   const { statusCode, body } = await got('http://example.test/abc/def', {
-    responseType: 'buffer',
+    encoding: null,
   })
 
   t.equal(statusCode, 200)
@@ -73,7 +73,7 @@ test('post', async t => {
     .reply(201, 'OK!')
 
   const { statusCode, body } = await got.post('http://example.test/form', {
-    responseType: 'buffer',
+    encoding: null,
   })
 
   t.equal(statusCode, 201)
@@ -88,7 +88,7 @@ test('post with empty response body', async t => {
     .reply()
 
   const { statusCode, body } = await got.post('http://example.test/form', {
-    responseType: 'buffer',
+    encoding: null,
   })
 
   t.equal(statusCode, 200)
@@ -137,7 +137,7 @@ test('post with regexp as spec', async t => {
     .post('/echo', /key=v.?l/g)
     .reply(200, (uri, body) => ['OK', uri, body].join(' '))
 
-  const { body } = await got.post('http://example.test/echo', { body: input })
+  const { body } = await got('http://example.test/echo', { body: input })
 
   t.equal(body, 'OK /echo key=val')
   scope.done()
@@ -148,9 +148,7 @@ test('post with function as spec', async t => {
     .post('/echo', body => body === 'key=val')
     .reply(200, (uri, body) => ['OK', uri, body].join(' '))
 
-  const { body } = await got.post('http://example.test/echo', {
-    body: 'key=val',
-  })
+  const { body } = await got('http://example.test/echo', { body: 'key=val' })
 
   t.equal(body, 'OK /echo key=val')
   scope.done()
@@ -163,7 +161,7 @@ test('post with chaining on call', async t => {
     .post('/echo', input)
     .reply(200, (uri, body) => ['OK', uri, body].join(' '))
 
-  const { body } = await got.post('http://example.test/echo', { body: input })
+  const { body } = await got('http://example.test/echo', { body: input })
 
   t.equal(body, 'OK /echo key=val')
   scope.done()
@@ -214,11 +212,11 @@ test('body data is differentiating', async t => {
     .post('/', 'def')
     .reply(200, 'Hey 2')
 
-  const response1 = await got.post('http://example.test/', { body: 'abc' })
+  const response1 = await got('http://example.test/', { body: 'abc' })
   t.equal(response1.statusCode, 200)
   t.equal(response1.body, 'Hey 1')
 
-  const response2 = await got.post('http://example.test/', { body: 'def' })
+  const response2 = await got('http://example.test/', { body: 'def' })
   t.equal(response2.statusCode, 200)
   t.equal(response2.body, 'Hey 2')
 
@@ -265,7 +263,7 @@ test('on interceptor, filter path with function', async t => {
     .reply(200, 'Hello World!')
 
   const { statusCode } = await got('http://example.test/', {
-    searchParams: { a: '1', b: '2' },
+    query: { a: '1', b: '2' },
   })
 
   t.equal(statusCode, 200)
@@ -404,7 +402,7 @@ test('can use https', async t => {
     .reply()
 
   const { statusCode } = await got('https://example.test/', {
-    responseType: 'buffer',
+    encoding: null,
   })
 
   t.equal(statusCode, 200)

--- a/tests/test_net_connect.js
+++ b/tests/test_net_connect.js
@@ -89,39 +89,4 @@ describe('`enableNetConnect()`', () => {
       /Nock: Disallowed net connect for "example.test:443\/"/
     )
   })
-
-  it('enables real HTTP request only for specified domain, via function', async () => {
-    const onResponse = sinon.spy()
-    const server = http.createServer((request, response) => {
-      onResponse()
-      response.writeHead(200)
-      response.end()
-    })
-    await new Promise(resolve => server.listen(resolve))
-
-    nock.enableNetConnect(host => host.includes('ocalhos'))
-
-    await got(`http://localhost:${server.address().port}/`)
-    expect(onResponse).to.have.been.calledOnce()
-
-    server.close()
-  })
-
-  it('disallows request for other domains, via function', async () => {
-    nock.enableNetConnect(host => host.includes('ocalhos'))
-
-    await assertRejects(
-      got('https://example.test/'),
-      /Nock: Disallowed net connect for "example.test:443\/"/
-    )
-  })
-
-  it('passes the domain to be tested, via function', async () => {
-    const matcher = sinon.stub().returns(false)
-    nock.enableNetConnect(matcher)
-
-    await got('https://example.test/').catch(() => undefined) // ignore rejection, expected
-
-    expect(matcher).to.have.been.calledOnceWithExactly('example.test:443')
-  })
 })

--- a/tests/test_query.js
+++ b/tests/test_query.js
@@ -130,7 +130,7 @@ describe('`query()`', () => {
         .reply()
 
       const { statusCode } = await got('http://example.test/', {
-        searchParams: { 'foo&bar': 'hello&world' },
+        query: { 'foo&bar': 'hello&world' },
       })
 
       expect(statusCode).to.equal(200)

--- a/tests/test_recorder.js
+++ b/tests/test_recorder.js
@@ -433,7 +433,7 @@ it('records nonstandard ports', done => {
   })
 })
 
-it('`req.end()` accepts and calls a callback when recording', done => {
+it('req.end accepts and calls a callback when recording', done => {
   const onEnd = sinon.spy()
 
   server = http.createServer((request, response) => {
@@ -466,51 +466,6 @@ it('`req.end()` accepts and calls a callback when recording', done => {
     )
 
     req.end(onEnd)
-  })
-})
-
-// https://nodejs.org/api/http.html#http_request_end_data_encoding_callback
-it('when recording, when `req.end()` is called with only data and a callback, the callback is invoked and the data is sent', done => {
-  const onEnd = sinon.spy()
-
-  let requestBody = ''
-  server = http.createServer((request, response) => {
-    request.on('data', data => {
-      requestBody += data
-    })
-    request.on('end', () => {
-      response.writeHead(200)
-      response.end()
-    })
-  })
-
-  nock.restore()
-  nock.recorder.clear()
-  expect(nock.recorder.play()).to.be.empty()
-
-  server.listen(() => {
-    nock.recorder.rec({ dont_print: true })
-
-    const req = http.request(
-      {
-        hostname: 'localhost',
-        port: server.address().port,
-        path: '/',
-        method: 'POST',
-      },
-      res => {
-        expect(onEnd).to.have.been.calledOnce()
-        expect(res.statusCode).to.equal(200)
-
-        res.on('end', () => {
-          expect(requestBody).to.equal('foobar')
-          done()
-        })
-        res.resume()
-      }
-    )
-
-    req.end('foobar', onEnd)
   })
 })
 
@@ -988,7 +943,7 @@ it('records query parameters', async () => {
   })
 
   await got(`http://localhost:${server.address().port}`, {
-    searchParams: { q: 'test search' },
+    query: { q: 'test search' },
   })
 
   nock.restore()
@@ -1015,7 +970,7 @@ it('encodes the query parameters when not outputting objects', async () => {
   })
 
   await got(`http://localhost:${server.address().port}`, {
-    searchParams: { q: 'test search++' },
+    query: { q: 'test search++' },
   })
 
   nock.restore()
@@ -1099,7 +1054,7 @@ it('outputs query string parameters using query()', async () => {
   nock.recorder.rec(true)
 
   await got(`http://localhost:${server.address().port}/`, {
-    searchParams: { param1: 1, param2: 2 },
+    query: { param1: 1, param2: 2 },
   })
 
   const recorded = nock.recorder.play()
@@ -1124,7 +1079,7 @@ it('outputs query string arrays correctly', async () => {
   nock.recorder.rec(true)
 
   await got(`http://localhost:${server.address().port}/`, {
-    searchParams: new URLSearchParams([
+    query: new URLSearchParams([
       ['foo', 'bar'],
       ['foo', 'baz'],
     ]),

--- a/tests/test_reply_function_async.js
+++ b/tests/test_reply_function_async.js
@@ -21,9 +21,7 @@ describe('asynchronous `reply()` function', () => {
           callback(null, 'Hello World!')
         )
 
-      const { body } = await got('http://example.test/', {
-        responseType: 'buffer',
-      })
+      const { body } = await got('http://example.test/', { encoding: null })
 
       expect(body).to.be.an.instanceOf(Buffer)
       expect(body.toString('utf8')).to.equal('Hello World!')

--- a/tests/test_reply_function_sync.js
+++ b/tests/test_reply_function_sync.js
@@ -124,7 +124,7 @@ describe('synchronous `reply()` function', () => {
           got.post('http://example.test/endpoint', {
             body: exampleRequestBody,
           }),
-          ({ response: { statusCode, body } }) => {
+          ({ statusCode, body }) => {
             expect(statusCode).to.equal(404)
             expect(body).to.equal(exampleResponseBody)
             return true
@@ -149,10 +149,10 @@ describe('synchronous `reply()` function', () => {
             })
 
           await assertRejects(
-            got.post('http://example.test/endpoint', {
+            got('http://example.test/endpoint', {
               body: exampleRequestBody,
             }),
-            ({ response: { statusCode, body } }) => {
+            ({ statusCode, body }) => {
               expect(statusCode).to.equal(404)
               expect(body).to.equal('')
               return true
@@ -178,7 +178,7 @@ describe('synchronous `reply()` function', () => {
                 .and.to.deep.equal(JSON.parse(exampleRequestBody))
             })
 
-          const { statusCode } = await got.post('http://example.test/', {
+          const { statusCode } = await got('http://example.test/', {
             headers: { 'Content-Type': 'application/json' },
             body: exampleRequestBody,
           })
@@ -201,7 +201,7 @@ describe('synchronous `reply()` function', () => {
                 .and.to.to.deep.equal(JSON.parse(exampleRequestBody))
             })
 
-          const { statusCode } = await got.post('http://example.test/', {
+          const { statusCode } = await got('http://example.test/', {
             // Providing the field value as an array is probably a bug on the callers behalf,
             // but it is still allowed by Node
             headers: { 'Content-Type': ['application/json', 'charset=utf8'] },
@@ -272,7 +272,7 @@ describe('synchronous `reply()` function', () => {
 
       await assertRejects(
         got('http://example.test/'),
-        ({ response: { statusCode, body } }) => {
+        ({ statusCode, body }) => {
           expect(statusCode).to.equal(401)
           expect(body).to.equal(exampleResponse)
           return true

--- a/tests/test_scope.js
+++ b/tests/test_scope.js
@@ -134,7 +134,7 @@ describe('filteringPath()', function() {
       .reply()
 
     const { statusCode } = await got('http://example.test/', {
-      searchParams: { a: '1', b: '2' },
+      query: { a: '1', b: '2' },
     })
 
     expect(statusCode).to.equal(200)
@@ -148,7 +148,7 @@ describe('filteringPath()', function() {
       .reply()
 
     const { statusCode } = await got('http://example.test/', {
-      searchParams: { a: '1', b: '2' },
+      query: { a: '1', b: '2' },
     })
 
     expect(statusCode).to.equal(200)
@@ -176,7 +176,7 @@ describe('filteringRequestBody()', () => {
       .post('/', 'mamma tua')
       .reply()
 
-    const { statusCode } = await got.post('http://example.test/', {
+    const { statusCode } = await got('http://example.test/', {
       body: 'mamma mia',
     })
 
@@ -191,7 +191,7 @@ describe('filteringRequestBody()', () => {
       .post('/', 'mamma nostra')
       .reply(200, 'Hello World!')
 
-    const { statusCode } = await got.post('http://example.test/', {
+    const { statusCode } = await got('http://example.test/', {
       body: 'mamma mia',
     })
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,9 +21,7 @@ declare namespace nock {
   function activeMocks(): string[]
   function removeInterceptor(interceptor: Interceptor | ReqOptions): boolean
   function disableNetConnect(): void
-  function enableNetConnect(
-    matcher?: string | RegExp | ((host: string) => boolean)
-  ): void
+  function enableNetConnect(matcher?: string | RegExp): void
   function load(path: string): Scope[]
   function loadDefs(path: string): Definition[]
   function define(defs: Definition[]): Scope[]

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -703,9 +703,6 @@ nock.enableNetConnect('example.test')
 // or a RegExp
 nock.enableNetConnect(/example\.(com|test)/)
 
-// or a Function
-nock.enableNetConnect(host => host.includes('example.com'))
-
 nock.disableNetConnect()
 nock.enableNetConnect('127.0.0.1') // Allow localhost connections so we can test local routes and mock servers.
 


### PR DESCRIPTION
Follow up to https://github.com/nock/nock/issues/1896\#issuecomment-586734273

This PR reverts the changes from these commits

- a275769 test: Update got to the latest version and fill in missing coverage (#1825)
- 566461b feat: allow passing a function to `enableNetConnect()` (#1889)
- 11c0542 Require Node 10+ (#1895)
- e04d61d Update mkdirp to the latest version 🚀 (#1857)
- 9379f09 Do not return the `nock` global from `cleanAll()` (#1872)
- 6c504c3 Drop support for String constructor (#1873)