### PR TITLE
fix(ClientRequest): Use native `abort` and `destroy`

### DIFF
--- a/lib/intercepted_request_router.js
+++ b/lib/intercepted_request_router.js
@@ -13,6 +13,20 @@ const globalEmitter = require('./global_emitter')
 const Socket = require('./socket')
 const { playbackInterceptor } = require('./playback_interceptor')
 
+function socketOnClose(req) {
+  debug('socket close')
+
+  if (!req.res && !req.socket._hadError) {
+    // If we don't have a response then we know that the socket
+    // ended prematurely and we need to emit an error on the request.
+    req.socket._hadError = true
+    const err = new Error('socket hang up')
+    err.code = 'ECONNRESET'
+    req.emit('error', err)
+  }
+  req.emit('close')
+}
+
 /**
  * Given a group of interceptors, appropriately route an outgoing request.
  * Identify which interceptor ought to respond, if any, then delegate to
@@ -48,10 +62,15 @@ class InterceptedRequestRouter {
     this.readyToStartPlaybackOnSocketEvent = false
 
     this.attachToReq()
+
+    // Emit a fake socket event on the next tick to mimic what would happen on a real request.
+    // Some clients listen for a 'socket' event to be emitted before calling end(),
+    // which causes Nock to hang.
+    process.nextTick(() => this.connectSocket())
   }
 
   attachToReq() {
-    const { req, socket, options } = this
+    const { req, options } = this
 
     for (const [name, val] of Object.entries(options.headers)) {
       req.setHeader(name.toLowerCase(), val)
@@ -68,18 +87,9 @@ class InterceptedRequestRouter {
     req.path = options.path
     req.method = options.method
 
-    // ClientRequest.connection is an alias for ClientRequest.socket
-    // https://nodejs.org/api/http.html#http_request_socket
-    // https://github.com/nodejs/node/blob/b0f75818f39ed4e6bd80eb7c4010c1daf5823ef7/lib/_http_client.js#L640-L641
-    // The same Socket is shared between the request and response to mimic native behavior.
-    req.socket = req.connection = socket
-
-    propagate(['close', 'error', 'timeout'], req.socket, req)
-
     req.write = (...args) => this.handleWrite(...args)
     req.end = (...args) => this.handleEnd(...args)
     req.flushHeaders = (...args) => this.handleFlushHeaders(...args)
-    req.abort = (...args) => this.handleAbort(...args)
 
     // https://github.com/nock/nock/issues/256
     if (options.headers.expect === '100-continue') {
@@ -88,49 +98,51 @@ class InterceptedRequestRouter {
         req.emit('continue')
       })
     }
-
-    // Emit a fake socket event on the next tick to mimic what would happen on a real request.
-    // Some clients listen for a 'socket' event to be emitted before calling end(),
-    // which causes nock to hang.
-    process.nextTick(() => {
-      if (req.aborted) {
-        return
-      }
-
-      socket.connecting = false
-      req.emit('socket', socket)
-
-      // https://nodejs.org/api/net.html#net_event_connect
-      socket.emit('connect')
-
-      // https://nodejs.org/api/tls.html#tls_event_secureconnect
-      if (socket.authorized) {
-        socket.emit('secureConnect')
-      }
-
-      if (this.readyToStartPlaybackOnSocketEvent) {
-        this.maybeStartPlayback()
-      }
-    })
   }
 
-  emitError(error) {
-    const { req } = this
-    process.nextTick(() => {
-      req.emit('error', error)
-    })
+  connectSocket() {
+    const { req, socket } = this
+
+    // Until Node 14 is the minimum, we need to look at both flags to see if the request has been cancelled.
+    if (req.destroyed || req.aborted) {
+      return
+    }
+
+    // ClientRequest.connection is an alias for ClientRequest.socket
+    // https://nodejs.org/api/http.html#http_request_socket
+    // https://github.com/nodejs/node/blob/b0f75818f39ed4e6bd80eb7c4010c1daf5823ef7/lib/_http_client.js#L640-L641
+    // The same Socket is shared between the request and response to mimic native behavior.
+    req.socket = req.connection = socket
+
+    propagate(['error', 'timeout'], socket, req)
+    socket.on('close', () => socketOnClose(req))
+
+    socket.connecting = false
+    req.emit('socket', socket)
+
+    // https://nodejs.org/api/net.html#net_event_connect
+    socket.emit('connect')
+
+    // https://nodejs.org/api/tls.html#tls_event_secureconnect
+    if (socket.authorized) {
+      socket.emit('secureConnect')
+    }
+
+    if (this.readyToStartPlaybackOnSocketEvent) {
+      this.maybeStartPlayback()
+    }
   }
 
   // from docs: When write function is called with empty string or buffer, it does nothing and waits for more input.
   // However, actually implementation checks the state of finished and aborted before checking if the first arg is empty.
   handleWrite(buffer, encoding, callback) {
-    debug('write', arguments)
+    debug('request write')
     const { req } = this
 
     if (req.finished) {
       const err = new Error('write after end')
       err.code = 'ERR_STREAM_WRITE_AFTER_END'
-      this.emitError(err)
+      process.nextTick(() => req.emit('error', err))
 
       // It seems odd to return `true` here, not sure why you'd want to have
       // the stream potentially written to more, but it's what Node does.
@@ -138,7 +150,7 @@ class InterceptedRequestRouter {
       return true
     }
 
-    if (req.aborted) {
+    if (req.socket && req.socket.destroyed) {
       return false
     }
 
@@ -167,7 +179,7 @@ class InterceptedRequestRouter {
   }
 
   handleEnd(chunk, encoding, callback) {
-    debug('req.end')
+    debug('request end')
     const { req } = this
 
     // handle the different overloaded arg signatures
@@ -191,40 +203,8 @@ class InterceptedRequestRouter {
   }
 
   handleFlushHeaders() {
-    debug('req.flushHeaders')
+    debug('request flushHeaders')
     this.maybeStartPlayback()
-  }
-
-  handleAbort() {
-    debug('req.abort')
-    const { req, socket } = this
-
-    if (req.aborted) {
-      return
-    }
-
-    // Historically, `aborted` was undefined or a timestamp.
-    // Node changed this behavior in v11 to always be a bool.
-    req.aborted = true
-    req.destroyed = true
-
-    // the order of these next three steps is important to match order of events Node would emit.
-    process.nextTick(() => req.emit('abort'))
-
-    if (!socket.connecting) {
-      if (!req.res) {
-        // If we don't have a response then we know that the socket
-        // ended prematurely and we need to emit an error on the request.
-        // Node doesn't actually emit this during the `abort` method.
-        // Instead it listens to the socket's `end` and `close` events, however,
-        // Nock's socket doesn't have all the complexities and events to
-        // replicated that directly. This is an easy way to achieve the same behavior.
-        const connResetError = new Error('socket hang up')
-        connResetError.code = 'ECONNRESET'
-        this.emitError(connResetError)
-      }
-      socket.destroy()
-    }
   }
 
   /**
@@ -268,7 +248,8 @@ class InterceptedRequestRouter {
       return
     }
 
-    if (!req.aborted && !playbackStarted) {
+    // Until Node 14 is the minimum, we need to look at both flags to see if the request has been cancelled.
+    if (!req.destroyed && !req.aborted && !playbackStarted) {
       this.startPlayback()
     }
   }
@@ -345,14 +326,11 @@ class InterceptedRequestRouter {
         // We send the raw buffer as we received it, not as we interpreted it.
         newReq.end(requestBodyBuffer)
       } else {
-        const err = new Error(
-          `Nock: No match for request ${common.stringifyRequest(
-            options,
-            requestBodyString
-          )}`
-        )
+        const reqStr = common.stringifyRequest(options, requestBodyString)
+        const err = new Error(`Nock: No match for request ${reqStr}`)
+        err.code = 'ERR_NOCK_NO_MATCH'
         err.statusCode = err.status = 404
-        this.emitError(err)
+        req.destroy(err)
       }
     }
   }

--- a/lib/playback_interceptor.js
+++ b/lib/playback_interceptor.js
@@ -123,12 +123,6 @@ function playbackInterceptor({
 }) {
   const { logger } = interceptor.scope
 
-  function emitError(error) {
-    process.nextTick(() => {
-      req.emit('error', error)
-    })
-  }
-
   function start() {
     interceptor.markConsumed()
     interceptor.req = req
@@ -145,7 +139,7 @@ function playbackInterceptor({
       }
 
       const delay = interceptor.delayBodyInMs + interceptor.delayConnectionInMs
-      common.setTimeout(emitError, delay, error)
+      common.setTimeout(() => req.destroy(error), delay)
       return
     }
 
@@ -170,7 +164,7 @@ function playbackInterceptor({
       // wrapping in `Promise.resolve` makes it into a promise either way.
       Promise.resolve(fn.call(interceptor, options.path, parsedRequestBody))
         .then(continueWithResponseBody)
-        .catch(emitError)
+        .catch(err => req.destroy(err))
       return
     }
 
@@ -184,7 +178,7 @@ function playbackInterceptor({
 
       Promise.resolve(fn.call(interceptor, options.path, parsedRequestBody))
         .then(continueWithFullResponse)
-        .catch(emitError)
+        .catch(err => req.destroy(err))
       return
     }
 
@@ -234,7 +228,7 @@ function playbackInterceptor({
     try {
       responseBody = parseFullReplyResult(response, fullReplyResult)
     } catch (err) {
-      emitError(err)
+      req.destroy(err)
       return
     }
 

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -20,6 +20,9 @@ module.exports = class Socket extends EventEmitter {
     this.destroyed = false
     this.connecting = true
 
+    // Undocumented flag used by ClientRequest to ensure errors aren't double-fired
+    this._hadError = false
+
     // Maximum allowed delay. 0 means unlimited.
     this.timeout = 0
 
@@ -83,11 +86,13 @@ module.exports = class Socket extends EventEmitter {
       return this
     }
 
+    debug('socket destroy')
     this.destroyed = true
     this.readable = this.writable = false
 
     process.nextTick(() => {
       if (err) {
+        this._hadError = true
         this.emit('error', err)
       }
       this.emit('close')

--- a/tests/test_request_overrider.js
+++ b/tests/test_request_overrider.js
@@ -554,6 +554,7 @@ describe('Request Overrider', () => {
     nock('http://example.test').get('/').reply(200, 'hey')
 
     const req = http.get('http://example.test')
+    req.on('error', () => {}) // listen for error so it doesn't bubble
     req.once('socket', socket => {
       socket.destroy()
       done()
@@ -564,6 +565,7 @@ describe('Request Overrider', () => {
     nock('http://example.test').get('/').reply(200, 'hey')
 
     const req = http.get('http://example.test')
+    req.on('error', () => {}) // listen for error so it doesn't bubble
     req.once('socket', socket => {
       const closeSpy = sinon.spy()
       socket.on('close', closeSpy)


### PR DESCRIPTION
- Stop monkey patching `abort` on the overridden `ClientRequest`.
- Stop prematurely associating the socket with the request.
- Prefer `destroy` instead of emitting an error when appropriate.

----

### The Catalyst

Overall I think this change is great because it brings the overridden `ClientRequest` even more inline with native Node.

There were two external changes that prompted this update: First [`ClientRequest.abort`](https://nodejs.org/docs/latest-v14.x/api/http.html#http_request_abort) was deprecated in Node 14.1 in favor of [`ClientRequest.destroy`](https://nodejs.org/docs/latest-v14.x/api/http.html#http_request_destroy_error). And second Got v11 began handling _only the first_ error emitted by a `ClientRequest`, which caused subsequent errors to bubble up as unhandled when using the client lib.
A discussion on Got's change as well as the direction of Node's changes with two Node contributors can be found here https://github.com/sindresorhus/got/issues/1224.

As a rule, Nock tries to not make exceptions for client libs, however, Got's reasoning is founded in the expected behavior of the [`stream.Writable` "error" event](https://nodejs.org/api/stream.html#stream_event_error):
> After 'error', no further events other than 'close' _should_ be emitted (including 'error' events).

Plus, since Nock uses Got for its own tests, it is convenient when they play well together. 

The changes in Node are being driven by the desire to better align the interfaces and usages of Streams. `ClientRequest` is a `Writeable` after all. Note this [comment](https://github.com/sindresorhus/got/issues/1224#issuecomment-624532387):

> ... starting Node.js 14.0.0 the recommended approach [is] to `req.destroy(...)` and not `req.emit('error', ...)`. Streams that have errored should be destroyed.

### The Issue

The current behavior of Nock is to emit an error on the request if the second matching phase finds no match and the Scope does no allow unmocked requests. This is the "Nock: No match for request ..." error.  This step happens to be between the 'socket' and 'response' events on the `ClientRequest`. In native Node, emitting an error on the request between those two events causes a "socket hang up" error to be emitted as well, which Nock faithfully replicates. However, it does mean that a "No match for request" error results in two errors being emitted on the request.

### The ever-moving target of Node

The tl;dr on how to fix this is to have Nock call `req.destroy` with the "No match for request" error. `destroy` "cancels" the request and ignores subsequent calls.

However, Node 14 changed the internal behavior of `destroy`. Previously it was defined on [`OutgoingMessage` and simply proxied to `destroy` on the message's socket](OutgoingMessage). 14 added [`destroy` as a method of `ClientRequest` and consumed most of the responsibilities of `abort`](https://github.com/nodejs/node/blob/027e1c706d25be75a790eb744835a0ebdc65452f/lib/_http_client.js#L341-L388). To more [align OutgoingMessage and ClientRequest](https://github.com/nodejs/node/pull/32148).

Because Nock has been monkey patching `abort`, my first attempt at this included monkey patching `destroy` too and sniffing the Node major version. It was gross.
Then I realized the methods weren't doing anything too fancy outside of handling the state of a socket on a request instance. So I went the direction of removing the `abort` monkey patch and alining the Socket behavior more with native Node. 
This required that we stop attaching the Nock socket on the request right away, instead waiting for a next tick, when we artificially fire a 'socket' event. It also meant the "socket hang up" error needed to be moved to an event listener on the socket's 'close' event. Which is how the native `ClientRequest` handles it. It's probably worth noting that _http_client.js does quite a bit more in listeners of the socket's 'close' and 'end' events. But Nock doesn't currently handle the flows and it seemed like overkill for this PR.

This change was tested on Node 10, 12, & 14 with Got 10.5 & 11.1.
