### PR TITLE
feature: remove Scope.log in favor of more debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1537,8 +1537,8 @@ It does this by manipulating the modules cache of Node in a way that conflicts w
 
 Nock uses [`debug`](https://github.com/visionmedia/debug), so just run with environmental variable `DEBUG` set to `nock.*`.
 
-```shell
-$ DEBUG=nock.* node my_test.js
+```console
+user@local$ DEBUG=nock.* node my_test.js
 ```
 
 Each step in the matching process is logged this way and can be useful when determining why a request was not intercepted by Nock.
@@ -1551,12 +1551,12 @@ nock('http://example.com').get('/').query({ foo: 'bar' }).reply()
 await got('http://example.com/?foo=bar&baz=foz')
 ```
 
-```shell
-$ DEBUG= nock.scope:example.com node my_test.js
+```console
+user@local$ DEBUG=nock.scope:example.com node my_test.js
 ...
-nock.scope:example.test Interceptor queries: {"foo":"bar"} +1ms
-nock.scope:example.test     Request queries: {"foo":"bar","baz":"foz"} +0ms
-nock.scope:example.test query matching failed +0ms
+nock.scope:example.com Interceptor queries: {"foo":"bar"} +1ms
+nock.scope:example.com     Request queries: {"foo":"bar","baz":"foz"} +0ms
+nock.scope:example.com query matching failed +0ms
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ For instance, if a module performs HTTP requests to a CouchDB server or makes HT
   - [.pendingMocks()](#pendingmocks)
   - [.activeMocks()](#activemocks)
   - [.isActive()](#isactive)
-- [Logging](#logging)
 - [Restoring](#restoring)
 - [Activating](#activating)
 - [Turning Nock Off (experimental!)](#turning-nock-off-experimental)
@@ -1048,16 +1047,6 @@ if (!nock.isActive()) {
 }
 ```
 
-## Logging
-
-Nock can log matches if you pass in a log function like this:
-
-```js
-const scope = nock('http://google.com')
-                .log(console.log)
-                ...
-```
-
 ## Restoring
 
 You can restore the HTTP interceptor to the normal unmocked behaviour by calling:
@@ -1548,8 +1537,26 @@ It does this by manipulating the modules cache of Node in a way that conflicts w
 
 Nock uses [`debug`](https://github.com/visionmedia/debug), so just run with environmental variable `DEBUG` set to `nock.*`.
 
-```js
+```shell
 $ DEBUG=nock.* node my_test.js
+```
+
+Each step in the matching process is logged this way and can be useful when determining why a request was not intercepted by Nock.
+
+For example the following shows that matching failed because the request had an extra search parameter.
+
+```js
+nock('http://example.com').get('/').query({ foo: 'bar' }).reply()
+
+await got('http://example.com/?foo=bar&baz=foz')
+```
+
+```shell
+$ DEBUG= nock.scope:example.com node my_test.js
+...
+nock.scope:example.test Interceptor queries: {"foo":"bar"} +1ms
+nock.scope:example.test     Request queries: {"foo":"bar","baz":"foz"} +0ms
+nock.scope:example.test query matching failed +0ms
 ```
 
 ## Contributing

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -159,7 +159,7 @@ function interceptorsFor(options) {
       // If scope filtering function is defined and returns a truthy value then
       // we have to treat this as a match.
       if (filteringScope && filteringScope(basePath)) {
-        debug('found matching scope interceptor')
+        interceptor.scope.logger('found matching scope interceptor')
 
         // Keep the filtered scope (its key) to signal the rest of the module
         // that this wasn't an exact but filtered match.

--- a/lib/intercepted_request_router.js
+++ b/lib/intercepted_request_router.js
@@ -270,7 +270,9 @@ class InterceptedRequestRouter {
     )
 
     if (matchedInterceptor) {
-      debug('interceptor identified, starting mocking')
+      matchedInterceptor.scope.logger(
+        'interceptor identified, starting mocking'
+      )
 
       // wait to emit the finish event until we know for sure an Interceptor is going to playback.
       // otherwise an unmocked request might emit finish twice.

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const debug = require('debug')('nock.interceptor')
 const stringify = require('json-stringify-safe')
 const querystring = require('querystring')
 const { URL, URLSearchParams } = require('url')
@@ -180,8 +179,8 @@ module.exports = class Interceptor {
       }
     }
 
-    debug('reply.headers:', this.headers)
-    debug('reply.rawHeaders:', this.rawHeaders)
+    this.scope.logger('reply.headers:', this.headers)
+    this.scope.logger('reply.rawHeaders:', this.rawHeaders)
 
     this.body = body
 
@@ -227,13 +226,23 @@ module.exports = class Interceptor {
       }
     }
 
-    debug("request header field doesn't match:", key, header, reqHeader)
+    this.scope.logger(
+      "request header field doesn't match:",
+      key,
+      header,
+      reqHeader
+    )
     return false
   }
 
   match(req, options, body) {
-    if (debug.enabled) {
-      debug('match %s, body = %s', stringify(options), stringify(body))
+    // check if the logger is enabled because the stringifies can be expensive.
+    if (this.scope.logger.enabled) {
+      this.scope.logger(
+        'attempting match %s, body = %s',
+        stringify(options),
+        stringify(body)
+      )
     }
 
     const method = (options.method || 'GET').toUpperCase()
@@ -243,7 +252,7 @@ module.exports = class Interceptor {
     const { proto } = options
 
     if (this.method !== method) {
-      debug(
+      this.scope.logger(
         `Method did not match. Request ${method} Interceptor ${this.method}`
       )
       return false
@@ -275,6 +284,7 @@ module.exports = class Interceptor {
     )
 
     if (!reqHeadersMatch) {
+      this.scope.logger("headers don't match")
       return false
     }
 
@@ -282,26 +292,32 @@ module.exports = class Interceptor {
       this.scope.scopeOptions.conditionally &&
       !this.scope.scopeOptions.conditionally()
     ) {
+      this.scope.logger(
+        'matching failed because Scope.conditionally() did not validate'
+      )
       return false
     }
 
-    const reqContainsBadHeaders = this.badheaders.some(
+    const badHeaders = this.badheaders.filter(
       header => header in options.headers
     )
 
-    if (reqContainsBadHeaders) {
+    if (badHeaders.length) {
+      this.scope.logger('request contains bad headers', ...badHeaders)
       return false
     }
 
     // Match query strings when using query()
     if (this.queries === null) {
-      debug('query matching skipped')
+      this.scope.logger('query matching skipped')
     } else {
       // can't rely on pathname or search being in the options, but path has a default
       const [pathname, search] = path.split('?')
       const matchQueries = this.matchQuery({ search })
 
-      debug(matchQueries ? 'query matching succeeded' : 'query matching failed')
+      this.scope.logger(
+        matchQueries ? 'query matching succeeded' : 'query matching failed'
+      )
 
       if (!matchQueries) {
         return false
@@ -404,8 +420,8 @@ module.exports = class Interceptor {
     }
 
     const reqQueries = querystring.parse(options.search)
-    debug('Interceptor queries: %j', this.queries)
-    debug('    Request queries: %j', reqQueries)
+    this.scope.logger('Interceptor queries: %j', this.queries)
+    this.scope.logger('    Request queries: %j', reqQueries)
 
     if (typeof this.queries === 'function') {
       return this.queries(reqQueries)

--- a/lib/playback_interceptor.js
+++ b/lib/playback_interceptor.js
@@ -83,6 +83,8 @@ function playbackInterceptor({
   response,
   interceptor,
 }) {
+  const { logger } = interceptor.scope
+
   function emitError(error) {
     process.nextTick(() => {
       req.emit('error', error)
@@ -114,7 +116,7 @@ function playbackInterceptor({
 
     // Clone headers/rawHeaders to not override them when evaluating later
     response.rawHeaders = [...interceptor.rawHeaders]
-    debug('response.rawHeaders:', response.rawHeaders)
+    logger('response.rawHeaders:', response.rawHeaders)
 
     if (interceptor.replyFunction) {
       const parsedRequestBody = parseJSONRequestBody(req, requestBodyString)
@@ -213,10 +215,10 @@ function playbackInterceptor({
     //  Transform the response body if it exists (it may not exist
     //  if we have `responseBuffers` instead)
     if (responseBody !== undefined) {
-      debug('transform the response body')
+      logger('transform the response body')
 
       if (interceptor.delayInMs) {
-        debug(
+        logger(
           'delaying the response for',
           interceptor.delayInMs,
           'milliseconds'
@@ -230,7 +232,7 @@ function playbackInterceptor({
       }
 
       if (common.isStream(responseBody)) {
-        debug('response body is a stream')
+        logger('response body is a stream')
         responseBody.pause()
         responseBody.on('data', function (d) {
           response.push(d)
@@ -295,16 +297,16 @@ function playbackInterceptor({
         return
       }
 
-      debug('emitting response')
+      logger('emitting response')
       req.emit('response', response)
 
       if (common.isStream(responseBody)) {
-        debug('resuming response stream')
+        logger('resuming response stream')
         responseBody.resume()
       } else {
         responseBuffers = responseBuffers || []
         if (typeof responseBody !== 'undefined') {
-          debug('adding body to buffer list')
+          logger('adding body to buffer list')
           responseBuffers.push(responseBody)
         }
 
@@ -313,11 +315,11 @@ function playbackInterceptor({
           const chunk = responseBuffers.shift()
 
           if (chunk) {
-            debug('emitting response chunk')
+            logger('emitting response chunk')
             response.push(chunk)
             common.setImmediate(emitChunk)
           } else {
-            debug('ending response stream')
+            logger('ending response stream')
             response.push(null)
             // https://nodejs.org/dist/latest-v10.x/docs/api/http.html#http_message_complete
             response.complete = true

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -39,7 +39,6 @@ class Scope extends EventEmitter {
     this.transformPathFunction = null
     this.transformRequestBodyFunction = null
     this.matchHeaders = []
-    this.logger = debug
     this.scopeOptions = options || {}
     this.urlParts = {}
     this._persist = false
@@ -50,13 +49,18 @@ class Scope extends EventEmitter {
     this.port = null
     this._defaultReplyHeaders = []
 
+    let logNamespace = String(basePath)
+
     if (!(basePath instanceof RegExp)) {
       this.urlParts = url.parse(basePath)
       this.port =
         this.urlParts.port || (this.urlParts.protocol === 'http:' ? 80 : 443)
       this.basePathname = this.urlParts.pathname.replace(/\/$/, '')
       this.basePath = `${this.urlParts.protocol}//${this.urlParts.hostname}:${this.port}`
+      logNamespace = this.urlParts.host
     }
+
+    this.logger = debug.extend(logNamespace)
   }
 
   add(key, interceptor) {
@@ -215,11 +219,6 @@ class Scope extends EventEmitter {
 
   defaultReplyHeaders(headers) {
     this._defaultReplyHeaders = common.headersInputToRawArray(headers)
-    return this
-  }
-
-  log(newLogger) {
-    this.logger = newLogger
     return this
   }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -120,7 +120,6 @@ declare namespace nock {
     filteringRequestBody(regex: RegExp, replace: string): this
     filteringRequestBody(fn: (body: string) => string): this
 
-    log(out: (message: any, ...optionalParams: any[]) => void): this
     persist(flag?: boolean): this
     replyContentLength(): this
     replyDate(d?: Date): this

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -653,9 +653,6 @@ console.error('pending mocks: %j', nock.pendingMocks())
 nock.activeMocks() // $ExpectType string[]
 nock('http://example.test').activeMocks() // $ExpectType string[]
 
-// Logging
-google = nock('http://example.test').log(console.log)
-
 // Restoring
 nock.restore()
 

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -120,7 +120,6 @@ scope = scope.filteringRequestBody((path: string) => {
   return str
 })
 
-scope = scope.log(() => {})
 scope = scope.persist()
 scope = scope.persist(false)
 scope = scope.replyContentLength()
@@ -619,7 +618,7 @@ options = { allowUnmocked: true }
 scope = nock('http://example.test', options).get('/my/url').reply(200, 'OK!')
 
 // Expectations
-let google = nock('http://example.test')
+const google = nock('http://example.test')
   .get('/')
   .reply(200, 'Hello from Google!')
 setTimeout(() => {


### PR DESCRIPTION
Consolidates the behavior around debugging and logging to exclusively use [`debug`](https://github.com/visionmedia/debug).

The use of `scope.log(console.log)` was problematic and confusing for consumers as that
appeared to be the correct approach when debugging unless they found the correct section in the README.
The use of the logger vs directly using `debug` in the core of Nock was inconsistent, especially when matching.
Now any failure to match a request will be directed to `debug` and if a single Interceptor is in context,
the namespace in the log will include the host from the Scope. This allows for filtering of logs to stdout
as well as differentiating colors from `debug`, when enabled.

BREAKING CHANGE:  `Scope.log` has been removed. Use the `debug` library when debugging failed matches.