### PR TITLE
chore: remove body matching using "*" using definitions

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -306,13 +306,6 @@ function tryJsonParse(string) {
   }
 }
 
-// Use a noop deprecate util instead calling emitWarning directly so we get --no-deprecation and single warning behavior for free.
-const emitAsteriskDeprecation = util.deprecate(
-  () => {},
-  'Skipping body matching using "*" is deprecated. Set the definition body to undefined instead.',
-  'NOCK1579'
-)
-
 function define(nockDefs) {
   const scopes = []
 
@@ -334,17 +327,6 @@ function define(nockDefs) {
     //  be changing the user's options object so we clone it first.
     options.reqheaders = reqheaders
     options.badheaders = badheaders
-
-    let { body } = nockDef
-
-    if (body === '*') {
-      // In previous versions, it was impossible to NOT filter on request bodies. This special value
-      // is sniffed out for users manipulating the definitions and not wanting to match on the
-      // request body. For newer versions, users should remove the `body` key or set to `undefined`
-      // to achieve the same affect. Maintaining legacy behavior for now.
-      emitAsteriskDeprecation()
-      body = undefined
-    }
 
     // Response is not always JSON as it could be a string or binary data or
     // even an array of binary buffers (e.g. when content is encoded).
@@ -375,7 +357,9 @@ function define(nockDefs) {
       }
     })
 
-    scope.intercept(npath, method, body).reply(status, response, rawHeaders)
+    scope
+      .intercept(npath, method, nockDef.body)
+      .reply(status, response, rawHeaders)
 
     scopes.push(scope)
   })

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -9,7 +9,6 @@ const assert = require('assert')
 const url = require('url')
 const debug = require('debug')('nock.scope')
 const { EventEmitter } = require('events')
-const util = require('util')
 const Interceptor = require('./interceptor')
 
 let fs

--- a/tests/test_define.js
+++ b/tests/test_define.js
@@ -304,29 +304,3 @@ test('define() uses badheaders', t => {
   )
   req.end()
 })
-
-test('define() treats a * body as a special case for not matching the request body', async t => {
-  t.plan(4)
-
-  nock.define([
-    {
-      scope: 'http://example.test',
-      method: 'POST',
-      path: '/',
-      body: '*',
-      response: 'matched',
-    },
-  ])
-
-  process.once('warning', warning => {
-    t.equal(warning.name, 'DeprecationWarning')
-    t.match(warning.message, 'Skipping body matching using')
-  })
-
-  const { statusCode, body } = await got.post('http://example.test/', {
-    body: 'foo bar',
-  })
-
-  t.equal(statusCode, 200)
-  t.equal(body, 'matched')
-})


### PR DESCRIPTION
BREAKING CHANGE: Skipping body matching using "*" is no longer supported.
Set the definition `body` to `undefined` instead.

This was deprecated in v11. https://github.com/nock/nock/pull/1579