### PR TITLE
fix: add path to NetConnectNotAllowedError

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -24,11 +24,11 @@ const globalEmitter = require('./global_emitter')
 function NetConnectNotAllowedError(host, path) {
   Error.call(this)
 
-  this.host = host;
+  this.host = host
   this.name = 'NetConnectNotAllowedError'
   this.code = 'ENETUNREACH'
   this.message = `Nock: Disallowed net connect for "${host}${path}"`
-  this.path = path;
+  this.path = path
 
   Error.captureStackTrace(this, this.constructor)
 }
@@ -238,8 +238,8 @@ let originalClientRequest
 
 function ErroringClientRequest(error) {
   http.OutgoingMessage.call(this)
-  this.host = error.host;
-  this.path = error.path;
+  this.host = error.host
+  this.path = error.path
 
   process.nextTick(
     function() {

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -24,9 +24,11 @@ const globalEmitter = require('./global_emitter')
 function NetConnectNotAllowedError(host, path) {
   Error.call(this)
 
+  this.host = host;
   this.name = 'NetConnectNotAllowedError'
   this.code = 'ENETUNREACH'
   this.message = `Nock: Disallowed net connect for "${host}${path}"`
+  this.path = path;
 
   Error.captureStackTrace(this, this.constructor)
 }
@@ -236,6 +238,9 @@ let originalClientRequest
 
 function ErroringClientRequest(error) {
   http.OutgoingMessage.call(this)
+  this.host = error.host;
+  this.path = error.path;
+
   process.nextTick(
     function() {
       this.emit('error', error)

--- a/tests/test_nock_lifecycle.js
+++ b/tests/test_nock_lifecycle.js
@@ -111,10 +111,8 @@ describe('Nock lifecycle functions', () => {
 
       await assertRejects(got('http://example.test/'), err => {
         expect(err).to.include({
-          host: 'example.test:80',
           name: 'RequestError',
           code: 'ENOTFOUND',
-          path: '/'
         })
         return true
       })

--- a/tests/test_nock_lifecycle.js
+++ b/tests/test_nock_lifecycle.js
@@ -111,7 +111,7 @@ describe('Nock lifecycle functions', () => {
 
       await assertRejects(got('http://example.test/'), err => {
         expect(err).to.include({
-          host: 'http://example.test',
+          host: 'example.test:80',
           name: 'RequestError',
           code: 'ENOTFOUND',
           path: '/'

--- a/tests/test_nock_lifecycle.js
+++ b/tests/test_nock_lifecycle.js
@@ -111,8 +111,10 @@ describe('Nock lifecycle functions', () => {
 
       await assertRejects(got('http://example.test/'), err => {
         expect(err).to.include({
+          host: 'http://example.test',
           name: 'RequestError',
           code: 'ENOTFOUND',
+          path: '/'
         })
         return true
       })


### PR DESCRIPTION
# Error 

```
name: 'NetConnectNotAllowedError',
code: 'ENETUNREACH',
message: 'Nock: Disallowed net connect for "111.111.111.254:80/2016-09-02/dynamic/instance-identity/document"',

"Cannot read property 'protocol' of undefined",
"name":"TypeError",
"stack":"TypeError: Cannot read property 'protocol' of undefined
    at Object.scrubAndParseParameters (node-newrelic/lib/util/urltils.js:160:28)
    at instrumentRequest (node-newrelic/lib/instrumentation/core/http-outbound.js:127:28)
    at wrapped (node-newrelic/lib/transaction/tracer/index.js:188:22)
    at Tracer.addSegment (node-newrelic/lib/transaction/tracer/index.js:83:48)
    at instrumentOutbound (node-newrelic/lib/instrumentation/core/http-outbound.js:75:23)
    at Object.wrappedRequest [as request] (node-newrelic/lib/instrumentation/core/http.js:476:12)
    at node_modules/express-http-proxy/app/steps/sendProxyRequest.js:13:29
    at new Promise (<anonymous>)
    at sendProxyRequest (node_modules/express-http-proxy/app/steps/sendProxyRequest.js:11:10)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)"
```

# Context: 

Newrelic is also expecting the Error to have a path.

https://github.com/newrelic/node-newrelic/blob/master/lib/instrumentation/core/http-outbound.js#L126

```
const parsed = urltils.scrubAndParseParameters(request.path)
```

https://github.com/newrelic/node-newrelic/blob/master/lib/util/urltils.js#L160

```
scrubAndParseParameters: function scrubAndParseParameters(requestURL) {
  ...
  requestURL = url.parse(requestURL, true)
  ...
  protocol: requestURL.protocol,
```

# Similar issues

This was brought up in https://github.com/nock/nock/issues/211#issuecomment-227352613 where superagent was expecting a path on the error.

```
[TypeError: Cannot call method 'indexOf' of undefined] 
TypeError: Cannot call method \'indexOf\' of undefined
at Request.end (/Volumes/Store/Projects/nock/node_modules/superagent/lib/node/index.js:759:20)
at Test.<anonymous> (/Volumes/Store/Projects/nock/tests/test_intercept.js:3329:6)
at Test.EventEmitter.emit (events.js:117:20)
at Test.emit (/Volumes/Store/Projects/nock/node_modules/tap/lib/tap-test.js:104:8)
at GlobalHarness.Harness.process (/Volumes/Store/Projects/nock/node_modules/tap/lib/tap-harness.js:87:13)
at process._tickDomainCallback (node.js:459:13)
```

There was also a PR https://github.com/nock/nock/pull/590/files#diff-503754c07b5098227646f913eee85885R216 but it set defaults rather than the original path. 

## What's different

In this pr, I added the path to NetConnectNotAllowedError so that it can be added to ErroringClientRequest. While its not a full solution, it does help use nock with newrelic and superagent.  In both cases, adding a `path` would resolve most integrations. 
