### PR TITLE
fix(router): bring behavior of `abort()` inline with native Node

### DIFF
--- a/lib/intercepted_request_router.js
+++ b/lib/intercepted_request_router.js
@@ -39,9 +39,13 @@ class InterceptedRequestRouter {
     }
 
     this.response = new IncomingMessage(this.socket)
-    this.playbackStarted = false
-    this.playbackOnSocket = false
     this.requestBodyBuffers = []
+    this.playbackStarted = false
+
+    // For parity with Node, it's important the socket event is emitted before we begin playback.
+    // This flag is set when playback is triggered if we haven't yet gotten the
+    // socket event to indicate that playback should start as soon as it comes in.
+    this.readyToStartPlaybackOnSocketEvent = false
 
     this.attachToReq()
   }
@@ -104,7 +108,7 @@ class InterceptedRequestRouter {
         socket.emit('secureConnect')
       }
 
-      if (this.playbackOnSocket) {
+      if (this.readyToStartPlaybackOnSocketEvent) {
         this.maybeStartPlayback()
       }
     })
@@ -127,6 +131,10 @@ class InterceptedRequestRouter {
       const err = new Error('write after end')
       err.code = 'ERR_STREAM_WRITE_AFTER_END'
       this.emitError(err)
+
+      // It seems odd to return `true` here, not sure why you'd want to have
+      // the stream potentially written to more, but it's what Node does.
+      // https://github.com/nodejs/node/blob/master/lib/_http_outgoing.js#L662-L665
       return true
     }
 
@@ -194,7 +202,10 @@ class InterceptedRequestRouter {
     if (req.aborted) {
       return
     }
-    req.aborted = true // as of v11 this is a bool instead of a timestamp
+
+    // Historically, `aborted` was undefined or a timestamp.
+    // Node changed this behavior in v11 to always be a bool.
+    req.aborted = true
     req.destroyed = true
 
     // the order of these next three steps is important to match order of events Node would emit.
@@ -253,7 +264,7 @@ class InterceptedRequestRouter {
     // In order to get the events in the right order we need to delay playback
     // if we get here before the `socket` event is emitted.
     if (socket.connecting) {
-      this.playbackOnSocket = true
+      this.readyToStartPlaybackOnSocketEvent = true
       return
     }
 

--- a/lib/intercepted_request_router.js
+++ b/lib/intercepted_request_router.js
@@ -40,15 +40,14 @@ class InterceptedRequestRouter {
 
     this.response = new IncomingMessage(this.socket)
     this.playbackStarted = false
+    this.playbackOnSocket = false
     this.requestBodyBuffers = []
 
     this.attachToReq()
   }
 
   attachToReq() {
-    const { req, response, socket, options } = this
-
-    response.req = req
+    const { req, socket, options } = this
 
     for (const [name, val] of Object.entries(options.headers)) {
       req.setHeader(name.toLowerCase(), val)
@@ -71,7 +70,7 @@ class InterceptedRequestRouter {
     // The same Socket is shared between the request and response to mimic native behavior.
     req.socket = req.connection = socket
 
-    propagate(['error', 'timeout'], req.socket, req)
+    propagate(['close', 'error', 'timeout'], req.socket, req)
 
     req.write = (...args) => this.handleWrite(...args)
     req.end = (...args) => this.handleEnd(...args)
@@ -90,6 +89,11 @@ class InterceptedRequestRouter {
     // Some clients listen for a 'socket' event to be emitted before calling end(),
     // which causes nock to hang.
     process.nextTick(() => {
+      if (req.aborted) {
+        return
+      }
+
+      socket.connecting = false
       req.emit('socket', socket)
 
       // https://nodejs.org/api/net.html#net_event_connect
@@ -98,6 +102,10 @@ class InterceptedRequestRouter {
       // https://nodejs.org/api/tls.html#tls_event_secureconnect
       if (socket.authorized) {
         socket.emit('secureConnect')
+      }
+
+      if (this.playbackOnSocket) {
+        this.maybeStartPlayback()
       }
     })
   }
@@ -109,26 +117,38 @@ class InterceptedRequestRouter {
     })
   }
 
+  // from docs: When write function is called with empty string or buffer, it does nothing and waits for more input.
+  // However, actually implementation checks the state of finished and aborted before checking if the first arg is empty.
   handleWrite(buffer, encoding, callback) {
     debug('write', arguments)
     const { req } = this
 
-    if (!req.aborted) {
-      if (buffer) {
-        if (!Buffer.isBuffer(buffer)) {
-          buffer = Buffer.from(buffer, encoding)
-        }
-        this.requestBodyBuffers.push(buffer)
-      }
-      // can't use instanceof Function because some test runners
-      // run tests in vm.runInNewContext where Function is not same
-      // as that in the current context
-      // https://github.com/nock/nock/pull/1754#issuecomment-571531407
-      if (typeof callback === 'function') {
-        callback()
-      }
-    } else {
-      this.emitError(new Error('Request aborted'))
+    if (req.finished) {
+      const err = new Error('write after end')
+      err.code = 'ERR_STREAM_WRITE_AFTER_END'
+      this.emitError(err)
+      return true
+    }
+
+    if (req.aborted) {
+      return false
+    }
+
+    if (!buffer || buffer.length === 0) {
+      return true
+    }
+
+    if (!Buffer.isBuffer(buffer)) {
+      buffer = Buffer.from(buffer, encoding)
+    }
+    this.requestBodyBuffers.push(buffer)
+
+    // can't use instanceof Function because some test runners
+    // run tests in vm.runInNewContext where Function is not same
+    // as that in the current context
+    // https://github.com/nock/nock/pull/1754#issuecomment-571531407
+    if (typeof callback === 'function') {
+      callback()
     }
 
     common.setImmediate(function () {
@@ -142,7 +162,7 @@ class InterceptedRequestRouter {
     debug('req.end')
     const { req } = this
 
-    // handle the different overloaded param signatures
+    // handle the different overloaded arg signatures
     if (typeof chunk === 'function') {
       callback = chunk
       chunk = null
@@ -155,51 +175,45 @@ class InterceptedRequestRouter {
       req.once('finish', callback)
     }
 
-    if (!req.aborted && !this.playbackStarted) {
-      req.write(chunk, encoding)
-      this.startPlayback()
-    }
-    if (req.aborted) {
-      this.emitError(new Error('Request aborted'))
-    }
+    req.write(chunk, encoding)
+    req.finished = true
+    this.maybeStartPlayback()
 
     return req
   }
 
   handleFlushHeaders() {
     debug('req.flushHeaders')
-    const { req } = this
-
-    if (!req.aborted && !this.playbackStarted) {
-      this.startPlayback()
-    }
-    if (req.aborted) {
-      this.emitError(new Error('Request aborted'))
-    }
+    this.maybeStartPlayback()
   }
 
   handleAbort() {
     debug('req.abort')
-    const { req, response, socket } = this
+    const { req, socket } = this
 
     if (req.aborted) {
       return
     }
-    req.aborted = Date.now()
-    if (!this.playbackStarted) {
-      this.startPlayback()
+    req.aborted = true // as of v11 this is a bool instead of a timestamp
+    req.destroyed = true
+
+    // the order of these next three steps is important to match order of events Node would emit.
+    process.nextTick(() => req.emit('abort'))
+
+    if (!socket.connecting) {
+      if (!req.res) {
+        // If we don't have a response then we know that the socket
+        // ended prematurely and we need to emit an error on the request.
+        // Node doesn't actually emit this during the `abort` method.
+        // Instead it listens to the socket's `end` and `close` events, however,
+        // Nock's socket doesn't have all the complexities and events to
+        // replicated that directly. This is an easy way to achieve the same behavior.
+        const connResetError = new Error('socket hang up')
+        connResetError.code = 'ECONNRESET'
+        this.emitError(connResetError)
+      }
+      socket.destroy()
     }
-    const err = new Error()
-    err.code = 'aborted'
-    response.emit('close', err)
-
-    socket.destroy()
-
-    req.emit('abort')
-
-    const connResetError = new Error('socket hang up')
-    connResetError.code = 'ECONNRESET'
-    this.emitError(connResetError)
   }
 
   /**
@@ -230,6 +244,21 @@ class InterceptedRequestRouter {
 
         req.setHeader(HOST_HEADER, hostHeader)
       }
+    }
+  }
+
+  maybeStartPlayback() {
+    const { req, socket, playbackStarted } = this
+
+    // In order to get the events in the right order we need to delay playback
+    // if we get here before the `socket` event is emitted.
+    if (socket.connecting) {
+      this.playbackOnSocket = true
+      return
+    }
+
+    if (!req.aborted && !playbackStarted) {
+      this.startPlayback()
     }
   }
 
@@ -274,7 +303,6 @@ class InterceptedRequestRouter {
 
       // wait to emit the finish event until we know for sure an Interceptor is going to playback.
       // otherwise an unmocked request might emit finish twice.
-      req.finished = true
       req.emit('finish')
 
       playbackInterceptor({

--- a/lib/playback_interceptor.js
+++ b/lib/playback_interceptor.js
@@ -257,10 +257,6 @@ function playbackInterceptor({
 
     interceptor.markConsumed()
 
-    if (req.aborted) {
-      return
-    }
-
     response.rawHeaders.push(
       ...selectDefaultHeaders(
         response.rawHeaders,
@@ -277,23 +273,23 @@ function playbackInterceptor({
 
     response.headers = common.headersArrayToObject(response.rawHeaders)
 
-    process.nextTick(() =>
-      respondUsingInterceptor({
-        responseBody,
-        responseBuffers,
-      })
-    )
+    respondUsingInterceptor({
+      responseBody,
+      responseBuffers,
+    })
   }
 
   function respondUsingInterceptor({ responseBody, responseBuffers }) {
-    if (req.aborted) {
-      return
-    }
-
     function respond() {
       if (req.aborted) {
         return
       }
+
+      // Even though we've had the response object for awhile at this point,
+      // we only attach it to the request immediately before the `response`
+      // event because, as in Node, it alters the error handling around aborts.
+      req.res = response
+      response.req = req
 
       debug('emitting response')
       req.emit('response', response)
@@ -342,7 +338,15 @@ function playbackInterceptor({
     }
   }
 
-  start()
+  // stall the playback to ensure the correct events are emitted first and
+  // any aborts in the queue can be called.
+  common.setImmediate(() => {
+    if (req.aborted) {
+      return
+    }
+
+    start()
+  })
 }
 
 module.exports = { playbackInterceptor }

--- a/lib/playback_interceptor.js
+++ b/lib/playback_interceptor.js
@@ -338,14 +338,15 @@ function playbackInterceptor({
     }
   }
 
-  // stall the playback to ensure the correct events are emitted first and
-  // any aborts in the queue can be called.
+  // If there are no delays configured on the Interceptor, calling `start` will
+  // take the request all the way to the 'response' event during a single microtask
+  // execution. This setImmediate stalls the playback to ensure the correct events
+  // are emitted first ('socket', 'finish') and any aborts in the in the queue
+  // or called during a 'finish' listener can be called.
   common.setImmediate(() => {
-    if (req.aborted) {
-      return
+    if (!req.aborted) {
+      start()
     }
-
-    start()
   })
 }
 

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -18,7 +18,7 @@ module.exports = class Socket extends EventEmitter {
     this.readable = true
     this.pending = false
     this.destroyed = false
-    this.connecting = false
+    this.connecting = true
 
     // totalDelay that has already been applied to the current
     // request/connection, timeout error will be generated if
@@ -70,11 +70,20 @@ module.exports = class Socket extends EventEmitter {
   }
 
   destroy(err) {
+    if (this.destroyed) {
+      return this
+    }
+
     this.destroyed = true
     this.readable = this.writable = false
-    if (err) {
-      this.emit('error', err)
-    }
+
+    process.nextTick(() => {
+      if (err) {
+        this.emit('error', err)
+      }
+      this.emit('close')
+    })
+
     return this
   }
 }

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -69,6 +69,13 @@ module.exports = class Socket extends EventEmitter {
     ).toString('base64')
   }
 
+  /**
+   * Denotes that no more I/O activity should happen on this socket.
+   *
+   * The implementation in Node if far more complex as it juggles underlying async streams.
+   * For the purposes of Nock, we just need it to set some flags and on the first call
+   * emit a 'close' and optional 'error' event. Both events propagate through the request object.
+   */
   destroy(err) {
     if (this.destroyed) {
       return this

--- a/tests/test_abort.js
+++ b/tests/test_abort.js
@@ -17,9 +17,7 @@ require('./setup')
 // Starting the top by aborting requests early on then aborting later and later.
 describe('`ClientRequest.abort()`', () => {
   it('should not emit an error when `write` is called on an aborted request', done => {
-    const scope = nock('http://example.test')
-      .get('/')
-      .reply()
+    const scope = nock('http://example.test').get('/').reply()
 
     const req = http.request('http://example.test')
     const emitSpy = sinon.spy(req, 'emit')
@@ -34,9 +32,7 @@ describe('`ClientRequest.abort()`', () => {
   })
 
   it('should not emit an error when `end` is called on an aborted request', done => {
-    const scope = nock('http://example.test')
-      .get('/')
-      .reply()
+    const scope = nock('http://example.test').get('/').reply()
 
     const req = http.request('http://example.test')
     const emitSpy = sinon.spy(req, 'emit')
@@ -51,9 +47,7 @@ describe('`ClientRequest.abort()`', () => {
   })
 
   it('should not emit an error when `flushHeaders` is called on an aborted request', done => {
-    const scope = nock('http://example.test')
-      .get('/')
-      .reply()
+    const scope = nock('http://example.test').get('/').reply()
 
     const req = http.request('http://example.test')
     const emitSpy = sinon.spy(req, 'emit')
@@ -68,9 +62,7 @@ describe('`ClientRequest.abort()`', () => {
   })
 
   it('should not emit an error when called immediately after `end`', done => {
-    const scope = nock('http://example.test')
-      .get('/')
-      .reply()
+    const scope = nock('http://example.test').get('/').reply()
 
     const req = http.request('http://example.test')
     const emitSpy = sinon.spy(req, 'emit')
@@ -85,9 +77,7 @@ describe('`ClientRequest.abort()`', () => {
   })
 
   it('should emit an ECONNRESET error when aborted inside a `socket` event listener', done => {
-    const scope = nock('http://example.test')
-      .get('/')
-      .reply()
+    const scope = nock('http://example.test').get('/').reply()
 
     const req = http.request('http://example.test')
     const emitSpy = sinon.spy(req, 'emit')
@@ -110,9 +100,7 @@ describe('`ClientRequest.abort()`', () => {
   })
 
   it('should only emit `abort` and `error` events once if aborted multiple times', done => {
-    const scope = nock('http://example.test')
-      .get('/')
-      .reply()
+    const scope = nock('http://example.test').get('/').reply()
 
     const req = http.request('http://example.test')
     const emitSpy = sinon.spy(req, 'emit')
@@ -134,9 +122,7 @@ describe('`ClientRequest.abort()`', () => {
   })
 
   it('should emit an ECONNRESET error when aborted inside a `finish` event listener', done => {
-    const scope = nock('http://example.test')
-      .get('/')
-      .reply()
+    const scope = nock('http://example.test').get('/').reply()
 
     const req = http.request('http://example.test')
     const emitSpy = sinon.spy(req, 'emit')
@@ -168,9 +154,7 @@ describe('`ClientRequest.abort()`', () => {
   // all tests below assert the Scope is done.
 
   it('should not emit an error when called inside a `response` event listener', done => {
-    const scope = nock('http://example.test')
-      .get('/')
-      .reply()
+    const scope = nock('http://example.test').get('/').reply()
 
     const req = http.request('http://example.test')
     const emitSpy = sinon.spy(req, 'emit')

--- a/tests/test_abort.js
+++ b/tests/test_abort.js
@@ -16,7 +16,7 @@ require('./setup')
 // The order of tests run sequentially through a ClientRequest's lifetime.
 // Starting the top by aborting requests early on then aborting later and later.
 describe('`ClientRequest.abort()`', () => {
-  it('should not emit an error when `write` is called on an aborted request', done => {
+  it('Emits the expected event sequence when `write` is called on an aborted request', done => {
     const scope = nock('http://example.test').get('/').reply()
 
     const req = http.request('http://example.test')
@@ -31,7 +31,7 @@ describe('`ClientRequest.abort()`', () => {
     }, 10)
   })
 
-  it('should not emit an error when `end` is called on an aborted request', done => {
+  it('Emits the expected event sequence when `end` is called on an aborted request', done => {
     const scope = nock('http://example.test').get('/').reply()
 
     const req = http.request('http://example.test')
@@ -46,7 +46,7 @@ describe('`ClientRequest.abort()`', () => {
     }, 10)
   })
 
-  it('should not emit an error when `flushHeaders` is called on an aborted request', done => {
+  it('Emits the expected event sequence when `flushHeaders` is called on an aborted request', done => {
     const scope = nock('http://example.test').get('/').reply()
 
     const req = http.request('http://example.test')
@@ -61,7 +61,7 @@ describe('`ClientRequest.abort()`', () => {
     }, 10)
   })
 
-  it('should not emit an error when called immediately after `end`', done => {
+  it('Emits the expected event sequence when aborted immediately after `end`', done => {
     const scope = nock('http://example.test').get('/').reply()
 
     const req = http.request('http://example.test')
@@ -76,7 +76,7 @@ describe('`ClientRequest.abort()`', () => {
     }, 10)
   })
 
-  it('should emit an ECONNRESET error when aborted inside a `socket` event listener', done => {
+  it('Emits the expected event sequence when aborted inside a `socket` event listener', done => {
     const scope = nock('http://example.test').get('/').reply()
 
     const req = http.request('http://example.test')
@@ -99,7 +99,7 @@ describe('`ClientRequest.abort()`', () => {
     }, 10)
   })
 
-  it('should only emit `abort` and `error` events once if aborted multiple times', done => {
+  it('Emits the expected event sequence when aborted multiple times', done => {
     const scope = nock('http://example.test').get('/').reply()
 
     const req = http.request('http://example.test')
@@ -115,13 +115,14 @@ describe('`ClientRequest.abort()`', () => {
 
     setTimeout(() => {
       const events = emitSpy.args.map(i => i[0])
+      // important: `abort` and `error` events only fire once and the `close` event still fires at the end
       expect(events).to.deep.equal(['socket', 'abort', 'error', 'close'])
       expect(scope.isDone()).to.be.false()
       done()
     }, 10)
   })
 
-  it('should emit an ECONNRESET error when aborted inside a `finish` event listener', done => {
+  it('Emits the expected event sequence when aborted inside a `finish` event listener', done => {
     const scope = nock('http://example.test').get('/').reply()
 
     const req = http.request('http://example.test')
@@ -153,7 +154,7 @@ describe('`ClientRequest.abort()`', () => {
   // The Interceptor is considered consumed just prior to the `response` event on the request,
   // all tests below assert the Scope is done.
 
-  it('should not emit an error when called inside a `response` event listener', done => {
+  it('Emits the expected event sequence when aborted inside a `response` event listener', done => {
     const scope = nock('http://example.test').get('/').reply()
 
     const req = http.request('http://example.test')

--- a/tests/test_abort.js
+++ b/tests/test_abort.js
@@ -1,157 +1,196 @@
 'use strict'
 
-const nock = require('..')
 const { expect } = require('chai')
 const http = require('http')
 const sinon = require('sinon')
+const nock = require('..')
 
 require('./setup')
 
-it('`req.abort()` should cause "abort" and "error" to be emitted', done => {
-  const scope = nock('http://example.test')
-    .get('/')
-    .delayConnection(500)
-    .reply()
+// These tests use `setTimeout` before verifying emitted events to ensure any
+// number of `nextTicks` or `setImmediate` can process first.
 
-  const onAbort = sinon.spy()
-  const req = http
-    .get('http://example.test/')
-    .once('abort', onAbort)
-    .once('error', err => {
-      // Should trigger last
-      expect(err.code).to.equal('ECONNRESET')
-      expect(onAbort).to.have.been.calledOnce()
-      scope.done()
+// Node will emit a `prefinish` event after `socket`, but it's an internal,
+// undocumented event that Nock does not emulate.
+
+// The order of tests run sequentially through a ClientRequest's lifetime.
+// Starting the top by aborting requests early on then aborting later and later.
+describe('`ClientRequest.abort()`', () => {
+  it('should not emit an error when `write` is called on an aborted request', done => {
+    const scope = nock('http://example.test')
+      .get('/')
+      .reply()
+
+    const req = http.request('http://example.test')
+    const emitSpy = sinon.spy(req, 'emit')
+    req.abort()
+    req.write('foo')
+
+    setTimeout(() => {
+      expect(emitSpy).to.have.been.calledOnceWithExactly('abort')
+      expect(scope.isDone()).to.be.false()
       done()
-    })
-  process.nextTick(() => req.abort())
-})
+    }, 10)
+  })
 
-it('abort is emitted before delay time', done => {
-  const scope = nock('http://example.test')
-    .get('/')
-    .delayConnection(500)
-    .reply()
+  it('should not emit an error when `end` is called on an aborted request', done => {
+    const scope = nock('http://example.test')
+      .get('/')
+      .reply()
 
-  const start = Date.now()
-  const req = http
-    .get('http://example.test/')
-    .once('abort', () => {
-      const actual = Date.now() - start
-      expect(actual).to.be.below(250)
-      scope.done()
+    const req = http.request('http://example.test')
+    const emitSpy = sinon.spy(req, 'emit')
+    req.abort()
+    req.end()
+
+    setTimeout(() => {
+      expect(emitSpy).to.have.been.calledOnceWithExactly('abort')
+      expect(scope.isDone()).to.be.false()
       done()
-    })
-    .once('error', () => {}) // Don't care.
-  // Don't bother with the response
+    }, 10)
+  })
 
-  setTimeout(() => req.abort(), 10)
-})
+  it('should not emit an error when `flushHeaders` is called on an aborted request', done => {
+    const scope = nock('http://example.test')
+      .get('/')
+      .reply()
 
-it('Aborting an aborted request should not emit an error', done => {
-  const scope = nock('http://example.test').get('/').reply()
+    const req = http.request('http://example.test')
+    const emitSpy = sinon.spy(req, 'emit')
+    req.abort()
+    req.flushHeaders()
 
-  let errorCount = 0
-  const req = http.get('http://example.test/').on('error', () => {
-    errorCount++
-    if (errorCount < 3) {
-      // Abort 3 times at max, otherwise this would be an endless loop.
-      // https://github.com/nock/nock/issues/882
+    setTimeout(() => {
+      expect(emitSpy).to.have.been.calledOnceWithExactly('abort')
+      expect(scope.isDone()).to.be.false()
+      done()
+    }, 10)
+  })
+
+  it('should not emit an error when called immediately after `end`', done => {
+    const scope = nock('http://example.test')
+      .get('/')
+      .reply()
+
+    const req = http.request('http://example.test')
+    const emitSpy = sinon.spy(req, 'emit')
+    req.end()
+    req.abort()
+
+    setTimeout(() => {
+      expect(emitSpy).to.have.been.calledOnceWithExactly('abort')
+      expect(scope.isDone()).to.be.false()
+      done()
+    }, 10)
+  })
+
+  it('should emit an ECONNRESET error when aborted inside a `socket` event listener', done => {
+    const scope = nock('http://example.test')
+      .get('/')
+      .reply()
+
+    const req = http.request('http://example.test')
+    const emitSpy = sinon.spy(req, 'emit')
+
+    req.on('socket', () => {
       req.abort()
-    }
+    })
+    req.on('error', err => {
+      expect(err.message).to.equal('socket hang up')
+      expect(err.code).to.equal('ECONNRESET')
+    })
+    req.end()
+
+    setTimeout(() => {
+      const events = emitSpy.args.map(i => i[0])
+      expect(events).to.deep.equal(['socket', 'abort', 'error', 'close'])
+      expect(scope.isDone()).to.be.false()
+      done()
+    }, 10)
   })
-  req.abort()
 
-  // Allow some time to fail.
-  setTimeout(() => {
-    expect(errorCount).to.equal(1, 'Only one error should be sent')
-    scope.done()
-    done()
-  }, 10)
-})
+  it('should only emit `abort` and `error` events once if aborted multiple times', done => {
+    const scope = nock('http://example.test')
+      .get('/')
+      .reply()
 
-it('Aborting a not-yet-ended request should end it', done => {
-  // Set up.
-  const scope = nock('http://example.test').post('/').reply()
+    const req = http.request('http://example.test')
+    const emitSpy = sinon.spy(req, 'emit')
 
-  const req = http.request({
-    host: 'example.test',
-    method: 'post',
-    path: '/',
+    req.on('error', () => {}) // listen for error so it doesn't bubble
+    req.on('socket', () => {
+      req.abort()
+      req.abort()
+      req.abort()
+    })
+    req.end()
+
+    setTimeout(() => {
+      const events = emitSpy.args.map(i => i[0])
+      expect(events).to.deep.equal(['socket', 'abort', 'error', 'close'])
+      expect(scope.isDone()).to.be.false()
+      done()
+    }, 10)
   })
-  req.on('error', () => {})
 
-  // Act.
-  req.abort()
+  it('should emit an ECONNRESET error when aborted inside a `finish` event listener', done => {
+    const scope = nock('http://example.test')
+      .get('/')
+      .reply()
 
-  // Assert.
-  scope.done()
+    const req = http.request('http://example.test')
+    const emitSpy = sinon.spy(req, 'emit')
 
-  done()
-})
+    req.on('finish', () => {
+      req.abort()
+    })
+    req.on('error', err => {
+      expect(err.message).to.equal('socket hang up')
+      expect(err.code).to.equal('ECONNRESET')
+    })
+    req.end()
 
-it('`req.write() on an aborted request should trigger the expected error', done => {
-  const scope = nock('http://example.test').get('/').reply()
+    setTimeout(() => {
+      const events = emitSpy.args.map(i => i[0])
+      expect(events).to.deep.equal([
+        'socket',
+        'finish',
+        'abort',
+        'error',
+        'close',
+      ])
+      expect(scope.isDone()).to.be.false()
+      done()
+    }, 10)
+  })
 
-  const req = http.get('http://example.test/')
+  // The Interceptor is considered consumed just prior to the `response` event on the request,
+  // all tests below assert the Scope is done.
 
-  req.once('error', err => {
-    // This is the expected first error event emitted, triggered by
-    // `req.abort()`.
-    expect(err.code).to.equal('ECONNRESET')
+  it('should not emit an error when called inside a `response` event listener', done => {
+    const scope = nock('http://example.test')
+      .get('/')
+      .reply()
 
-    req.once('error', err => {
-      // This is the abort error under test, triggered by `req.write()`
-      expect(err.message).to.equal('Request aborted')
+    const req = http.request('http://example.test')
+    const emitSpy = sinon.spy(req, 'emit')
+
+    req.on('response', () => {
+      req.abort()
+    })
+    req.end()
+
+    setTimeout(() => {
+      const events = emitSpy.args.map(i => i[0])
+      expect(events).to.deep.equal([
+        'socket',
+        'finish',
+        'response',
+        'abort',
+        'close',
+      ])
       scope.done()
       done()
-    })
+    }, 10)
   })
-
-  process.nextTick(() => req.abort())
-  process.nextTick(() => req.write('some nonsense'))
-})
-
-it('`req.end()` on an aborted request should trigger the expected error', done => {
-  const scope = nock('http://example.test').get('/').reply()
-
-  const req = http.get('http://example.test/')
-
-  req.once('error', err => {
-    // This is the expected first error event emitted, triggered by
-    // `req.abort()`.
-    expect(err.code).to.equal('ECONNRESET')
-
-    req.once('error', err => {
-      // This is the abort error under test, triggered by `req.end()`
-      expect(err.message).to.equal('Request aborted')
-      scope.done()
-      done()
-    })
-  })
-
-  process.nextTick(() => req.abort())
-  process.nextTick(() => req.end())
-})
-
-it('`req.flushHeaders()` on an aborted request should trigger the expected error', done => {
-  const scope = nock('http://example.test').get('/').reply()
-
-  const req = http.get('http://example.test/')
-
-  req.once('error', err => {
-    // This is the expected first error event emitted, triggered by
-    // `req.abort()`.
-    expect(err.code).to.equal('ECONNRESET')
-
-    req.once('error', err => {
-      // This is the abort error under test, triggered by `req.flushHeaders()`
-      expect(err.message).to.equal('Request aborted')
-      scope.done()
-      done()
-    })
-  })
-
-  process.nextTick(() => req.abort())
-  process.nextTick(() => req.flushHeaders())
 })

--- a/tests/test_back.js
+++ b/tests/test_back.js
@@ -54,10 +54,11 @@ function nockBackWithFixture(t, scopesLoaded) {
 
   nockBack('good_request.json', function (done) {
     t.equal(this.scopes.length, scopesLength)
-    http.get('http://www.example.test/')
-    this.assertScopesFinished()
-    done()
-    t.end()
+    http.get('http://www.example.test/', () => {
+      this.assertScopesFinished()
+      done()
+      t.end()
+    })
   })
 }
 
@@ -360,10 +361,11 @@ test('nockBack record tests', nw => {
   nw.test('it loads your recorded tests', t => {
     nockBack('good_request.json', function (done) {
       t.true(this.scopes.length > 0)
-      http.get('http://www.example.test/').end()
-      this.assertScopesFinished()
-      done()
-      t.end()
+      http.get('http://www.example.test/', () => {
+        this.assertScopesFinished()
+        done()
+        t.end()
+      })
     })
   })
 

--- a/tests/test_client_request.js
+++ b/tests/test_client_request.js
@@ -79,11 +79,10 @@ describe('Direct use of `ClientRequest`', () => {
     }
     const req = new http.ClientRequest(reqOpts, res => {
       expect(res.statusCode).to.equal(201)
+      scope.done()
       done()
     })
     req.end()
-
-    scope.done()
   })
 
   it('should throw an expected error when creating with empty options', () => {

--- a/tests/test_header_matching.js
+++ b/tests/test_header_matching.js
@@ -568,7 +568,7 @@ it('header manipulation', done => {
     .get('/accounts')
     .reply(200, { accounts: [{ id: 1, name: 'Joe Blow' }] })
 
-  const req = http.get({ host: 'example.test', path: '/accounts' }, res => {
+  const req = http.request({ host: 'example.test', path: '/accounts' }, res => {
     res.on('end', () => {
       scope.done()
       done()

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -257,7 +257,9 @@ test('on interceptor, filter path with function', async t => {
 
 // TODO: Move to test_request_overrider.
 test('abort request', t => {
-  const scope = nock('http://example.test').get('/hey').reply(200, 'nobody')
+  const scope = nock('http://example.test')
+    .get('/hey')
+    .reply(200, 'nobody')
 
   const req = http.request({
     host: 'example.test',
@@ -708,27 +710,19 @@ test('get correct filtering with scope and request headers filtering', t => {
     .reply(200, responseText, { 'Content-Type': 'text/plain' })
 
   const onData = sinon.spy()
-  const req = http.get(
-    {
-      host: 'bar.example.test',
-      method: 'GET',
-      path: '/path',
-      port: 80,
-    },
-    res => {
-      res.on('data', data => {
-        onData()
-        expect(data.toString()).to.equal(responseText)
-      })
-      res.on('end', () => {
-        expect(onData).to.have.been.calledOnce()
-        scope.done()
-        t.end()
-      })
-    }
-  )
+  const req = http.get('http://bar.example.test/path', res => {
+    expect(req.getHeaders()).to.deep.equal({ host: requestHeaders.host })
 
-  expect(req.getHeaders()).to.deep.equal({ host: requestHeaders.host })
+    res.on('data', data => {
+      onData()
+      expect(data.toString()).to.equal(responseText)
+    })
+    res.on('end', () => {
+      expect(onData).to.have.been.calledOnce()
+      scope.done()
+      t.end()
+    })
+  })
 })
 
 test('different subdomain with reply callback and filtering scope', async t => {

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -255,36 +255,6 @@ test('on interceptor, filter path with function', async t => {
   scope.done()
 })
 
-// TODO: Move to test_request_overrider.
-test('abort request', t => {
-  const scope = nock('http://example.test')
-    .get('/hey')
-    .reply(200, 'nobody')
-
-  const req = http.request({
-    host: 'example.test',
-    path: '/hey',
-  })
-
-  req.on('response', res => {
-    res.on('close', err => {
-      expect(err.code).to.equal('aborted')
-      scope.done()
-    })
-
-    res.on('end', () => expect.fail())
-
-    req.once('error', err => {
-      expect(err.code).to.equal('ECONNRESET')
-      t.end()
-    })
-
-    req.abort()
-  })
-
-  req.end()
-})
-
 test('chaining API', async t => {
   const scope = nock('http://example.test')
     .get('/one')

--- a/tests/test_request_overrider.js
+++ b/tests/test_request_overrider.js
@@ -222,9 +222,7 @@ describe('Request Overrider', () => {
   })
 
   it('should emit an error if `write` is called after `end`', done => {
-    nock('http://example.test')
-      .get('/')
-      .reply()
+    nock('http://example.test').get('/').reply()
 
     const req = http.request('http://example.test')
 
@@ -563,19 +561,14 @@ describe('Request Overrider', () => {
   })
 
   it('calling Socket#destroy() multiple times only emits a single `close` event', done => {
-    nock('http://example.test')
-      .get('/')
-      .reply(200, 'hey')
+    nock('http://example.test').get('/').reply(200, 'hey')
 
     const req = http.get('http://example.test')
     req.once('socket', socket => {
       const closeSpy = sinon.spy()
       socket.on('close', closeSpy)
 
-      socket
-        .destroy()
-        .destroy()
-        .destroy()
+      socket.destroy().destroy().destroy()
 
       setTimeout(() => {
         expect(closeSpy).to.have.been.calledOnce()

--- a/tests/test_request_overrider.js
+++ b/tests/test_request_overrider.js
@@ -50,9 +50,10 @@ describe('Request Overrider', () => {
 
     const req = http.get('http://example.test')
 
-    scope.done()
-
-    req.on('response', () => done())
+    req.on('response', () => {
+      scope.done()
+      done()
+    })
   })
 
   it('write callback called', done => {
@@ -218,6 +219,23 @@ describe('Request Overrider', () => {
     )
 
     req.end('foobar', reqEndCallback)
+  })
+
+  it('should emit an error if `write` is called after `end`', done => {
+    nock('http://example.test')
+      .get('/')
+      .reply()
+
+    const req = http.request('http://example.test')
+
+    req.on('error', err => {
+      expect(err.message).to.equal('write after end')
+      expect(err.code).to.equal('ERR_STREAM_WRITE_AFTER_END')
+      done()
+    })
+
+    req.end()
+    req.write('foo')
   })
 
   // http://github.com/nock/nock/issues/139
@@ -541,6 +559,28 @@ describe('Request Overrider', () => {
     req.once('socket', socket => {
       socket.destroy()
       done()
+    })
+  })
+
+  it('calling Socket#destroy() multiple times only emits a single `close` event', done => {
+    nock('http://example.test')
+      .get('/')
+      .reply(200, 'hey')
+
+    const req = http.get('http://example.test')
+    req.once('socket', socket => {
+      const closeSpy = sinon.spy()
+      socket.on('close', closeSpy)
+
+      socket
+        .destroy()
+        .destroy()
+        .destroy()
+
+      setTimeout(() => {
+        expect(closeSpy).to.have.been.calledOnce()
+        done()
+      }, 10)
     })
   })
 

--- a/tests/test_socket_delay.js
+++ b/tests/test_socket_delay.js
@@ -89,6 +89,7 @@ describe('`socketDelay()`', () => {
 
       res.once('end', () => {
         expect(body).to.equal(responseText)
+        scope.done()
         done()
       })
     })
@@ -98,7 +99,6 @@ describe('`socketDelay()`', () => {
     })
 
     req.end()
-    scope.done()
   })
 })
 

--- a/tests/test_stream.js
+++ b/tests/test_stream.js
@@ -43,35 +43,29 @@ it('pause response after data', done => {
     // multiple 'data' events.
     .reply(200, response)
 
-  http.get(
-    {
-      host: 'example.test',
-      path: '/',
-    },
-    res => {
-      const didTimeout = sinon.spy()
+  http.get('http://example.test', res => {
+    const didTimeout = sinon.spy()
 
-      setTimeout(() => {
-        didTimeout()
-        res.resume()
-      }, 500)
+    setTimeout(() => {
+      didTimeout()
+      res.resume()
+    }, 500)
 
-      res.on('data', data => res.pause())
+    res.on('data', () => res.pause())
 
-      res.on('end', () => {
-        expect(didTimeout).to.have.been.calledOnce()
-        scope.done()
-        done()
-      })
-    }
-  )
+    res.on('end', () => {
+      expect(didTimeout).to.have.been.calledOnce()
+      scope.done()
+      done()
+    })
 
-  // Manually simulate multiple 'data' events.
-  response.emit('data', 'one')
-  setTimeout(() => {
-    response.emit('data', 'two')
-    response.end()
-  }, 0)
+    // Manually simulate multiple 'data' events.
+    response.emit('data', 'one')
+    setTimeout(() => {
+      response.emit('data', 'two')
+      response.end()
+    }, 0)
+  })
 })
 
 // https://github.com/nock/nock/issues/1493
@@ -83,30 +77,22 @@ it("response has 'complete' property and it's true after end", done => {
     // multiple 'data' events.
     .reply(200, response)
 
-  http.get(
-    {
-      host: 'example.test',
-      path: '/',
-    },
-    res => {
-      const onData = sinon.spy()
+  http.get('http://example.test', res => {
+    const onData = sinon.spy()
 
-      res.on('data', onData)
+    res.on('data', onData)
 
-      res.on('end', () => {
-        expect(onData).to.have.been.called()
-        expect(res.complete).to.be.true()
-        scope.done()
-        done()
-      })
-    }
-  )
+    res.on('end', () => {
+      expect(onData).to.have.been.called()
+      expect(res.complete).to.be.true()
+      scope.done()
+      done()
+    })
 
-  // Manually simulate multiple 'data' events.
-  response.emit('data', 'one')
-  setTimeout(() => {
+    // Manually simulate multiple 'data' events.
+    response.emit('data', 'one')
     response.end()
-  }, 0)
+  })
 })
 
 // TODO Convert to async / got.
@@ -325,14 +311,13 @@ it('error events on reply streams proxy to the response', done => {
     res => {
       res.on('error', err => {
         expect(err).to.equal('oh no!')
+        scope.done()
         done()
+      })
+
+      replyBody.end(() => {
+        replyBody.emit('error', 'oh no!')
       })
     }
   )
-
-  scope.done()
-
-  replyBody.end(() => {
-    replyBody.emit('error', 'oh no!')
-  })
 })


### PR DESCRIPTION
Nocks behavior around events and errors relating to aborting and ending requests has not lined up
with Node for while. I dug into an investigation of how it differs, if there were git commits/pull-requests explaining why they differ, and trying to answer the question of should Nock change to line up better.

The single largest deviation were the errors emitted around aborting or already aborted requests.
Emitting an error on abort was added to fix issue #439.
The conversation talks about how Node emits an error post abort.
> ... in practice the `http` module does emit an `ECONNRESET` error after aborting. ... - Jan 7, 2016

However, this is only true between the 'socket' and 'response' events.
Otherwise calling abort does not emit an error of any kind.

Determining exactly what Nock should do is a bit of moving target.
As Node's internals of HTTP, Net, Stream, and micro task timing have changed a lot since
iojs/v4, when Nock added these errors, and v13, current at this time.

My conclusion is that none of Nock's deviations from Node's _documented_ behavior
are user features that should be maintained. If anything, bringing Nock closer to Node
better fulfills original requests.
https://github.com/nock/nock/pull/282

The entire `test_abort.js` file was scraped and rewritten by writing assertions against Node behavior, without Nock first.
Then adding Nock into each test to ensure events and errors were correct.

**BREAKING CHANGE**:

Calling `request.abort()`:
- Use to always emit a 'socket hang up' error. Now only emits the error if `abort` is called between the 'socket' and 'response' events.
- The emitted 'abort' event now happens on `nextTick`.
- The socket is now only destroyed if the 'socket' event has fired, and now emits a 'close' event on `nextTick` that propagates though the request object.
- `request.aborted` attribute is set to `true` instead of a timestamp. Changed in Node v11.0 https://github.com/nodejs/node/pull/20230

Calling `write`, `end`, or `flushHeaders` on an aborted request no longer emits an error.
However, writing to a request that is already finished (ended) will emit a 'write after end' error.

Playback of a mocked responses will now never happen until the 'socket' event is emitted.
The 'socket' event is still artificially set to emit on `nextTick` when a ClientRequest is created.
This means in the following code the Scope will never be done because at least one tick needs
to happen before any matched Interceptor is considered consumed.
```js
const scope = nock(...).get('/').reply()
const req = http.get(...)
scope.done()
```

Closes #1953