### PR TITLE
refactor(test): Chai assert destroy & dynamic mock

### DIFF
--- a/tests/test_destroy.js
+++ b/tests/test_destroy.js
@@ -1,25 +1,27 @@
 'use strict'
 
-const nock = require('..')
+const { expect } = require('chai')
 const http = require('http')
 const { test } = require('tap')
+const nock = require('..')
 
 require('./cleanup_after_each')()
+require('./setup')
 
 test('req.destroy should emit error event if called with error', t => {
   nock('http://example.test')
     .get('/')
     .reply(404)
 
+  const respErr = new Error('Response error')
+
   http
     .get('http://example.test/', res => {
-      if (res.statusCode !== 200) {
-        res.destroy(new Error('Response error'))
-      }
+      expect(res.statusCode).to.equal(404)
+      res.destroy(respErr)
     })
     .once('error', err => {
-      t.type(err, Error)
-      t.equal(err.message, 'Response error')
+      expect(err).to.equal(respErr)
       t.end()
     })
 })
@@ -31,13 +33,11 @@ test('req.destroy should not emit error event if called without error', t => {
 
   http
     .get('http://example.test/', res => {
-      if (res.statusCode === 403) {
-        res.destroy()
-      }
-
+      expect(res.statusCode).to.equal(403)
+      res.destroy()
       t.end()
     })
     .once('error', () => {
-      t.fail('should not emit error')
+      expect.fail('should not emit error')
     })
 })

--- a/tests/test_dynamic_mock.js
+++ b/tests/test_dynamic_mock.js
@@ -45,10 +45,12 @@ test('asynchronous function gets request headers', async t => {
     .get('/yo')
     .reply(201, function(path, reqBody, cb) {
       expect(this.req.path).to.equal('/yo')
-      expect(this.req.headers).to.include({
+      expect(this.req.headers).to.deep.equal({
+        'accept-encoding': 'gzip, deflate, br',
+        host: 'example.test',
         'x-my-header': 'some-value',
         'x-my-other-header': 'some-other-value',
-        host: 'example.test',
+        'user-agent': 'got (https://github.com/sindresorhus/got)',
       })
       setTimeout(function() {
         cb(null, 'foobar')

--- a/tests/test_dynamic_mock.js
+++ b/tests/test_dynamic_mock.js
@@ -1,28 +1,30 @@
 'use strict'
 
+const { expect } = require('chai')
 const { test } = require('tap')
-const request = require('request')
 const nock = require('..')
+const got = require('./got_client')
 
 require('./cleanup_after_each')()
+require('./setup')
 
-test('one function returning the status code and body defines a full mock', function(t) {
-  nock('http://example.test')
+test('one function returning the status code and body defines a full mock', async t => {
+  const scope = nock('http://example.test')
     .get('/def')
     .reply(function() {
       return [201, 'DEF']
     })
 
-  request.get('http://example.test/def', function(err, resp, body) {
-    t.error(err)
-    t.equal(resp.statusCode, 201)
-    t.equal(body, 'DEF')
-    t.end()
-  })
+  const { statusCode, body } = await got('http://example.test/def')
+  expect(statusCode).to.equal(201)
+  expect(body).to.equal('DEF')
+
+  scope.done()
+  t.end()
 })
 
-test('one asynchronous function returning the status code and body defines a full mock', function(t) {
-  nock('http://example.test')
+test('one asynchronous function returning the status code and body defines a full mock', async t => {
+  const scope = nock('http://example.test')
     .get('/ghi')
     .reply(function(path, reqBody, cb) {
       setTimeout(function() {
@@ -30,20 +32,20 @@ test('one asynchronous function returning the status code and body defines a ful
       }, 1e3)
     })
 
-  request.get('http://example.test/ghi', function(err, resp, body) {
-    t.error(err)
-    t.equal(resp.statusCode, 201)
-    t.equal(body, 'GHI')
-    t.end()
-  })
+  const { statusCode, body } = await got('http://example.test/ghi')
+  expect(statusCode).to.equal(201)
+  expect(body).to.equal('GHI')
+
+  scope.done()
+  t.end()
 })
 
-test('asynchronous function gets request headers', function(t) {
-  nock('http://example.test')
+test('asynchronous function gets request headers', async t => {
+  const scope = nock('http://example.test')
     .get('/yo')
     .reply(201, function(path, reqBody, cb) {
-      t.equal(this.req.path, '/yo')
-      t.deepEqual(this.req.headers, {
+      expect(this.req.path).to.equal('/yo')
+      expect(this.req.headers).to.include({
         'x-my-header': 'some-value',
         'x-my-other-header': 'some-other-value',
         host: 'example.test',
@@ -53,20 +55,16 @@ test('asynchronous function gets request headers', function(t) {
       }, 1e3)
     })
 
-  request(
-    {
-      method: 'GET',
-      uri: 'http://example.test/yo',
-      headers: {
-        'x-my-header': 'some-value',
-        'x-my-other-header': 'some-other-value',
-      },
+  const { statusCode, body } = await got('http://example.test/yo', {
+    headers: {
+      'x-my-header': 'some-value',
+      'x-my-other-header': 'some-other-value',
     },
-    function(err, resp, body) {
-      t.error(err)
-      t.equal(resp.statusCode, 201)
-      t.equal(body, 'foobar')
-      t.end()
-    }
-  )
+  })
+
+  expect(statusCode).to.equal(201)
+  expect(body).to.equal('foobar')
+
+  scope.done()
+  t.end()
 })


### PR DESCRIPTION
Also replaced `request` with `got` in the dynamic tests.