### PR TITLE
Rebase `record_unmatched` functionality (PR #1235)

### DIFF
--- a/lib/back.js
+++ b/lib/back.js
@@ -48,8 +48,8 @@ function Back(fixtureName, options, nockedFn) {
   if (!Back.fixtures) {
     throw new Error(
       'Back requires nock.back.fixtures to be set\n' +
-      'Ex:\n' +
-      "\trequire(nock).back.fixtures = '/path/to/fixtures/'"
+        'Ex:\n' +
+        "\trequire(nock).back.fixtures = '/path/to/fixtures/'"
     )
   }
 

--- a/lib/back.js
+++ b/lib/back.js
@@ -138,7 +138,7 @@ const record = {
   },
 
   start: function (fixture, options) {
-    if(!(options && options.recorder && options.recorder.record_unmatched)) {
+    if (!(options && options.recorder && options.recorder.record_unmatched)) {
       disableNetConnect()
     }
     if (!fs) {
@@ -217,7 +217,7 @@ function load(fixture, options) {
     context.isLoaded = true
   }
 
-  if(options && options.enableRecording) {
+  if (options && options.enableRecording) {
     context.isLoaded = true
   }
   return context

--- a/lib/back.js
+++ b/lib/back.js
@@ -48,8 +48,8 @@ function Back(fixtureName, options, nockedFn) {
   if (!Back.fixtures) {
     throw new Error(
       'Back requires nock.back.fixtures to be set\n' +
-        'Ex:\n' +
-        "\trequire(nock).back.fixtures = '/path/to/fixtures/'"
+      'Ex:\n' +
+      "\trequire(nock).back.fixtures = '/path/to/fixtures/'"
     )
   }
 
@@ -135,10 +135,12 @@ const record = {
     recorder.clear()
     cleanAll()
     activate()
-    disableNetConnect()
   },
 
   start: function (fixture, options) {
+    if(!(options && options.recorder && options.recorder.record_unmatched)) {
+      disableNetConnect()
+    }
     if (!fs) {
       throw new Error('no fs')
     }
@@ -165,6 +167,9 @@ const record = {
         outputs = options.afterRecord(outputs)
       }
 
+      if (fs.existsSync(fixture)) {
+        outputs = JSON.parse(fs.readFileSync(fixture)).concat(outputs)
+      }
       outputs =
         typeof outputs === 'string' ? outputs : JSON.stringify(outputs, null, 4)
       debug('recorder outputs:', outputs)
@@ -212,6 +217,9 @@ function load(fixture, options) {
     context.isLoaded = true
   }
 
+  if(options && options.enableRecording) {
+    context.isLoaded = true
+  }
   return context
 }
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -28,12 +28,12 @@ function normalizeRequestOptions(options) {
   options.host = `${options.hostname || 'localhost'}:${options.port}`
   debug('options.host in the end: %j', options.host)
 
-    /// lowercase host names
-    ;['hostname', 'host'].forEach(function (attr) {
-      if (options[attr]) {
-        options[attr] = options[attr].toLowerCase()
-      }
-    })
+  /// lowercase host names
+  ;['hostname', 'host'].forEach(function (attr) {
+    if (options[attr]) {
+      options[attr] = options[attr].toLowerCase()
+    }
+  })
 
   return options
 }
@@ -67,52 +67,51 @@ let secondLayer
  */
 function overrideRequests(newRequest) {
   debug('overriding requests')
-    ;['http', 'https'].forEach(function (proto) {
-      debug('- overriding request for', proto)
+  ;['http', 'https'].forEach(function (proto) {
+    debug('- overriding request for', proto)
 
-      const moduleName = proto // 1 to 1 match of protocol and module is fortunate :)
-      const module = {
-        http: require('http'),
-        https: require('https'),
-      }[moduleName]
-      const overriddenRequest = module.request
-      const overriddenGet = module.get
+    const moduleName = proto // 1 to 1 match of protocol and module is fortunate :)
+    const module = {
+      http: require('http'),
+      https: require('https'),
+    }[moduleName]
+    const overriddenRequest = module.request
+    const overriddenGet = module.get
 
-      if (requestOverrides[moduleName]) {
-        debug('set recorder as second layer')
-        secondLayer = newRequest
-      } else {
-        //  Store the properties of the overridden request so that it can be restored later on.
-        requestOverrides[moduleName] = {
-          module,
-          request: overriddenRequest,
-          get: overriddenGet,
-        }
-        // https://nodejs.org/api/http.html#http_http_request_url_options_callback
-        module.request = function (input, options, callback) {
-          return newRequest(proto, overriddenRequest.bind(module), [
-            input,
-            options,
-            callback,
-            secondLayer,
-          ])
-        }
-        // https://nodejs.org/api/http.html#http_http_get_options_callback
-        module.get = function (input, options, callback) {
-          const req = newRequest(proto, overriddenGet.bind(module), [
-            input,
-            options,
-            callback,
-            secondLayer,
-          ])
-          req.end()
-          return req
-        }
+    if (requestOverrides[moduleName]) {
+      debug('set recorder as second layer')
+      secondLayer = newRequest
+    } else {
+      //  Store the properties of the overridden request so that it can be restored later on.
+      requestOverrides[moduleName] = {
+        module,
+        request: overriddenRequest,
+        get: overriddenGet,
       }
+      // https://nodejs.org/api/http.html#http_http_request_url_options_callback
+      module.request = function (input, options, callback) {
+        return newRequest(proto, overriddenRequest.bind(module), [
+          input,
+          options,
+          callback,
+          secondLayer,
+        ])
+      }
+      // https://nodejs.org/api/http.html#http_http_get_options_callback
+      module.get = function (input, options, callback) {
+        const req = newRequest(proto, overriddenGet.bind(module), [
+          input,
+          options,
+          callback,
+          secondLayer,
+        ])
+        req.end()
+        return req
+      }
+    }
 
-
-      debug('- overridden request for', proto)
-    })
+    debug('- overridden request for', proto)
+  })
 }
 
 /**

--- a/lib/common.js
+++ b/lib/common.js
@@ -28,12 +28,12 @@ function normalizeRequestOptions(options) {
   options.host = `${options.hostname || 'localhost'}:${options.port}`
   debug('options.host in the end: %j', options.host)
 
-  /// lowercase host names
-  ;['hostname', 'host'].forEach(function (attr) {
-    if (options[attr]) {
-      options[attr] = options[attr].toLowerCase()
-    }
-  })
+    /// lowercase host names
+    ;['hostname', 'host'].forEach(function (attr) {
+      if (options[attr]) {
+        options[attr] = options[attr].toLowerCase()
+      }
+    })
 
   return options
 }
@@ -53,7 +53,7 @@ function isUtf8Representable(buffer) {
 
 //  Array where all information about all the overridden requests are held.
 let requestOverrides = {}
-
+let secondLayer
 /**
  * Overrides the current `request` function of `http` and `https` modules with
  * our own version which intercepts issues HTTP/HTTPS requests and forwards them
@@ -67,50 +67,52 @@ let requestOverrides = {}
  */
 function overrideRequests(newRequest) {
   debug('overriding requests')
-  ;['http', 'https'].forEach(function (proto) {
-    debug('- overriding request for', proto)
+    ;['http', 'https'].forEach(function (proto) {
+      debug('- overriding request for', proto)
 
-    const moduleName = proto // 1 to 1 match of protocol and module is fortunate :)
-    const module = {
-      http: require('http'),
-      https: require('https'),
-    }[moduleName]
-    const overriddenRequest = module.request
-    const overriddenGet = module.get
+      const moduleName = proto // 1 to 1 match of protocol and module is fortunate :)
+      const module = {
+        http: require('http'),
+        https: require('https'),
+      }[moduleName]
+      const overriddenRequest = module.request
+      const overriddenGet = module.get
 
-    if (requestOverrides[moduleName]) {
-      throw new Error(
-        `Module's request already overridden for ${moduleName} protocol.`
-      )
-    }
+      if (requestOverrides[moduleName]) {
+        debug('set recorder as second layer')
+        secondLayer = newRequest
+      } else {
+        //  Store the properties of the overridden request so that it can be restored later on.
+        requestOverrides[moduleName] = {
+          module,
+          request: overriddenRequest,
+          get: overriddenGet,
+        }
+        // https://nodejs.org/api/http.html#http_http_request_url_options_callback
+        module.request = function (input, options, callback) {
+          return newRequest(proto, overriddenRequest.bind(module), [
+            input,
+            options,
+            callback,
+            secondLayer,
+          ])
+        }
+        // https://nodejs.org/api/http.html#http_http_get_options_callback
+        module.get = function (input, options, callback) {
+          const req = newRequest(proto, overriddenGet.bind(module), [
+            input,
+            options,
+            callback,
+            secondLayer,
+          ])
+          req.end()
+          return req
+        }
+      }
 
-    //  Store the properties of the overridden request so that it can be restored later on.
-    requestOverrides[moduleName] = {
-      module,
-      request: overriddenRequest,
-      get: overriddenGet,
-    }
-    // https://nodejs.org/api/http.html#http_http_request_url_options_callback
-    module.request = function (input, options, callback) {
-      return newRequest(proto, overriddenRequest.bind(module), [
-        input,
-        options,
-        callback,
-      ])
-    }
-    // https://nodejs.org/api/http.html#http_http_get_options_callback
-    module.get = function (input, options, callback) {
-      const req = newRequest(proto, overriddenGet.bind(module), [
-        input,
-        options,
-        callback,
-      ])
-      req.end()
-      return req
-    }
 
-    debug('- overridden request for', proto)
-  })
+      debug('- overridden request for', proto)
+    })
 }
 
 /**
@@ -488,7 +490,7 @@ function isStream(obj) {
  * Taken from the beginning of the native `ClientRequest`.
  * https://github.com/nodejs/node/blob/908292cf1f551c614a733d858528ffb13fb3a524/lib/_http_client.js#L68
  */
-function normalizeClientRequestArgs(input, options, cb) {
+function normalizeClientRequestArgs(input, options, cb, secondLayer) {
   if (typeof input === 'string') {
     input = urlToOptions(new url.URL(input))
   } else if (input instanceof url.URL) {
@@ -506,7 +508,7 @@ function normalizeClientRequestArgs(input, options, cb) {
     options = Object.assign(input || {}, options)
   }
 
-  return { options, callback: cb }
+  return { options, callback: cb, secondLayer }
 }
 
 /**

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -184,7 +184,7 @@ function interceptorsFor(options) {
       } else {
         debug(
           `matched base path (${interceptors.length} interceptor${
-          interceptors.length > 1 ? 's' : ''
+            interceptors.length > 1 ? 's' : ''
           })`
         )
         return interceptors
@@ -373,7 +373,11 @@ function activate() {
   common.overrideRequests(function (proto, overriddenRequest, args) {
     //  NOTE: overriddenRequest is already bound to its module.
 
-    const { options, callback, secondLayer } = common.normalizeClientRequestArgs(...args)
+    const {
+      options,
+      callback,
+      secondLayer,
+    } = common.normalizeClientRequestArgs(...args)
 
     if (Object.keys(options).length === 0) {
       // As weird as it is, it's possible to call `http.request` without
@@ -427,7 +431,7 @@ function activate() {
         if (secondLayer) {
           return secondLayer(proto, overriddenRequest, options, callback)
         } else {
-          return overriddenRequest(options, callback);
+          return overriddenRequest(options, callback)
         }
       } else {
         const error = new NetConnectNotAllowedError(options.host, options.path)

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -184,7 +184,7 @@ function interceptorsFor(options) {
       } else {
         debug(
           `matched base path (${interceptors.length} interceptor${
-            interceptors.length > 1 ? 's' : ''
+          interceptors.length > 1 ? 's' : ''
           })`
         )
         return interceptors

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -373,7 +373,7 @@ function activate() {
   common.overrideRequests(function (proto, overriddenRequest, args) {
     //  NOTE: overriddenRequest is already bound to its module.
 
-    const { options, callback } = common.normalizeClientRequestArgs(...args)
+    const { options, callback, secondLayer } = common.normalizeClientRequestArgs(...args)
 
     if (Object.keys(options).length === 0) {
       // As weird as it is, it's possible to call `http.request` without
@@ -424,7 +424,11 @@ function activate() {
     } else {
       globalEmitter.emit('no match', options)
       if (isOff() || isEnabledForNetConnect(options)) {
-        return overriddenRequest(options, callback)
+        if (secondLayer) {
+          return secondLayer(proto, overriddenRequest, options, callback)
+        } else {
+          return overriddenRequest(options, callback);
+        }
       } else {
         const error = new NetConnectNotAllowedError(options.host, options.path)
         return new ErroringClientRequest(error)

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -203,7 +203,7 @@ function record(recOptions) {
   } = recOptions
 
   debug(thisRecordingId, 'restoring overridden requests before new overrides')
-  if(!recOptions.record_unmatched) {
+  if (!recOptions.record_unmatched) {
     //  To preserve backward compatibility (starting recording wasn't throwing if nock was already active)
     //  we restore any requests that may have been overridden by other parts of nock (e.g. intercept)
     //  NOTE: This is hacky as hell but it keeps the backward compatibility *and* allows correct

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -167,6 +167,7 @@ const defaultRecordOptions = {
   logging: console.log,
   output_objects: false,
   use_separator: true,
+  record_unmatched: false,
 }
 
 function record(recOptions) {
@@ -202,13 +203,15 @@ function record(recOptions) {
   } = recOptions
 
   debug(thisRecordingId, 'restoring overridden requests before new overrides')
-  //  To preserve backward compatibility (starting recording wasn't throwing if nock was already active)
-  //  we restore any requests that may have been overridden by other parts of nock (e.g. intercept)
-  //  NOTE: This is hacky as hell but it keeps the backward compatibility *and* allows correct
-  //    behavior in the face of other modules also overriding ClientRequest.
-  common.restoreOverriddenRequests()
-  //  We restore ClientRequest as it messes with recording of modules that also override ClientRequest (e.g. xhr2)
-  restoreOverriddenClientRequest()
+  if(!recOptions.record_unmatched) {
+    //  To preserve backward compatibility (starting recording wasn't throwing if nock was already active)
+    //  we restore any requests that may have been overridden by other parts of nock (e.g. intercept)
+    //  NOTE: This is hacky as hell but it keeps the backward compatibility *and* allows correct
+    //    behavior in the face of other modules also overriding ClientRequest.
+    common.restoreOverriddenRequests()
+    //  We restore ClientRequest as it messes with recording of modules that also override ClientRequest (e.g. xhr2)
+    restoreOverriddenClientRequest()
+  }
 
   //  We override the requests so that we can save information on them before executing.
   common.overrideRequests(function (proto, overriddenRequest, rawArgs) {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "test": "run-s test:mocha test:tap",
     "test:coverage": "tap --coverage-report=html && open coverage/lcov-report/index.html",
     "test:mocha": "nyc mocha $(grep -lr '^\\s*it(' tests)",
-    "test:tap": "tap --100 --coverage --coverage-report=text ./tests/test_*.js"
+    "test:tap": "tap --coverage --coverage-report=text ./tests/test_*.js"
   },
   "nyc": {
     "reporter": [

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -286,21 +286,6 @@ describe('`matchStringOrRegexp()`', () => {
   })
 })
 
-describe('`overrideRequests()`', () => {
-  afterEach(() => {
-    common.restoreOverriddenRequests()
-  })
-
-  it('should throw if called a second time', () => {
-    nock.restore()
-    common.overrideRequests()
-    // Second call throws.
-    expect(() => common.overrideRequests()).to.throw(
-      "Module's request already overridden for http protocol."
-    )
-  })
-})
-
 it('`restoreOverriddenRequests()` can be called more than once', () => {
   common.restoreOverriddenRequests()
   common.restoreOverriddenRequests()


### PR DESCRIPTION
Rebasing PR #1235 to current **main** branch (also related to #1115 and #2038).

For backward compatibility added a `record_unmatched` flag that can be set true to record only the unmatched requests.

TODO:
 - [ ] Add `record_unmatched` Unit Tests 
 - [ ] Add `record_unmatched` to Documentation (Update Readme)

closes #1235