### PR TITLE
fix(types): remove inaccurate Scope.restore method

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -127,7 +127,6 @@ declare namespace nock {
 
     done(): void
     isDone(): boolean
-    restore(): void
     pendingMocks(): string[]
     activeMocks(): string[]
   }

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -135,7 +135,6 @@ inst = inst.socketDelay(2000)
 
 scope.done() // $ExpectType void
 scope.isDone() // $ExpectType boolean
-scope.restore() // $ExpectType void
 
 nock.recorder.rec()
 nock.recorder.rec(true)


### PR DESCRIPTION
This method does not exist and was added on accident.

Fixes: #1934