### PR TITLE
refactor(test): Mocha DSL for destroy & dynamic mocks.

### DIFF
--- a/tests/test_destroy.js
+++ b/tests/test_destroy.js
@@ -2,42 +2,42 @@
 
 const { expect } = require('chai')
 const http = require('http')
-const { test } = require('tap')
 const nock = require('..')
 
-require('./cleanup_after_each')()
 require('./setup')
 
-test('req.destroy should emit error event if called with error', t => {
-  nock('http://example.test')
-    .get('/')
-    .reply(404)
+describe('`res.destroy()`', () => {
+  it('should emit error event if called with error', done => {
+    nock('http://example.test')
+      .get('/')
+      .reply(404)
 
-  const respErr = new Error('Response error')
+    const respErr = new Error('Response error')
 
-  http
-    .get('http://example.test/', res => {
-      expect(res.statusCode).to.equal(404)
-      res.destroy(respErr)
-    })
-    .once('error', err => {
-      expect(err).to.equal(respErr)
-      t.end()
-    })
-})
+    http
+      .get('http://example.test/', res => {
+        expect(res.statusCode).to.equal(404)
+        res.destroy(respErr)
+      })
+      .once('error', err => {
+        expect(err).to.equal(respErr)
+        done()
+      })
+  })
 
-test('req.destroy should not emit error event if called without error', t => {
-  nock('http://example.test')
-    .get('/')
-    .reply(403)
+  it('should not emit error event if called without error', done => {
+    nock('http://example.test')
+      .get('/')
+      .reply(403)
 
-  http
-    .get('http://example.test/', res => {
-      expect(res.statusCode).to.equal(403)
-      res.destroy()
-      t.end()
-    })
-    .once('error', () => {
-      expect.fail('should not emit error')
-    })
+    http
+      .get('http://example.test/', res => {
+        expect(res.statusCode).to.equal(403)
+        res.destroy()
+        done()
+      })
+      .once('error', () => {
+        expect.fail('should not emit error')
+      })
+  })
 })


### PR DESCRIPTION
I moved the one test from 'dynamic' to `test_reply_function_async.js` since it was passing the callback as a second arg, then added a few tests to `test_dynamic_mock.js` to cover body and headers being optional. 