### PR TITLE
build: replace master with main

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -3,9 +3,9 @@ name: Continuous Delivery
 on:
   push:
     branches:
-      - '*.x' # maintenance releases such as 15.x
+      - '*.x' # maintenance releases such as 12.x
+      - main
       - beta
-      - master
       - next
 
 jobs:

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -7,7 +7,7 @@ on:
       - synchronize
   push:
     branches:
-      - master
+      - main
 
 jobs:
   fix-formatting:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Please note that this project is released with a [Contributor Code of Conduct](.
 
 We use [semantic-release](https://github.com/semantic-release/semantic-release) to automate the release of new versions based on semantic commit messages as described above. Depending on the branch that a new pull request is merged into, it is published to different versions using different [npm dist-tags](https://docs.npmjs.com/cli/dist-tag).
 
-- `master`: Publish with `@latest`, or if the commits have been merged into `next` branch before, update the `@latest` dist-tag to point at the new version
+- `main`: Publish with `@latest`, or if the commits have been merged into `next` branch before, update the `@latest` dist-tag to point at the new version
 - `next`: Publish with `@next`
 - `beta`: Publish to `X.0.0-beta.Y`, where `X` is the next breaking version and `Y` is number that gets increased with each release.
 - `[Version].x`: For example `10.x`, where `10` is the major release number. No breaking changes are allowed on this branch. Publishes fix/feature versions to `[Version]` using a `@release-@[version].x` release tag
@@ -48,7 +48,7 @@ If you want to **backport a fix** to version 10, and the last version released o
 
 ### Submit a Beta / Next release
 
-Create a new branch based off `beta` or `next`, depending on what you want. Make your changes and submit them to the same branches. If either `beta` or `next` is outdated, ask a maintainer to re-create them from `master`
+Create a new branch based off `beta` or `next`, depending on what you want. Make your changes and submit them to the same branches. If either `beta` or `next` is outdated, ask a maintainer to re-create them from `main`
 
 ## Formatting & linting
 
@@ -118,7 +118,7 @@ $ tap --only tests/example_file.js
 
 ## Release Process
 
-All of our releases are automated using [semantic-release](https://github.com/semantic-release/semantic-release). The commit messages pushed to the master branch trigger new releases. Semantic-release requires that commits follow certain conventions, [described above](#commit-message-conventions). semantic-release creates a GitHub release, adds release notes and publishes the new version to npm. This is why we do not store release notes in the [`CHANGELOG`](CHANGELOG.md) file - they're already on GitHub.
+All of our releases are automated using [semantic-release](https://github.com/semantic-release/semantic-release). The commit messages pushed to the main branch trigger new releases. Semantic-release requires that commits follow certain conventions, [described above](#commit-message-conventions). semantic-release creates a GitHub release, adds release notes and publishes the new version to npm. This is why we do not store release notes in the [`CHANGELOG`](CHANGELOG.md) file - they're already on GitHub.
 
 We use @nockbot as a separate account for releases, because npm tokens cannot be scoped to a single package. This improves our security model in case of a data breach involving npm tokens. @nockbot's credentials were set up by @gr2m; contact him if for any reason you need to change this in the future.
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "lint:js": "eslint --cache --cache-location './.cache/eslint' '**/*.js'",
     "lint:js:fix": "eslint --cache --cache-location './.cache/eslint' --fix '**/*.js'",
     "lint:ts": "dtslint types",
-    "semantic-release": "semantic-release",
     "test": "run-s test:mocha test:tap",
     "test:coverage": "tap --coverage-report=html && open coverage/lcov-report/index.html",
     "test:mocha": "nyc mocha $(grep -lr '^\\s*it(' tests)",
@@ -82,5 +81,21 @@
     "index.js",
     "lib",
     "types/index.d.ts"
-  ]
+  ],
+  "release": {
+    "branches": [
+      "+([0-9])?(.{+([0-9]),x}).x",
+      "main",
+      "next",
+      "next-major",
+      {
+        "name": "beta",
+        "prerelease": true
+      },
+      {
+        "name": "alpha",
+        "prerelease": true
+      }
+    ]
+  }
 }


### PR DESCRIPTION
fixes #2012. After merging, use https://github.com/gr2m/octokit-plugin-rename-branch to update the branch, pull requests, and repository settings. 

But lets wait for v13 to be released, to avoid merge conflicts with the current work on `beta` +@paulmelnikow