### PR TITLE
refactor(test): Mocha DSL for common utilities

### DIFF
--- a/tests/test_abort.js
+++ b/tests/test_abort.js
@@ -7,7 +7,7 @@ const sinon = require('sinon')
 
 require('./setup')
 
-it('req.abort() should cause "abort" and "error" to be emitted', done => {
+it('`req.abort()` should cause "abort" and "error" to be emitted', done => {
   const scope = nock('http://example.test')
     .get('/')
     .delayConnection(500)

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -14,432 +14,420 @@
 const http = require('http')
 const { expect } = require('chai')
 const sinon = require('sinon')
-const { test } = require('tap')
 const nock = require('..')
 
 const common = require('../lib/common')
 const matchBody = require('../lib/match_body')
 
-require('./cleanup_after_each')()
 require('./setup')
 
 // match_body has its own test file that tests the functionality from the API POV.
 // Since it's not in common.js does it make more sense for these six unit tests to move into that file?
-test('matchBody ignores new line characters from strings', t => {
-  const result = matchBody(
-    {},
-    'something //here is something more \n',
-    'something //here is something more \n\r'
-  )
-  expect(result).to.equal(true)
-  t.end()
+describe('Body Match', () => {
+  describe('unit', () => {
+    it('ignores new line characters from strings', () => {
+      const result = matchBody(
+        {},
+        'something //here is something more \n',
+        'something //here is something more \n\r'
+      )
+      expect(result).to.equal(true)
+    })
+
+    it("when spec is a function, it's called with newline characters intact", () => {
+      const exampleBody = 'something //here is something more \n'
+      const matchCbSpy = sinon.spy()
+
+      matchBody({}, matchCbSpy, exampleBody)
+      expect(matchCbSpy).to.have.been.calledOnceWithExactly(exampleBody)
+    })
+
+    it('should not throw, when headers come node-fetch style as array', () => {
+      const result = matchBody(
+        { headers: { 'Content-Type': ['multipart/form-data;'] } },
+        {},
+        'test'
+      )
+      expect(result).to.equal(false)
+    })
+
+    it("should not ignore new line characters from strings when Content-Type contains 'multipart'", () => {
+      const result = matchBody(
+        { headers: { 'Content-Type': 'multipart/form-data;' } },
+        'something //here is something more \nHello',
+        'something //here is something more \nHello'
+      )
+      expect(result).to.equal(true)
+    })
+
+    it("should not ignore new line characters from strings when Content-Type contains 'multipart' (arrays come node-fetch style as array)", () => {
+      const result = matchBody(
+        { headers: { 'Content-Type': ['multipart/form-data;'] } },
+        'something //here is something more \nHello',
+        'something //here is something more \nHello'
+      )
+      expect(result).to.equal(true)
+    })
+
+    it('should use strict equality for deep comparisons', () => {
+      const result = matchBody({}, { number: 1 }, '{"number": "1"}')
+      expect(result).to.equal(false)
+    })
+  })
 })
 
-test("when spec is a function, it's called with newline characters intact", t => {
-  const exampleBody = 'something //here is something more \n'
-  let param
-  const matchCb = body => {
-    param = body
-  }
+describe('`normalizeRequestOptions()`', () => {
+  it('should normalize hosts with port', () => {
+    const result = common.normalizeRequestOptions({
+      host: 'example.test:12345',
+      port: 12345,
+    })
 
-  matchBody({}, matchCb, exampleBody)
-  expect(param).to.equal(exampleBody)
-  t.end()
-})
+    const expected = {
+      host: 'example.test:12345',
+      hostname: 'example.test',
+      port: 12345,
+      proto: 'http',
+    }
 
-test('matchBody should not throw, when headers come node-fetch style as array', t => {
-  const result = matchBody(
-    { headers: { 'Content-Type': ['multipart/form-data;'] } },
-    {},
-    'test'
-  )
-  expect(result).to.equal(false)
-  t.end()
-})
-
-test("matchBody should not ignore new line characters from strings when Content-Type contains 'multipart'", t => {
-  const result = matchBody(
-    { headers: { 'Content-Type': 'multipart/form-data;' } },
-    'something //here is something more \nHello',
-    'something //here is something more \nHello'
-  )
-  expect(result).to.equal(true)
-  t.end()
-})
-
-test("matchBody should not ignore new line characters from strings when Content-Type contains 'multipart' (arrays come node-fetch style as array)", t => {
-  const result = matchBody(
-    { headers: { 'Content-Type': ['multipart/form-data;'] } },
-    'something //here is something more \nHello',
-    'something //here is something more \nHello'
-  )
-  expect(result).to.equal(true)
-  t.end()
-})
-
-test('matchBody uses strict equality for deep comparisons', t => {
-  const result = matchBody({}, { number: 1 }, '{"number": "1"}')
-  expect(result).to.equal(false)
-  t.end()
-})
-
-test('normalizeRequestOptions, with port', t => {
-  const result = common.normalizeRequestOptions({
-    host: 'example.test:12345',
-    port: 12345,
+    expect(result).to.deep.equal(expected)
   })
 
-  const expected = {
-    host: 'example.test:12345',
-    hostname: 'example.test',
-    port: 12345,
-    proto: 'http',
-  }
+  it('should normalize hosts without port', () => {
+    const result = common.normalizeRequestOptions({
+      hostname: 'example.test',
+    })
 
-  expect(result).to.deep.equal(expected)
-  t.end()
-})
+    const expected = {
+      host: 'example.test:80',
+      hostname: 'example.test',
+      port: 80,
+      proto: 'http',
+    }
 
-test('normalizeRequestOptions, without port', t => {
-  const result = common.normalizeRequestOptions({
-    hostname: 'example.test',
+    expect(result).to.deep.equal(expected)
   })
 
-  const expected = {
-    host: 'example.test:80',
-    hostname: 'example.test',
-    port: 80,
-    proto: 'http',
-  }
+  it('should not error and add defaults for empty options', () => {
+    const result = common.normalizeRequestOptions({})
 
-  expect(result).to.deep.equal(expected)
-  t.end()
+    const expected = {
+      host: 'localhost:80',
+      // Should this be included?
+      // hostname: 'localhost'
+      port: 80,
+      proto: 'http',
+    }
+
+    expect(result).to.deep.equal(expected)
+  })
 })
 
-test('normalizeRequestOptions, empty options', t => {
-  const result = common.normalizeRequestOptions({})
+describe('`isUtf8Representable()`', () => {
+  it("should return false for buffers that aren't utf8 representable", () => {
+    expect(common.isUtf8Representable(Buffer.from('8001', 'hex'))).to.equal(
+      false
+    )
+  })
 
-  const expected = {
-    host: 'localhost:80',
-    // Should this be included?
-    // hostname: 'localhost'
-    port: 80,
-    proto: 'http',
-  }
-
-  expect(result).to.deep.equal(expected)
-  t.end()
+  it('should returns true for buffers containing strings', () => {
+    expect(common.isUtf8Representable(Buffer.from('8001', 'utf8'))).to.equal(
+      true
+    )
+  })
 })
 
-test('isUtf8Representable works', t => {
-  // Returns false for buffers that aren't utf8 representable.
-  expect(common.isUtf8Representable(Buffer.from('8001', 'hex'))).to.equal(false)
-
-  // Returns true for buffers containing strings.
-  expect(common.isUtf8Representable(Buffer.from('8001', 'utf8'))).to.equal(true)
-
-  t.end()
-})
-
-test('isJSONContent', t => {
+it('`isJSONContent()`', () => {
   expect(common.isJSONContent({ 'content-type': 'application/json' })).to.equal(
     true
   )
+
   expect(
     common.isJSONContent({ 'content-type': 'application/json; charset=utf-8' })
   ).to.equal(true)
+
   expect(common.isJSONContent({ 'content-type': 'text/plain' })).to.equal(false)
-  t.end()
 })
 
-test('headersFieldNamesToLowerCase works', t => {
-  const result = common.headersFieldNamesToLowerCase({
-    HoSt: 'example.test',
-    'Content-typE': 'plain/text',
-  })
-  const expected = {
-    host: 'example.test',
-    'content-type': 'plain/text',
-  }
-
-  expect(result).to.deep.equal(expected)
-  t.end()
-})
-
-test('headersFieldNamesToLowerCase throws on conflicting keys', t => {
-  expect(() =>
-    common.headersFieldNamesToLowerCase({
+describe('`headersFieldNamesToLowerCase()`', () => {
+  it('should return a lower-cased copy of the input', () => {
+    const input = {
       HoSt: 'example.test',
-      HOST: 'example.test',
+      'Content-typE': 'plain/text',
+    }
+    const inputClone = { ...input }
+    const result = common.headersFieldNamesToLowerCase(input)
+    const expected = {
+      host: 'example.test',
+      'content-type': 'plain/text',
+    }
+
+    expect(result).to.deep.equal(expected)
+    expect(input).to.deep.equal(inputClone) // assert the input is not mutated
+  })
+
+  it('throws on conflicting keys', () => {
+    expect(() =>
+      common.headersFieldNamesToLowerCase({
+        HoSt: 'example.test',
+        HOST: 'example.test',
+      })
+    ).to.throw(
+      'Failed to convert header keys to lower case due to field name conflict: host'
+    )
+  })
+})
+
+describe('`headersFieldsArrayToLowerCase()`', () => {
+  it('should work on arrays', () => {
+    // Sort for comparison because order doesn't matter.
+    const result = common
+      .headersFieldsArrayToLowerCase(['HoSt', 'Content-typE'])
+      .sort()
+
+    expect(result).to.deep.equal(['content-type', 'host'])
+  })
+
+  it('should de-duplicate arrays', () => {
+    // Sort for comparison because order doesn't matter.
+    const result = common
+      .headersFieldsArrayToLowerCase([
+        'hosT',
+        'HoSt',
+        'Content-typE',
+        'conTenT-tYpe',
+      ])
+      .sort()
+
+    expect(result).to.deep.equal(['content-type', 'host'])
+  })
+})
+
+describe('`deleteHeadersField()`', () => {
+  it('should delete fields with case-insensitive field names', () => {
+    // Prepare.
+    const headers = {
+      HoSt: 'example.test',
+      'Content-typE': 'plain/text',
+    }
+
+    // Confidence check.
+    expect(headers).to.have.property('HoSt')
+    expect(headers).to.have.property('Content-typE')
+
+    // Act.
+    common.deleteHeadersField(headers, 'HOST')
+    common.deleteHeadersField(headers, 'CONTENT-TYPE')
+
+    // Assert.
+    expect(headers).to.not.have.property('HoSt')
+    expect(headers).to.not.have.property('Content-typE')
+  })
+
+  it('should remove multiple fields with same case-insensitive names', () => {
+    const headers = {
+      foo: 'one',
+      FOO: 'two',
+      'X-Foo': 'three',
+    }
+
+    common.deleteHeadersField(headers, 'foo')
+
+    expect(headers).to.deep.equal({ 'X-Foo': 'three' })
+  })
+
+  it('should throw for invalid headers', () => {
+    expect(() => common.deleteHeadersField('foo', 'Content-Type')).to.throw(
+      'headers must be an object'
+    )
+  })
+
+  it('should throw for invalid field name', () => {
+    expect(() => common.deleteHeadersField({}, /cookie/)).to.throw(
+      'field name must be a string'
+    )
+  })
+})
+
+describe('`matchStringOrRegexp()`', () => {
+  it('should match if pattern is string and target matches', () => {
+    const result = common.matchStringOrRegexp('to match', 'to match')
+    expect(result).to.equal(true)
+  })
+
+  it("should not match if pattern is string and target doesn't match", () => {
+    const result = common.matchStringOrRegexp('to match', 'not to match')
+    expect(result).to.equal(false)
+  })
+
+  it('should match pattern is number and target matches', () => {
+    const result = common.matchStringOrRegexp(123, 123)
+    expect(result).to.equal(true)
+  })
+
+  it('should handle undefined target when pattern is string', () => {
+    const result = common.matchStringOrRegexp(undefined, 'to not match')
+    expect(result).to.equal(false)
+  })
+
+  it('should handle undefined target when pattern is regex', () => {
+    const result = common.matchStringOrRegexp(undefined, /not/)
+    expect(result).to.equal(false)
+  })
+
+  it('should match if pattern is regex and target matches', () => {
+    const result = common.matchStringOrRegexp('to match', /match/)
+    expect(result).to.equal(true)
+  })
+
+  it("should not match if pattern is regex and target doesn't match", () => {
+    const result = common.matchStringOrRegexp('to match', /not/)
+    expect(result).to.equal(false)
+  })
+})
+
+describe('`overrideRequests()`', () => {
+  afterEach(() => {
+    common.restoreOverriddenRequests()
+  })
+
+  it('should throw if called a second time', () => {
+    nock.restore()
+    common.overrideRequests()
+    // Second call throws.
+    expect(() => common.overrideRequests()).to.throw(
+      "Module's request already overridden for http protocol."
+    )
+  })
+})
+
+it('`restoreOverriddenRequests()` can be called more than once', () => {
+  common.restoreOverriddenRequests()
+  common.restoreOverriddenRequests()
+})
+
+describe('`stringifyRequest()`', () => {
+  it('should include non-default ports', () => {
+    const options = {
+      method: 'GET',
+      port: 3000,
+      proto: 'http',
+      hostname: 'example.test',
+      path: '/',
+      headers: {},
+    }
+
+    const result = common.stringifyRequest(options, 'foo')
+
+    // We have to parse the object instead of comparing the raw string because the order of keys are not guaranteed.
+    expect(JSON.parse(result)).to.deep.equal({
+      method: 'GET',
+      url: 'http://example.test:3000/',
+      headers: {},
+      body: 'foo',
     })
-  ).to.throw(
-    'Failed to convert header keys to lower case due to field name conflict: host'
-  )
-  t.end()
-})
-
-test('headersFieldsArrayToLowerCase works on arrays', t => {
-  // Sort for comparison because order doesn't matter.
-  const result = common
-    .headersFieldsArrayToLowerCase(['HoSt', 'Content-typE'])
-    .sort()
-
-  expect(result).to.deep.equal(['content-type', 'host'])
-  t.end()
-})
-
-test('headersFieldsArrayToLowerCase de-duplicates arrays', t => {
-  // Sort for comparison because order doesn't matter.
-  const result = common
-    .headersFieldsArrayToLowerCase([
-      'hosT',
-      'HoSt',
-      'Content-typE',
-      'conTenT-tYpe',
-    ])
-    .sort()
-
-  expect(result).to.deep.equal(['content-type', 'host'])
-  t.end()
-})
-
-test('deleteHeadersField deletes fields with case-insensitive field names', t => {
-  // Prepare.
-  const headers = {
-    HoSt: 'example.test',
-    'Content-typE': 'plain/text',
-  }
-
-  // Confidence check.
-  expect(headers).to.have.property('HoSt')
-  expect(headers).to.have.property('Content-typE')
-
-  // Act.
-  common.deleteHeadersField(headers, 'HOST')
-  common.deleteHeadersField(headers, 'CONTENT-TYPE')
-
-  // Assert.
-  expect(headers).to.not.have.property('HoSt')
-  expect(headers).to.not.have.property('Content-typE')
-
-  // Wrap up.
-  t.end()
-})
-
-test('deleteHeadersField removes multiple fields with same case-insensitive names', t => {
-  const headers = {
-    foo: 'one',
-    FOO: 'two',
-    'X-Foo': 'three',
-  }
-
-  common.deleteHeadersField(headers, 'foo')
-
-  expect(headers).to.deep.equal({ 'X-Foo': 'three' })
-  t.done()
-})
-
-test('deleteHeadersField throws for invalid headers', t => {
-  expect(() => common.deleteHeadersField('foo', 'Content-Type')).to.throw(
-    'headers must be an object'
-  )
-  t.done()
-})
-
-test('deleteHeadersField throws for invalid field name', t => {
-  expect(() => common.deleteHeadersField({}, /cookie/)).to.throw(
-    'field name must be a string'
-  )
-  t.done()
-})
-
-test('matchStringOrRegexp', t => {
-  expect(common.matchStringOrRegexp('to match', 'to match')).to.equal(
-    true,
-    'true if pattern is string and target matches'
-  )
-
-  expect(common.matchStringOrRegexp('to match', 'not to match')).to.equal(
-    false,
-    "false if pattern is string and target doesn't match"
-  )
-
-  expect(common.matchStringOrRegexp(123, 123)).to.equal(
-    true,
-    'true if pattern is number and target matches'
-  )
-
-  expect(common.matchStringOrRegexp(undefined, 'to not match')).to.equal(
-    false,
-    'handle undefined target when pattern is string'
-  )
-
-  expect(common.matchStringOrRegexp(undefined, /not/)).to.equal(
-    false,
-    'handle undefined target when pattern is regex'
-  )
-
-  expect(common.matchStringOrRegexp('to match', /match/)).to.equal(
-    true,
-    'match if pattern is regex and target matches'
-  )
-
-  expect(common.matchStringOrRegexp('to match', /not/)).to.equal(
-    false,
-    "false if pattern is regex and target doesn't match"
-  )
-  t.end()
-})
-
-test('overrideRequests', t => {
-  t.on('end', () => common.restoreOverriddenRequests())
-  nock.restore()
-  common.overrideRequests()
-  // Second call throws.
-  expect(() => common.overrideRequests()).to.throw(
-    "Module's request already overridden for http protocol."
-  )
-  t.end()
-})
-
-test('restoreOverriddenRequests can be called more than once', t => {
-  common.restoreOverriddenRequests()
-  common.restoreOverriddenRequests()
-  t.end()
-})
-
-test('stringifyRequest includes non-default ports', t => {
-  const options = {
-    method: 'GET',
-    port: 3000,
-    proto: 'http',
-    hostname: 'example.test',
-    path: '/',
-    headers: {},
-  }
-
-  const result = common.stringifyRequest(options, 'foo')
-
-  // We have to parse the object instead of comparing the raw string because the order of keys are not guaranteed.
-  expect(JSON.parse(result)).to.deep.equal({
-    method: 'GET',
-    url: 'http://example.test:3000/',
-    headers: {},
-    body: 'foo',
   })
 
-  t.end()
-})
+  it('should not include default http port', () => {
+    const options = {
+      method: 'GET',
+      port: 80,
+      proto: 'http',
+      hostname: 'example.test',
+      path: '/',
+      headers: {},
+    }
 
-test('stringifyRequest does not include default http port', t => {
-  const options = {
-    method: 'GET',
-    port: 80,
-    proto: 'http',
-    hostname: 'example.test',
-    path: '/',
-    headers: {},
-  }
+    const result = common.stringifyRequest(options, 'foo')
 
-  const result = common.stringifyRequest(options, 'foo')
-
-  expect(JSON.parse(result)).to.deep.equal({
-    method: 'GET',
-    url: 'http://example.test/',
-    headers: {},
-    body: 'foo',
+    expect(JSON.parse(result)).to.deep.equal({
+      method: 'GET',
+      url: 'http://example.test/',
+      headers: {},
+      body: 'foo',
+    })
   })
 
-  t.end()
-})
+  it('should not include default https port', () => {
+    const options = {
+      method: 'POST',
+      port: 443,
+      proto: 'https',
+      hostname: 'example.test',
+      path: '/the/path',
+      headers: {},
+    }
 
-test('stringifyRequest does not include default https port', t => {
-  const options = {
-    method: 'POST',
-    port: 443,
-    proto: 'https',
-    hostname: 'example.test',
-    path: '/the/path',
-    headers: {},
-  }
+    const result = common.stringifyRequest(options, 'foo')
 
-  const result = common.stringifyRequest(options, 'foo')
-
-  expect(JSON.parse(result)).to.deep.equal({
-    method: 'POST',
-    url: 'https://example.test/the/path',
-    headers: {},
-    body: 'foo',
+    expect(JSON.parse(result)).to.deep.equal({
+      method: 'POST',
+      url: 'https://example.test/the/path',
+      headers: {},
+      body: 'foo',
+    })
   })
 
-  t.end()
-})
+  it('should default optional options', () => {
+    const options = {
+      port: 80,
+      proto: 'http',
+      hostname: 'example.test',
+      headers: {},
+    }
 
-test('stringifyRequest defaults optional options', t => {
-  const options = {
-    port: 80,
-    proto: 'http',
-    hostname: 'example.test',
-    headers: {},
-  }
+    const result = common.stringifyRequest(options, 'foo')
 
-  const result = common.stringifyRequest(options, 'foo')
-
-  expect(JSON.parse(result)).to.deep.equal({
-    method: 'GET',
-    url: 'http://example.test',
-    headers: {},
-    body: 'foo',
+    expect(JSON.parse(result)).to.deep.equal({
+      method: 'GET',
+      url: 'http://example.test',
+      headers: {},
+      body: 'foo',
+    })
   })
 
-  t.end()
-})
+  it('should pass headers through', () => {
+    const options = {
+      method: 'GET',
+      port: 80,
+      proto: 'http',
+      hostname: 'example.test',
+      path: '/',
+      headers: { cookie: 'fiz=baz', 'set-cookie': ['hello', 'world'] },
+    }
 
-test('stringifyRequest passes headers through', t => {
-  const options = {
-    method: 'GET',
-    port: 80,
-    proto: 'http',
-    hostname: 'example.test',
-    path: '/',
-    headers: { cookie: 'fiz=baz', 'set-cookie': ['hello', 'world'] },
-  }
+    const result = common.stringifyRequest(options, 'foo')
 
-  const result = common.stringifyRequest(options, 'foo')
-
-  expect(JSON.parse(result)).to.deep.equal({
-    method: 'GET',
-    url: 'http://example.test/',
-    headers: { cookie: 'fiz=baz', 'set-cookie': ['hello', 'world'] },
-    body: 'foo',
+    expect(JSON.parse(result)).to.deep.equal({
+      method: 'GET',
+      url: 'http://example.test/',
+      headers: { cookie: 'fiz=baz', 'set-cookie': ['hello', 'world'] },
+      body: 'foo',
+    })
   })
 
-  t.end()
-})
+  it('should always treat the body as a string', () => {
+    const options = {
+      method: 'GET',
+      port: 80,
+      proto: 'http',
+      hostname: 'example.test',
+      path: '/',
+      headers: {},
+    }
 
-test('stringifyRequest the body is always treated as a string', t => {
-  const options = {
-    method: 'GET',
-    port: 80,
-    proto: 'http',
-    hostname: 'example.test',
-    path: '/',
-    headers: {},
-  }
+    const result = common.stringifyRequest(options, '{"hello":"world"}')
 
-  const result = common.stringifyRequest(options, '{"hello":"world"}')
-
-  expect(JSON.parse(result)).to.deep.equal({
-    method: 'GET',
-    url: 'http://example.test/',
-    headers: {},
-    body: '{"hello":"world"}',
+    expect(JSON.parse(result)).to.deep.equal({
+      method: 'GET',
+      url: 'http://example.test/',
+      headers: {},
+      body: '{"hello":"world"}',
+    })
   })
-
-  t.end()
 })
 
-test('headersArrayToObject', function(t) {
+it('`headersArrayToObject()`', () => {
   const headers = [
     'Content-Type',
     'application/json; charset=utf-8',
@@ -478,43 +466,41 @@ test('headersArrayToObject', function(t) {
   expect(() => common.headersArrayToObject(123)).to.throw(
     'Expected a header array'
   )
-
-  t.end()
 })
 
-test('percentEncode encodes extra reserved characters', t => {
+it('`percentEncode()` encodes extra reserved characters', () => {
   expect(common.percentEncode('foo+(*)!')).to.equal('foo%2B%28%2A%29%21')
-  t.done()
 })
 
-test('normalizeClientRequestArgs throws for invalid URL', t => {
-  // no schema
-  expect(() => http.get('example.test')).to.throw(TypeError, 'example.test')
-  t.done()
+describe('`normalizeClientRequestArgs()`', () => {
+  it('should throw for invalid URL', () => {
+    // no schema
+    expect(() => http.get('example.test')).to.throw(TypeError, 'example.test')
+  })
+
+  it('can include auth info', async () => {
+    const scope = nock('http://example.test')
+      .get('/')
+      .basicAuth({ user: 'user', pass: 'pw' })
+      .reply()
+
+    http.get('http://user:pw@example.test')
+    scope.isDone()
+  })
+
+  it('should handle a single callback', async () => {
+    // TODO: Only passing a callback isn't currently supported by Nock,
+    // but should be in the future as Node allows it.
+    const cb = () => {}
+
+    const { options, callback } = common.normalizeClientRequestArgs(cb)
+
+    expect(options).to.deep.equal({})
+    expect(callback).to.equal(cb)
+  })
 })
 
-test('normalizeClientRequestArgs can include auth info', async () => {
-  const scope = nock('http://example.test')
-    .get('/')
-    .basicAuth({ user: 'user', pass: 'pw' })
-    .reply()
-
-  http.get('http://user:pw@example.test')
-  scope.isDone()
-})
-
-test('normalizeClientRequestArgs with a single callback', async () => {
-  // TODO: Only passing a callback isn't currently supported by Nock,
-  // but should be in the future as Node allows it.
-  const cb = () => {}
-
-  const { options, callback } = common.normalizeClientRequestArgs(cb)
-
-  expect(options).to.deep.equal({})
-  expect(callback).to.equal(cb)
-})
-
-test('testing timers are deleted correctly', t => {
+it('testing timers are deleted correctly', done => {
   const timeoutSpy = sinon.spy()
   const intervalSpy = sinon.spy()
   const immediateSpy = sinon.spy()
@@ -528,6 +514,6 @@ test('testing timers are deleted correctly', t => {
     expect(timeoutSpy).to.not.have.been.called()
     expect(intervalSpy).to.not.have.been.called()
     expect(immediateSpy).to.not.have.been.called()
-    t.end()
+    done()
   })
 })

--- a/tests/test_recorder.js
+++ b/tests/test_recorder.js
@@ -514,7 +514,7 @@ it('when recording, when `req.end()` is called with only data and a callback, th
   })
 })
 
-it('rec() throws when reinvoked with already recorder requests', () => {
+it('`rec()` throws when reinvoked with already recorder requests', () => {
   nock.restore()
   nock.recorder.clear()
   expect(nock.recorder.play()).to.be.empty()

--- a/tests/test_reply_with_file.js
+++ b/tests/test_reply_with_file.js
@@ -13,7 +13,7 @@ require('./setup')
 const textFile = path.join(__dirname, '..', 'assets', 'reply_file_1.txt')
 const binaryFile = path.join(__dirname, '..', 'assets', 'reply_file_2.txt.gz')
 
-describe('`.replyWithFile()', () => {
+describe('`replyWithFile()`', () => {
   it('reply with file', async () => {
     const scope = nock('http://example.test')
       .get('/')

--- a/tests/test_scope.js
+++ b/tests/test_scope.js
@@ -126,7 +126,7 @@ describe('`Scope#isDone()`', () => {
   })
 })
 
-describe('filteringPath()', function() {
+describe('`filteringPath()`', function() {
   it('filter path with function', async function() {
     const scope = nock('http://example.test')
       .filteringPath(() => '/?a=2&b=1')


### PR DESCRIPTION
Like the other Mocha refactors, this is easier to review [without whitespace](https://github.com/nock/nock/pull/1919/files?w=1).