### PR TITLE
chore: remove mkdirp

### DIFF
--- a/lib/back.js
+++ b/lib/back.js
@@ -24,13 +24,6 @@ try {
   // do nothing, probably in browser
 }
 
-let mkdirp
-try {
-  mkdirp = require('mkdirp')
-} catch (err) {
-  // do nothing, probably in browser
-}
-
 /**
  * nock the current function with the fixture given
  *
@@ -176,7 +169,7 @@ const record = {
         typeof outputs === 'string' ? outputs : JSON.stringify(outputs, null, 4)
       debug('recorder outputs:', outputs)
 
-      mkdirp.sync(path.dirname(fixture))
+      fs.mkdirSync(path.dirname(fixture), { recursive: true })
       fs.writeFileSync(fixture, outputs)
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2174,6 +2174,7 @@
         "levn": "^0.3.0",
         "lodash": "^4.17.14",
         "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
         "optionator": "^0.8.3",
         "progress": "^2.0.0",
@@ -2191,6 +2192,15 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
         },
         "strip-ansi": {
           "version": "5.2.0",
@@ -4412,11 +4422,6 @@
         "yallist": "^3.0.0"
       }
     },
-    "mkdirp": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.2.tgz",
-      "integrity": "sha512-N2REVrJ/X/jGPfit2d7zea2J1pf7EAR5chIUcfHffAZ7gmlam5U65sAm76+o4ntQbSRdTjYf7qZz3chuHlwXEA=="
-    },
     "mocha": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.0.1.tgz",
@@ -4436,6 +4441,7 @@
         "js-yaml": "3.13.1",
         "log-symbols": "2.2.0",
         "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
         "ms": "2.1.1",
         "node-environment-flags": "1.0.6",
         "object.assign": "4.1.0",
@@ -4507,6 +4513,15 @@
             "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
           }
         },
         "ms": {
@@ -12622,7 +12637,21 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
       "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        }
+      }
     },
     "write-file-atomic": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "debug": "^4.1.0",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.13",
-    "mkdirp": "^1.0.0",
     "propagate": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Now that we expect Node v10+, we can pass the `recursive` option to `fs.mkdir`.

Fixes #1913