### PR TITLE
docs: fix wrong typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,7 +574,7 @@ const scope = nock('http://www.headdy.com')
 
 #### Including Content-Length Header Automatically
 
-When using `scope.reply()` to set a response body manually, you can have the
+When using `interceptor.reply()` to set a response body manually, you can have the
 `Content-Length` header calculated automatically.
 
 ```js


### PR DESCRIPTION
`.reply` is a method of interceptor and not a method of scope