### PR TITLE
chore: lint docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ const scope = nock('https://api.github.com')
       name: 'MIT License',
       spdx_id: 'MIT',
       url: 'https://api.github.com/licenses/mit',
-      node_id: 'MDc6TGljZW5zZTEz'
-    }
+      node_id: 'MDc6TGljZW5zZTEz',
+    },
   })
 ```
 
@@ -261,9 +261,7 @@ nock('http://www.example.com')
 Nock understands query strings. Search parameters can be included as part of the path:
 
 ```js
-nock('http://example.com')
-  .get('/users?foo=bar')
-  .reply(200)
+nock('http://example.com').get('/users?foo=bar').reply(200)
 ```
 
 Instead of placing the entire URL, you can specify the query part as an object:
@@ -284,8 +282,8 @@ nock('http://example.com')
     names: ['alice', 'bob'],
     tags: {
       alice: ['admin', 'tester'],
-      bob: ['tester']
-    }
+      bob: ['tester'],
+    },
   })
   .reply(200, { results: [{ id: 'pgte' }] })
 ```
@@ -295,10 +293,7 @@ A `URLSearchParams` instance can be provided.
 ```js
 const params = new URLSearchParams({ foo: 'bar' })
 
-nock('http://example.com')
-  .get('/')
-  .query(params)
-  .reply(200)
+nock('http://example.com').get('/').query(params).reply(200)
 ```
 
 Nock supports passing a function to query. The function determines if the actual query matches or not.
@@ -339,9 +334,7 @@ nock('http://example.com', { encodedQueryParams: true })
 You can specify the return status code for a path on the first argument of reply like this:
 
 ```js
-const scope = nock('http://myapp.iriscouch.com')
-  .get('/users/1')
-  .reply(404)
+const scope = nock('http://myapp.iriscouch.com').get('/users/1').reply(404)
 ```
 
 You can also specify the reply body as a string:
@@ -355,13 +348,11 @@ const scope = nock('http://www.google.com')
 or as a JSON-encoded object:
 
 ```js
-const scope = nock('http://myapp.iriscouch.com')
-  .get('/')
-  .reply(200, {
-    username: 'pgte',
-    email: 'pedro.teixeira@gmail.com',
-    _id: '4324243fsd'
-  })
+const scope = nock('http://myapp.iriscouch.com').get('/').reply(200, {
+  username: 'pgte',
+  email: 'pedro.teixeira@gmail.com',
+  _id: '4324243fsd',
+})
 ```
 
 or even as a file:
@@ -370,7 +361,7 @@ or even as a file:
 const scope = nock('http://myapp.iriscouch.com')
   .get('/')
   .replyWithFile(200, __dirname + '/replies/user.json', {
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
   })
 ```
 
@@ -412,7 +403,7 @@ const scope = nock('http://www.google.com')
     return [
       201,
       'THIS IS THE REPLY BODY',
-      { header: 'value' } // optional headers
+      { header: 'value' }, // optional headers
     ]
   })
 ```
@@ -444,7 +435,7 @@ If you're using the reply callback style, you can access the original client req
 ```js
 const scope = nock('http://www.google.com')
   .get('/cat-poems')
-  .reply(function(uri, requestBody) {
+  .reply(function (uri, requestBody) {
     console.log('path:', this.req.path)
     console.log('headers:', this.req.headers)
     // ...
@@ -466,12 +457,10 @@ nock('http://www.google.com')
 JSON error responses are allowed too:
 
 ```js
-nock('http://www.google.com')
-  .get('/cat-poems')
-  .replyWithError({
-    message: 'something awful happened',
-    code: 'AWFUL_ERROR'
-  })
+nock('http://www.google.com').get('/cat-poems').replyWithError({
+  message: 'something awful happened',
+  code: 'AWFUL_ERROR',
+})
 ```
 
 > Note: This will emit an `error` event on the `request` object, not the reply.
@@ -489,8 +478,8 @@ You can specify the request headers like this:
 ```js
 const scope = nock('http://www.example.com', {
   reqheaders: {
-    authorization: 'Basic Auth'
-  }
+    authorization: 'Basic Auth',
+  },
 })
   .get('/')
   .reply(200)
@@ -503,8 +492,8 @@ function will be passed the header value.
 const scope = nock('http://www.example.com', {
   reqheaders: {
     'X-My-Headers': headerValue => headerValue.includes('cats'),
-    'X-My-Awesome-Header': /Awesome/i
-  }
+    'X-My-Awesome-Header': /Awesome/i,
+  },
 })
   .get('/')
   .reply(200)
@@ -518,7 +507,7 @@ You can also have Nock fail the request if certain headers are present:
 
 ```js
 const scope = nock('http://www.example.com', {
-  badheaders: ['cookie', 'x-forwarded-for']
+  badheaders: ['cookie', 'x-forwarded-for'],
 })
   .get('/')
   .reply(200)
@@ -554,7 +543,7 @@ const scope = nock('http://www.headdy.com')
   .get('/')
   .reply(200, 'Hello World!', {
     'Content-Length': (req, res, body) => body.length,
-    ETag: () => `${Date.now()}`
+    ETag: () => `${Date.now()}`,
   })
 ```
 
@@ -566,7 +555,7 @@ You can also specify default reply headers for all responses like this:
 const scope = nock('http://www.headdy.com')
   .defaultReplyHeaders({
     'X-Powered-By': 'Rails',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
   })
   .get('/')
   .reply(200, 'The default headers should come too')
@@ -577,7 +566,7 @@ Or you can use a function to generate the default headers values:
 ```js
 const scope = nock('http://www.headdy.com')
   .defaultReplyHeaders({
-    'Content-Length': (req, res, body) => body.length
+    'Content-Length': (req, res, body) => body.length,
   })
   .get('/')
   .reply(200, 'The default headers should come too')
@@ -653,10 +642,7 @@ const scope = nock('http://my.server.com:8081')
 You are able to specify the number of times to repeat the same response.
 
 ```js
-nock('http://zombo.com')
-  .get('/')
-  .times(4)
-  .reply(200, 'Ok')
+nock('http://zombo.com').get('/').times(4).reply(200, 'Ok')
 
 http.get('http://zombo.com/') // respond body "Ok"
 http.get('http://zombo.com/') // respond body "Ok"
@@ -668,18 +654,9 @@ http.get('http://zombo.com/') // respond with zombo.com result
 Sugar syntax
 
 ```js
-nock('http://zombo.com')
-  .get('/')
-  .once()
-  .reply(200, 'Ok')
-nock('http://zombo.com')
-  .get('/')
-  .twice()
-  .reply(200, 'Ok')
-nock('http://zombo.com')
-  .get('/')
-  .thrice()
-  .reply(200, 'Ok')
+nock('http://zombo.com').get('/').once().reply(200, 'Ok')
+nock('http://zombo.com').get('/').twice().reply(200, 'Ok')
+nock('http://zombo.com').get('/').thrice().reply(200, 'Ok')
 ```
 
 To repeat this response for as long as nock is active, use [.persist()](#persist).
@@ -714,7 +691,7 @@ nock('http://my.server.com')
 ```js
 delay({
   head: headDelayInMs,
-  body: bodyDelayInMs
+  body: bodyDelayInMs,
 })
 ```
 
@@ -725,7 +702,7 @@ nock('http://my.server.com')
   .get('/')
   .delay({
     head: 2000, // header will be delayed for 2 seconds, i.e. the whole response will be delayed for 2 seconds.
-    body: 3000 // body will be delayed for another 3 seconds after header is sent out.
+    body: 3000, // body will be delayed for another 3 seconds after header is sent out.
   })
   .reply(200, '<html></html>')
 ```
@@ -767,19 +744,19 @@ const scope = nock('http://myapp.iriscouch.com')
   .reply(404)
   .post('/users', {
     username: 'pgte',
-    email: 'pedro.teixeira@gmail.com'
+    email: 'pedro.teixeira@gmail.com',
   })
   .reply(201, {
     ok: true,
     id: '123ABC',
-    rev: '946B7D1C'
+    rev: '946B7D1C',
   })
   .get('/users/123ABC')
   .reply(200, {
     _id: '123ABC',
     _rev: '946B7D1C',
     username: 'pgte',
-    email: 'pedro.teixeira@gmail.com'
+    email: 'pedro.teixeira@gmail.com',
   })
 ```
 
@@ -791,7 +768,7 @@ This can be useful if you have a node module that randomly changes subdomains to
 
 ```js
 const scope = nock('https://api.dropbox.com', {
-  filteringScope: scope => /^https:\/\/api[0-9]*.dropbox.com/.test(scope)
+  filteringScope: scope => /^https:\/\/api[0-9]*.dropbox.com/.test(scope),
 })
   .get('/1/metadata/auto/Photos?include_deleted=false&list=true')
   .reply(200)
@@ -805,7 +782,7 @@ This can be useful if you only want certain scopes to apply depending on how you
 
 ```js
 const scope = nock('https://api.myservice.com', {
-  conditionally: () => true
+  conditionally: () => true,
 })
 ```
 
@@ -876,7 +853,7 @@ const scope = nock('http://api.myservice.com')
   .matchHeader('accept', 'application/json')
   .get('/')
   .reply(200, {
-    data: 'hello world'
+    data: 'hello world',
   })
 ```
 
@@ -887,7 +864,7 @@ const scope = nock('http://api.myservice.com')
   .matchHeader('User-Agent', /Mozilla\/.*/)
   .get('/')
   .reply(200, {
-    data: 'hello world'
+    data: 'hello world',
   })
 ```
 
@@ -898,7 +875,7 @@ const scope = nock('http://api.myservice.com')
   .matchHeader('content-length', val => val >= 1000)
   .get('/')
   .reply(200, {
-    data: 'hello world'
+    data: 'hello world',
   })
 ```
 
@@ -915,20 +892,14 @@ example.pendingMocks() // ["GET http://example.com:80/path"]
 // ...After a request to example.com/pathA:
 example.pendingMocks() // []
 
-example
-  .get('/pathB')
-  .optionally()
-  .reply(200)
+example.get('/pathB').optionally().reply(200)
 example.pendingMocks() // []
 
 // You can also pass a boolean argument to `optionally()`. This
 // is useful if you want to conditionally make a mocked request
 // optional.
 const getMock = optional =>
-  example
-    .get('/pathC')
-    .optionally(optional)
-    .reply(200)
+  example.get('/pathC').optionally(optional).reply(200)
 
 getMock(true)
 example.pendingMocks() // []
@@ -978,9 +949,7 @@ setTimeout(() => {
 You can call `isDone()` on a single expectation to determine if the expectation was met:
 
 ```js
-const scope = nock('http://google.com')
-  .get('/')
-  .reply(200)
+const scope = nock('http://google.com').get('/').reply(200)
 
 scope.isDone() // will return false
 ```
@@ -1023,10 +992,7 @@ Note that while a persisted scope will always intercept the requests, it is cons
 If you want to stop persisting an individual persisted mock you can call `persist(false)`:
 
 ```js
-const scope = nock('http://example.com')
-  .persist()
-  .get('/')
-  .reply(200, 'ok')
+const scope = nock('http://example.com').persist().get('/').reply(200, 'ok')
 
 // Do some tests ...
 
@@ -1222,7 +1188,7 @@ If you just want to capture the generated code into a var as an array you can us
 
 ```js
 nock.recorder.rec({
-  dont_print: true
+  dont_print: true,
 })
 // ... some HTTP calls
 const nockCalls = nock.recorder.play()
@@ -1240,7 +1206,7 @@ In case you want to generate the code yourself or use the test data in some othe
 
 ```js
 nock.recorder.rec({
-  output_objects: true
+  output_objects: true,
 })
 // ... some HTTP calls
 const nockCallObjects = nock.recorder.play()
@@ -1261,7 +1227,7 @@ If you save this as a JSON file, you can load them directly through `nock.load(p
 
 ```js
 nocks = nock.load(pathToJson)
-nocks.forEach(function(nock) {
+nocks.forEach(function (nock) {
   nock.filteringRequestBody = (body, aRecordedBody) => {
     if (typeof body !== 'string' || typeof aRecordedBody !== 'string') {
       return body
@@ -1270,7 +1236,11 @@ nocks.forEach(function(nock) {
     const recordedBodyResult = /timestamp:([0-9]+)/.exec(aRecordedBody)
     if (recordedBodyResult) {
       const recordedTimestamp = recordedBodyResult[1]
-      return body.replace(/(timestamp):([0-9]+)/g, function(match, key, value) {
+      return body.replace(/(timestamp):([0-9]+)/g, function (
+        match,
+        key,
+        value
+      ) {
         return key + ':' + recordedTimestamp
       })
     } else {
@@ -1292,7 +1262,7 @@ nockDefs.forEach(def => {
   //  Do something with the definition object e.g. scope filtering.
   def.options = {
     ...def.options,
-    filteringScope: scope => /^https:\/\/api[0-9]*.dropbox.com/.test(scope)
+    filteringScope: scope => /^https:\/\/api[0-9]*.dropbox.com/.test(scope),
   }
 })
 
@@ -1310,7 +1280,7 @@ The genuine use cases for recording request headers (e.g. checking authorization
 nock.recorder.rec({
   dont_print: true,
   output_objects: true,
-  enable_reqheaders_recording: true
+  enable_reqheaders_recording: true,
 })
 ```
 
@@ -1325,7 +1295,7 @@ const appendLogToFile = content => {
   fs.appendFile('record.txt', content)
 }
 nock.recorder.rec({
-  logging: appendLogToFile
+  logging: appendLogToFile,
 })
 ```
 
@@ -1337,7 +1307,7 @@ To disable this, set `use_separator` to false.
 
 ```js
 nock.recorder.rec({
-  use_separator: false
+  use_separator: false,
 })
 ```
 
@@ -1350,7 +1320,7 @@ Examples:
 ```js
 nock.removeInterceptor({
   hostname: 'localhost',
-  path: '/mockedResource'
+  path: '/mockedResource',
 })
 ```
 
@@ -1426,7 +1396,7 @@ nockBack('zomboFixture.json', nockDone => {
     nockDone()
 
     // usage of the created fixture
-    nockBack('zomboFixture.json', function(nockDone) {
+    nockBack('zomboFixture.json', function (nockDone) {
       http.get('http://zombo.com/').end() // respond body "Ok"
 
       this.assertScopesFinished() //throws an exception if all nocks in fixture were not satisfied


### PR DESCRIPTION
It seems when Prettier was updated on `master`, the linter didn't run and update the README file with the new preferences.

This is why https://github.com/nock/nock/pull/1989 has a conflict apparently. 

Mostly commas and whitespace inside the code blocks of the docs.