### PR TITLE
docs: add note on removeInterceptor usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1312,6 +1312,18 @@ const interceptor = nock('http://example.org').get('somePath')
 nock.removeInterceptor(interceptor)
 ```
 
+**Note** `.reply(...)` method returns Scope, not Interceptor, and so it is not a valid argument for `nock.removeInterceptor`. So if your method chain ends with `.reply` to be used with `nock.removeInterceptor` the chain need to be break in between:
+
+```js
+// this will NOT work
+const interceptor = nock('http://example.org').get('somePath').reply(200, 'OK')
+nock.removeInterceptor(interceptor)
+// this is how it should be
+const interceptor = nock('http://example.org').get('somePath')
+interceptor.reply(200, 'OK')
+nock.removeInterceptor(interceptor)
+```
+
 ## Events
 
 A scope emits the following events:


### PR DESCRIPTION
The fact that `removeInterceptor` works on some chains and doesn't work on other chains is very confusing because it means that existing code may break while the behavior is getting only extended (opposit to modified). Also, because documentation is not giving a clear difference on what chain methods returns what type of values. There are a bunch of issues on it:
https://github.com/nock/nock/issues/1822
https://github.com/nock/nock/issues/1117
https://github.com/nock/nock/issues/600