### PR TITLE
refactor(test): Mocha DSL for basic auth, body match, and define

### DIFF
--- a/tests/test_basic_auth.js
+++ b/tests/test_basic_auth.js
@@ -1,16 +1,14 @@
 'use strict'
 
 const { expect } = require('chai')
-const { test } = require('tap')
 const assertRejects = require('assert-rejects')
 const nock = require('..')
 const got = require('./got_client')
 
-require('./cleanup_after_each')()
 require('./setup')
 
-test('basic auth with username and password', async t => {
-  t.beforeEach(done => {
+describe('basic auth with username and password', () => {
+  beforeEach(done => {
     nock('http://example.test')
       .get('/test')
       .basicAuth({ user: 'foo', pass: 'bar' })
@@ -18,7 +16,7 @@ test('basic auth with username and password', async t => {
     done()
   })
 
-  await t.test('succeeds when it matches', async () => {
+  it('succeeds when it matches', async () => {
     const response = await got('http://example.test/test', {
       username: 'foo',
       password: 'bar',
@@ -27,7 +25,7 @@ test('basic auth with username and password', async t => {
     expect(response.body).to.equal('Here is the content')
   })
 
-  await t.test('fails when it doesnt match', async () => {
+  it('fails when it doesnt match', async () => {
     await assertRejects(
       got('http://example.test/test'),
       /Nock: No match for request/
@@ -35,8 +33,8 @@ test('basic auth with username and password', async t => {
   })
 })
 
-test('basic auth with username only', async t => {
-  t.beforeEach(done => {
+describe('basic auth with username only', () => {
+  beforeEach(done => {
     nock('http://example.test')
       .get('/test')
       .basicAuth({ user: 'foo' })
@@ -44,7 +42,7 @@ test('basic auth with username only', async t => {
     done()
   })
 
-  await t.test('succeeds when it matches', async () => {
+  it('succeeds when it matches', async () => {
     const response = await got('http://example.test/test', {
       username: 'foo',
       password: '',
@@ -53,7 +51,7 @@ test('basic auth with username only', async t => {
     expect(response.body).to.equal('Here is the content')
   })
 
-  await t.test('fails when it doesnt match', async () => {
+  it('fails when it doesnt match', async () => {
     await assertRejects(
       got('http://example.test/test'),
       /Nock: No match for request/

--- a/tests/test_body_match.js
+++ b/tests/test_body_match.js
@@ -3,312 +3,314 @@
 const assertRejects = require('assert-rejects')
 const { expect } = require('chai')
 const FormData = require('form-data')
-const { test } = require('tap')
 const nock = require('../')
 const got = require('./got_client')
 
-require('./cleanup_after_each')()
 require('./setup')
 
-test('match json body regardless of key ordering', async () => {
-  const scope = nock('http://example.test')
-    .post('/', { foo: 'bar', bar: 'foo' })
-    .reply(200, 'Heyyyy!')
+describe('`matchBody()`', () => {
+  it('match json body regardless of key ordering', async () => {
+    const scope = nock('http://example.test')
+      .post('/', { foo: 'bar', bar: 'foo' })
+      .reply(200, 'Heyyyy!')
 
-  const { body } = await got.post('http://example.test/', {
-    json: { bar: 'foo', foo: 'bar' },
-  })
-
-  expect(body).to.equal('Heyyyy!')
-  scope.done()
-})
-
-test('match form body regardless of field ordering', async () => {
-  const scope = nock('http://example.test')
-    .post('/', { foo: 'bar', bar: 'foo' })
-    .reply(200, 'Heyyyy!')
-
-  const { body } = await got.post('http://example.test/', {
-    form: { bar: 'foo', foo: 'bar' },
-  })
-
-  expect(body).to.equal('Heyyyy!')
-  scope.done()
-})
-
-test('match json body specified as json string', async () => {
-  const scope = nock('http://example.test')
-    .post('/', JSON.stringify({ bar: 'foo', foo: 'bar' }))
-    .reply(200, 'Heyyyy!')
-
-  const { body } = await got.post('http://example.test/', {
-    json: { bar: 'foo', foo: 'bar' },
-  })
-
-  expect(body).to.equal('Heyyyy!')
-  scope.done()
-})
-
-test('match body is regex trying to match string (matches)', async () => {
-  const scope = nock('http://example.test')
-    .post('/', new RegExp('abc'))
-    .reply(201)
-
-  const { statusCode } = await got.post('http://example.test/', {
-    json: { nested: { value: 'abc' } },
-  })
-
-  expect(statusCode).to.equal(201)
-  scope.done()
-})
-
-test('match body is regex trying to match string (does not match)', async () => {
-  const scope1 = nock('http://example.test')
-    .post('/', new RegExp('def'))
-    .reply(201)
-  const scope2 = nock('http://example.test')
-    .post('/', new RegExp('.'))
-    .reply(202)
-
-  const { statusCode } = await got.post('http://example.test/', {
-    json: { nested: { value: 'abc' } },
-  })
-
-  expect(statusCode).to.equal(202)
-  expect(scope1.isDone()).to.be.false()
-  scope2.done()
-})
-
-test('match body with regex', async () => {
-  const scope = nock('http://example.test')
-    .post('/', { auth: { passwd: /a.+/ } })
-    .reply(200)
-
-  const { statusCode } = await got.post('http://example.test', {
-    json: { auth: { passwd: 'abc' } },
-  })
-
-  expect(statusCode).to.equal(200)
-  scope.done()
-})
-
-test('match body (with space character) with regex', async () => {
-  const scope = nock('http://example.test').post('/', /a bc/).reply(200)
-
-  const { statusCode } = await got.post('http://example.test', {
-    json: { auth: { passwd: 'a bc' } },
-  })
-
-  expect(statusCode).to.equal(200)
-  scope.done()
-})
-
-test('match body with regex inside array', async () => {
-  const scope = nock('http://example.test')
-    .post('/', { items: [{ name: /t.+/ }] })
-    .reply(200)
-
-  const { statusCode } = await got.post('http://example.test', {
-    json: { items: [{ name: 'test' }] },
-  })
-
-  expect(statusCode).to.equal(200)
-  scope.done()
-})
-
-test('match body with empty object inside', async () => {
-  const scope = nock('http://example.test').post('/', { obj: {} }).reply(200)
-
-  const { statusCode } = await got.post('http://example.test', {
-    json: { obj: {} },
-  })
-
-  expect(statusCode).to.equal(200)
-  scope.done()
-})
-
-test('match body with nested object inside', async () => {
-  const scope = nock('http://example.test').post('/', /x/).reply(200)
-
-  const { statusCode } = await got.post('http://example.test', {
-    json: { obj: { x: 1 } },
-  })
-
-  expect(statusCode).to.equal(200)
-  scope.done()
-})
-
-test("doesn't match body with mismatching keys", async () => {
-  nock('http://example.test').post('/', { a: 'a' }).reply(200)
-
-  const request = got.post('http://example.test', { json: { a: 'a', b: 'b' } })
-  await assertRejects(request, /Nock: No match for request/)
-})
-
-// https://github.com/nock/nock/issues/1713
-test("doesn't match body with same number of keys but different keys", async () => {
-  nock('http://example.test').post('/', { a: {} }).reply()
-
-  const request = got.post('http://example.test', { json: { b: 123 } })
-  await assertRejects(request, /Nock: No match for request/)
-})
-
-test('match body with form multipart', async () => {
-  const form = new FormData()
-  const boundary = form.getBoundary()
-  form.append('field', 'value')
-
-  const scope = nock('http://example.test')
-    .post(
-      '/',
-      `--${boundary}\r\nContent-Disposition: form-data; name="field"\r\n\r\nvalue\r\n--${boundary}--\r\n`
-    )
-    .reply(200)
-
-  const { statusCode } = await got.post('http://example.test', { body: form })
-
-  expect(statusCode).to.equal(200)
-  scope.done()
-})
-
-test('array like urlencoded form posts are correctly parsed', async () => {
-  const scope = nock('http://example.test')
-    .post('/', {
-      arrayLike: [
-        {
-          fieldA: '0',
-          fieldB: 'data',
-          fieldC: 'value',
-        },
-      ],
+    const { body } = await got.post('http://example.test/', {
+      json: { bar: 'foo', foo: 'bar' },
     })
-    .reply()
 
-  const { statusCode } = await got.post('http://example.test', {
-    form: {
-      'arrayLike[0].fieldA': '0',
-      'arrayLike[0].fieldB': 'data',
-      'arrayLike[0].fieldC': 'value',
-    },
+    expect(body).to.equal('Heyyyy!')
+    scope.done()
   })
 
-  expect(statusCode).to.equal(200)
-  scope.done()
-})
+  it('match form body regardless of field ordering', async () => {
+    const scope = nock('http://example.test')
+      .post('/', { foo: 'bar', bar: 'foo' })
+      .reply(200, 'Heyyyy!')
 
-// This test pokes at an inherent shortcoming of URL encoded form data. "technically" form data values
-// can ONLY be strings. However, years of HTML abuse have lead to non-standard ways of handling more complex data.
-// https://url.spec.whatwg.org/#urlencoded-serializing
-// > The application/x-www-form-urlencoded format is in many ways an aberrant monstrosity...
-// Mikeal's Request uses `querystring` by default, optionally `qs` or `form-data`. Got uses `URLSearchParams`.
-// All of which handle "arrays" as values differently.
-// Nock uses `querystring`, as the consensus seems to be that it's the most widely used and intuitive, but it means
-// this test only passes with Got if the array is stringified.
-test('urlencoded form posts are matched with non-string values', async () => {
-  const scope = nock('http://example.test')
-    .post('/', {
-      boolean: true,
-      number: 1,
-      values: 'false,-1,test',
+    const { body } = await got.post('http://example.test/', {
+      form: { bar: 'foo', foo: 'bar' },
     })
-    .reply()
 
-  const { statusCode } = await got.post('http://example.test', {
-    // "body": "boolean=true&number=1&values=false%2C-1%2Ctest"
-    form: {
-      boolean: true,
-      number: 1,
-      values: [false, -1, 'test'],
-    },
+    expect(body).to.equal('Heyyyy!')
+    scope.done()
   })
 
-  expect(statusCode).to.equal(200)
-  scope.done()
-})
+  it('match json body specified as json string', async () => {
+    const scope = nock('http://example.test')
+      .post('/', JSON.stringify({ bar: 'foo', foo: 'bar' }))
+      .reply(200, 'Heyyyy!')
 
-test('urlencoded form posts are matched with regexp', async () => {
-  const scope = nock('http://example.test')
-    .post('/', {
-      regexp: /^xyz$/,
+    const { body } = await got.post('http://example.test/', {
+      json: { bar: 'foo', foo: 'bar' },
     })
-    .reply()
 
-  const { statusCode } = await got.post('http://example.test', {
-    form: {
-      regexp: 'xyz',
-    },
+    expect(body).to.equal('Heyyyy!')
+    scope.done()
   })
 
-  expect(statusCode).to.equal(200)
-  scope.done()
-})
+  it('match body is regex trying to match string (matches)', async () => {
+    const scope = nock('http://example.test')
+      .post('/', new RegExp('abc'))
+      .reply(201)
 
-test('match utf-8 buffer body with utf-8 buffer', async () => {
-  const scope = nock('http://example.test')
-    .post('/', Buffer.from('hello'))
-    .reply(200)
+    const { statusCode } = await got.post('http://example.test/', {
+      json: { nested: { value: 'abc' } },
+    })
 
-  const { statusCode } = await got.post('http://example.test', {
-    body: Buffer.from('hello'),
+    expect(statusCode).to.equal(201)
+    scope.done()
   })
 
-  expect(statusCode).to.equal(200)
-  scope.done()
-})
+  it('match body is regex trying to match string (does not match)', async () => {
+    const scope1 = nock('http://example.test')
+      .post('/', new RegExp('def'))
+      .reply(201)
+    const scope2 = nock('http://example.test')
+      .post('/', new RegExp('.'))
+      .reply(202)
 
-test("doesn't match utf-8 buffer body with mismatching utf-8 buffer", async () => {
-  nock('http://example.test').post('/', Buffer.from('goodbye')).reply(200)
+    const { statusCode } = await got.post('http://example.test/', {
+      json: { nested: { value: 'abc' } },
+    })
 
-  const request = got.post('http://example.test', {
-    body: Buffer.from('hello'),
+    expect(statusCode).to.equal(202)
+    expect(scope1.isDone()).to.be.false()
+    scope2.done()
   })
 
-  await assertRejects(request, /Nock: No match for request/)
-})
+  it('match body with regex', async () => {
+    const scope = nock('http://example.test')
+      .post('/', { auth: { passwd: /a.+/ } })
+      .reply(200)
 
-test('match binary buffer body with binary buffer', async () => {
-  const scope = nock('http://example.test')
-    .post('/', Buffer.from([0xff, 0xff, 0xff]))
-    .reply(200)
+    const { statusCode } = await got.post('http://example.test', {
+      json: { auth: { passwd: 'abc' } },
+    })
 
-  const { statusCode } = await got.post('http://example.test', {
-    body: Buffer.from([0xff, 0xff, 0xff]),
+    expect(statusCode).to.equal(200)
+    scope.done()
   })
 
-  expect(statusCode).to.equal(200)
-  scope.done()
-})
+  it('match body (with space character) with regex', async () => {
+    const scope = nock('http://example.test').post('/', /a bc/).reply(200)
 
-test("doesn't match binary buffer body with mismatching binary buffer", async () => {
-  nock('http://example.test')
-    .post('/', Buffer.from([0xff, 0xff, 0xfa]))
-    .reply(200)
+    const { statusCode } = await got.post('http://example.test', {
+      json: { auth: { passwd: 'a bc' } },
+    })
 
-  const request = got.post('http://example.test', {
-    body: Buffer.from([0xff, 0xff, 0xff]),
+    expect(statusCode).to.equal(200)
+    scope.done()
   })
 
-  await assertRejects(request, /Nock: No match for request/)
-})
+  it('match body with regex inside array', async () => {
+    const scope = nock('http://example.test')
+      .post('/', { items: [{ name: /t.+/ }] })
+      .reply(200)
 
-test("doesn't match binary buffer body with mismatching utf-8 buffer", async () => {
-  nock('http://example.test')
-    .post('/', Buffer.from([0xff, 0xff, 0xff]))
-    .reply(200)
+    const { statusCode } = await got.post('http://example.test', {
+      json: { items: [{ name: 'test' }] },
+    })
 
-  const request = got.post('http://example.test', {
-    body: Buffer.from('hello'),
+    expect(statusCode).to.equal(200)
+    scope.done()
   })
 
-  await assertRejects(request, /Nock: No match for request/)
-})
+  it('match body with empty object inside', async () => {
+    const scope = nock('http://example.test').post('/', { obj: {} }).reply(200)
 
-test("doesn't match utf-8 buffer body with mismatching binary buffer", async () => {
-  nock('http://example.test').post('/', Buffer.from('hello')).reply(200)
+    const { statusCode } = await got.post('http://example.test', {
+      json: { obj: {} },
+    })
 
-  const request = got.post('http://example.test', {
-    body: Buffer.from([0xff, 0xff, 0xff]),
+    expect(statusCode).to.equal(200)
+    scope.done()
   })
 
-  await assertRejects(request, /Nock: No match for request/)
+  it('match body with nested object inside', async () => {
+    const scope = nock('http://example.test').post('/', /x/).reply(200)
+
+    const { statusCode } = await got.post('http://example.test', {
+      json: { obj: { x: 1 } },
+    })
+
+    expect(statusCode).to.equal(200)
+    scope.done()
+  })
+
+  it("doesn't match body with mismatching keys", async () => {
+    nock('http://example.test').post('/', { a: 'a' }).reply(200)
+
+    const request = got.post('http://example.test', {
+      json: { a: 'a', b: 'b' },
+    })
+    await assertRejects(request, /Nock: No match for request/)
+  })
+
+  // https://github.com/nock/nock/issues/1713
+  it("doesn't match body with same number of keys but different keys", async () => {
+    nock('http://example.test').post('/', { a: {} }).reply()
+
+    const request = got.post('http://example.test', { json: { b: 123 } })
+    await assertRejects(request, /Nock: No match for request/)
+  })
+
+  it('match body with form multipart', async () => {
+    const form = new FormData()
+    const boundary = form.getBoundary()
+    form.append('field', 'value')
+
+    const scope = nock('http://example.test')
+      .post(
+        '/',
+        `--${boundary}\r\nContent-Disposition: form-data; name="field"\r\n\r\nvalue\r\n--${boundary}--\r\n`
+      )
+      .reply(200)
+
+    const { statusCode } = await got.post('http://example.test', { body: form })
+
+    expect(statusCode).to.equal(200)
+    scope.done()
+  })
+
+  it('array like urlencoded form posts are correctly parsed', async () => {
+    const scope = nock('http://example.test')
+      .post('/', {
+        arrayLike: [
+          {
+            fieldA: '0',
+            fieldB: 'data',
+            fieldC: 'value',
+          },
+        ],
+      })
+      .reply()
+
+    const { statusCode } = await got.post('http://example.test', {
+      form: {
+        'arrayLike[0].fieldA': '0',
+        'arrayLike[0].fieldB': 'data',
+        'arrayLike[0].fieldC': 'value',
+      },
+    })
+
+    expect(statusCode).to.equal(200)
+    scope.done()
+  })
+
+  // This test pokes at an inherent shortcoming of URL encoded form data. "technically" form data values
+  // can ONLY be strings. However, years of HTML abuse have lead to non-standard ways of handling more complex data.
+  // https://url.spec.whatwg.org/#urlencoded-serializing
+  // > The application/x-www-form-urlencoded format is in many ways an aberrant monstrosity...
+  // Mikeal's Request uses `querystring` by default, optionally `qs` or `form-data`. Got uses `URLSearchParams`.
+  // All of which handle "arrays" as values differently.
+  // Nock uses `querystring`, as the consensus seems to be that it's the most widely used and intuitive, but it means
+  // this test only passes with Got if the array is stringified.
+  it('urlencoded form posts are matched with non-string values', async () => {
+    const scope = nock('http://example.test')
+      .post('/', {
+        boolean: true,
+        number: 1,
+        values: 'false,-1,test',
+      })
+      .reply()
+
+    const { statusCode } = await got.post('http://example.test', {
+      // "body": "boolean=true&number=1&values=false%2C-1%2Ctest"
+      form: {
+        boolean: true,
+        number: 1,
+        values: [false, -1, 'test'],
+      },
+    })
+
+    expect(statusCode).to.equal(200)
+    scope.done()
+  })
+
+  it('urlencoded form posts are matched with regexp', async () => {
+    const scope = nock('http://example.test')
+      .post('/', {
+        regexp: /^xyz$/,
+      })
+      .reply()
+
+    const { statusCode } = await got.post('http://example.test', {
+      form: {
+        regexp: 'xyz',
+      },
+    })
+
+    expect(statusCode).to.equal(200)
+    scope.done()
+  })
+
+  it('match utf-8 buffer body with utf-8 buffer', async () => {
+    const scope = nock('http://example.test')
+      .post('/', Buffer.from('hello'))
+      .reply(200)
+
+    const { statusCode } = await got.post('http://example.test', {
+      body: Buffer.from('hello'),
+    })
+
+    expect(statusCode).to.equal(200)
+    scope.done()
+  })
+
+  it("doesn't match utf-8 buffer body with mismatching utf-8 buffer", async () => {
+    nock('http://example.test').post('/', Buffer.from('goodbye')).reply(200)
+
+    const request = got.post('http://example.test', {
+      body: Buffer.from('hello'),
+    })
+
+    await assertRejects(request, /Nock: No match for request/)
+  })
+
+  it('match binary buffer body with binary buffer', async () => {
+    const scope = nock('http://example.test')
+      .post('/', Buffer.from([0xff, 0xff, 0xff]))
+      .reply(200)
+
+    const { statusCode } = await got.post('http://example.test', {
+      body: Buffer.from([0xff, 0xff, 0xff]),
+    })
+
+    expect(statusCode).to.equal(200)
+    scope.done()
+  })
+
+  it("doesn't match binary buffer body with mismatching binary buffer", async () => {
+    nock('http://example.test')
+      .post('/', Buffer.from([0xff, 0xff, 0xfa]))
+      .reply(200)
+
+    const request = got.post('http://example.test', {
+      body: Buffer.from([0xff, 0xff, 0xff]),
+    })
+
+    await assertRejects(request, /Nock: No match for request/)
+  })
+
+  it("doesn't match binary buffer body with mismatching utf-8 buffer", async () => {
+    nock('http://example.test')
+      .post('/', Buffer.from([0xff, 0xff, 0xff]))
+      .reply(200)
+
+    const request = got.post('http://example.test', {
+      body: Buffer.from('hello'),
+    })
+
+    await assertRejects(request, /Nock: No match for request/)
+  })
+
+  it("doesn't match utf-8 buffer body with mismatching binary buffer", async () => {
+    nock('http://example.test').post('/', Buffer.from('hello')).reply(200)
+
+    const request = got.post('http://example.test', {
+      body: Buffer.from([0xff, 0xff, 0xff]),
+    })
+
+    await assertRejects(request, /Nock: No match for request/)
+  })
 })

--- a/tests/test_define.js
+++ b/tests/test_define.js
@@ -3,294 +3,287 @@
 const http = require('http')
 const { expect } = require('chai')
 const assertRejects = require('assert-rejects')
-const { test } = require('tap')
 const nock = require('..')
 const got = require('./got_client')
 
 require('./setup')
-require('./cleanup_after_each')()
 
-test('define() is backward compatible', async t => {
-  expect(
-    nock.define([
-      {
-        scope: 'http://example.test',
-        //  "port" has been deprecated
-        port: 12345,
-        method: 'GET',
-        path: '/',
-        //  "reply" has been deprecated
-        reply: '500',
-      },
-    ])
-  ).to.be.ok()
+describe('`define()`', () => {
+  it('is backward compatible', async () => {
+    expect(
+      nock.define([
+        {
+          scope: 'http://example.test',
+          //  "port" has been deprecated
+          port: 12345,
+          method: 'GET',
+          path: '/',
+          //  "reply" has been deprecated
+          reply: '500',
+        },
+      ])
+    ).to.be.ok()
 
-  await assertRejects(
-    got('http://example.test:12345/'),
-    ({ response: { statusCode } }) => {
-      expect(statusCode).to.equal(500)
-      return true
-    }
-  )
-})
-
-test('define() throws when reply is not a numeric string', t => {
-  expect(() =>
-    nock.define([
-      {
-        scope: 'http://example.test:1451',
-        method: 'GET',
-        path: '/',
-        reply: 'frodo',
-      },
-    ])
-  ).to.throw('`reply`, when present, must be a numeric string')
-  t.end()
-})
-
-test('define() applies default status code when none is specified', async t => {
-  const body = '�'
-
-  expect(
-    nock.define([
-      {
-        scope: 'http://example.test',
-        method: 'POST',
-        path: '/',
-        body,
-        response: '�',
-      },
-    ])
-  ).to.have.lengthOf(1)
-
-  const { statusCode } = await got.post('http://example.test/', { body })
-
-  expect(statusCode).to.equal(200)
-})
-
-test('define() works when scope and port are both specified', async t => {
-  const body = 'Hello, world!'
-
-  expect(
-    nock.define([
-      {
-        scope: 'http://example.test:1451',
-        port: 1451,
-        method: 'POST',
-        path: '/',
-        body,
-        response: '�',
-      },
-    ])
-  ).to.be.ok()
-
-  const { statusCode } = await got.post('http://example.test:1451/', { body })
-
-  expect(statusCode).to.equal(200)
-
-  t.end()
-})
-
-test('define() throws the expected error when scope and port conflict', t => {
-  expect(() =>
-    nock.define([
-      {
-        scope: 'http://example.test:8080',
-        port: 5000,
-        method: 'POST',
-        path: '/',
-        body: 'Hello, world!',
-        response: '�',
-      },
-    ])
-  ).to.throw(
-    'Mismatched port numbers in scope and port properties of nock definition.'
-  )
-
-  t.end()
-})
-
-test('define() throws the expected error when method is missing', t => {
-  expect(() =>
-    nock.define([
-      {
-        scope: 'http://example.test',
-        path: '/',
-        body: 'Hello, world!',
-        response: 'yo',
-      },
-    ])
-  ).to.throw('Method is required')
-
-  t.end()
-})
-
-test('define() works with non-JSON responses', async t => {
-  const exampleBody = '�'
-  const exampleResponseBody = 'hey: �'
-
-  expect(
-    nock.define([
-      {
-        scope: 'http://example.test',
-        method: 'POST',
-        path: '/',
-        body: exampleBody,
-        status: 200,
-        response: exampleResponseBody,
-      },
-    ])
-  ).to.be.ok()
-
-  const { statusCode, body } = await got.post('http://example.test/', {
-    body: exampleBody,
-    responseType: 'buffer',
+    await assertRejects(
+      got('http://example.test:12345/'),
+      ({ response: { statusCode } }) => {
+        expect(statusCode).to.equal(500)
+        return true
+      }
+    )
   })
 
-  expect(statusCode).to.equal(200)
-  expect(body).to.be.an.instanceOf(Buffer)
-  expect(body.toString()).to.equal(exampleResponseBody)
-})
-
-// TODO: There seems to be a bug here. When testing via `got` with
-// `{ encoding: false }` the body that comes back should be a buffer, but is
-// not. It's difficult to get this test to pass after porting it.
-// I think this bug has been fixed in Got v10, so this should be unblocked.
-test('define() works with binary buffers', t => {
-  const exampleBody = '8001'
-  const exampleResponse = '8001'
-
-  expect(
-    nock.define([
-      {
-        scope: 'http://example.test',
-        method: 'POST',
-        path: '/',
-        body: exampleBody,
-        status: 200,
-        response: exampleResponse,
-      },
-    ])
-  ).to.be.ok()
-
-  const req = http.request(
-    {
-      host: 'example.test',
-      method: 'POST',
-      path: '/',
-    },
-    res => {
-      expect(res.statusCode).to.equal(200)
-
-      const dataChunks = []
-
-      res.on('data', chunk => {
-        dataChunks.push(chunk)
-      })
-
-      res.once('end', () => {
-        const response = Buffer.concat(dataChunks)
-        expect(response.toString('hex')).to.equal(exampleResponse)
-        t.end()
-      })
-    }
-  )
-
-  req.on('error', () => {
-    //  This should never happen.
-    expect.fail()
-    t.end()
+  it('throws when reply is not a numeric string', () => {
+    expect(() =>
+      nock.define([
+        {
+          scope: 'http://example.test:1451',
+          method: 'GET',
+          path: '/',
+          reply: 'frodo',
+        },
+      ])
+    ).to.throw('`reply`, when present, must be a numeric string')
   })
 
-  req.write(Buffer.from(exampleBody, 'hex'))
-  req.end()
-})
+  it('applies default status code when none is specified', async () => {
+    const body = '�'
 
-test('define() uses reqheaders', t => {
-  const auth = 'foo:bar'
-  const authHeader = `Basic ${Buffer.from('foo:bar').toString('base64')}`
-  const reqheaders = {
-    host: 'example.test',
-    authorization: authHeader,
-  }
+    expect(
+      nock.define([
+        {
+          scope: 'http://example.test',
+          method: 'POST',
+          path: '/',
+          body,
+          response: '�',
+        },
+      ])
+    ).to.have.lengthOf(1)
 
-  expect(
-    nock.define([
+    const { statusCode } = await got.post('http://example.test/', { body })
+
+    expect(statusCode).to.equal(200)
+  })
+
+  it('works when scope and port are both specified', async () => {
+    const body = 'Hello, world!'
+
+    expect(
+      nock.define([
+        {
+          scope: 'http://example.test:1451',
+          port: 1451,
+          method: 'POST',
+          path: '/',
+          body,
+          response: '�',
+        },
+      ])
+    ).to.be.ok()
+
+    const { statusCode } = await got.post('http://example.test:1451/', { body })
+
+    expect(statusCode).to.equal(200)
+  })
+
+  it('throws the expected error when scope and port conflict', () => {
+    expect(() =>
+      nock.define([
+        {
+          scope: 'http://example.test:8080',
+          port: 5000,
+          method: 'POST',
+          path: '/',
+          body: 'Hello, world!',
+          response: '�',
+        },
+      ])
+    ).to.throw(
+      'Mismatched port numbers in scope and port properties of nock definition.'
+    )
+  })
+
+  it('throws the expected error when method is missing', () => {
+    expect(() =>
+      nock.define([
+        {
+          scope: 'http://example.test',
+          path: '/',
+          body: 'Hello, world!',
+          response: 'yo',
+        },
+      ])
+    ).to.throw('Method is required')
+  })
+
+  it('works with non-JSON responses', async () => {
+    const exampleBody = '�'
+    const exampleResponseBody = 'hey: �'
+
+    expect(
+      nock.define([
+        {
+          scope: 'http://example.test',
+          method: 'POST',
+          path: '/',
+          body: exampleBody,
+          status: 200,
+          response: exampleResponseBody,
+        },
+      ])
+    ).to.be.ok()
+
+    const { statusCode, body } = await got.post('http://example.test/', {
+      body: exampleBody,
+      responseType: 'buffer',
+    })
+
+    expect(statusCode).to.equal(200)
+    expect(body).to.be.an.instanceOf(Buffer)
+    expect(body.toString()).to.equal(exampleResponseBody)
+  })
+
+  // TODO: There seems to be a bug here. When testing via `got` with
+  // `{ encoding: false }` the body that comes back should be a buffer, but is
+  // not. It's difficult to get this test to pass after porting it.
+  // I think this bug has been fixed in Got v10, so this should be unblocked.
+  it('works with binary buffers', done => {
+    const exampleBody = '8001'
+    const exampleResponse = '8001'
+
+    expect(
+      nock.define([
+        {
+          scope: 'http://example.test',
+          method: 'POST',
+          path: '/',
+          body: exampleBody,
+          status: 200,
+          response: exampleResponse,
+        },
+      ])
+    ).to.be.ok()
+
+    const req = http.request(
       {
-        scope: 'http://example.test',
-        method: 'GET',
+        host: 'example.test',
+        method: 'POST',
         path: '/',
-        status: 200,
-        reqheaders,
       },
-    ])
-  ).to.be.ok()
+      res => {
+        expect(res.statusCode).to.equal(200)
 
-  // Make a request which should match the mock that was configured above.
-  // This does not hit the network.
-  const req = http.request(
-    {
+        const dataChunks = []
+
+        res.on('data', chunk => {
+          dataChunks.push(chunk)
+        })
+
+        res.once('end', () => {
+          const response = Buffer.concat(dataChunks)
+          expect(response.toString('hex')).to.equal(exampleResponse)
+          done()
+        })
+      }
+    )
+
+    req.on('error', () => {
+      //  This should never happen.
+      expect.fail()
+      done()
+    })
+
+    req.write(Buffer.from(exampleBody, 'hex'))
+    req.end()
+  })
+
+  it('uses reqheaders', done => {
+    const auth = 'foo:bar'
+    const authHeader = `Basic ${Buffer.from('foo:bar').toString('base64')}`
+    const reqheaders = {
       host: 'example.test',
-      method: 'GET',
-      path: '/',
-      auth,
-    },
-    res => {
-      expect(res.statusCode).to.equal(200)
-
-      res.once('end', () => {
-        expect(res.req.getHeaders(), reqheaders)
-        t.end()
-      })
-      // Streams start in 'paused' mode and must be started.
-      // See https://nodejs.org/api/stream.html#stream_class_stream_readable
-      res.resume()
+      authorization: authHeader,
     }
-  )
-  req.end()
-})
 
-test('define() uses badheaders', t => {
-  expect(
-    nock.define([
+    expect(
+      nock.define([
+        {
+          scope: 'http://example.test',
+          method: 'GET',
+          path: '/',
+          status: 200,
+          reqheaders,
+        },
+      ])
+    ).to.be.ok()
+
+    // Make a request which should match the mock that was configured above.
+    // This does not hit the network.
+    const req = http.request(
       {
-        scope: 'http://example.test',
+        host: 'example.test',
         method: 'GET',
         path: '/',
-        status: 401,
-        badheaders: ['x-foo'],
+        auth,
       },
+      res => {
+        expect(res.statusCode).to.equal(200)
+
+        res.once('end', () => {
+          expect(res.req.getHeaders(), reqheaders)
+          done()
+        })
+        // Streams start in 'paused' mode and must be started.
+        // See https://nodejs.org/api/stream.html#stream_class_stream_readable
+        res.resume()
+      }
+    )
+    req.end()
+  })
+
+  it('uses badheaders', done => {
+    expect(
+      nock.define([
+        {
+          scope: 'http://example.test',
+          method: 'GET',
+          path: '/',
+          status: 401,
+          badheaders: ['x-foo'],
+        },
+        {
+          scope: 'http://example.test',
+          method: 'GET',
+          path: '/',
+          status: 200,
+          reqheaders: {
+            'x-foo': 'bar',
+          },
+        },
+      ])
+    ).to.be.ok()
+
+    const req = http.request(
       {
-        scope: 'http://example.test',
+        host: 'example.test',
         method: 'GET',
         path: '/',
-        status: 200,
-        reqheaders: {
+        headers: {
           'x-foo': 'bar',
         },
       },
-    ])
-  ).to.be.ok()
+      res => {
+        expect(res.statusCode).to.equal(200)
 
-  const req = http.request(
-    {
-      host: 'example.test',
-      method: 'GET',
-      path: '/',
-      headers: {
-        'x-foo': 'bar',
-      },
-    },
-    res => {
-      expect(res.statusCode).to.equal(200)
-
-      res.once('end', () => {
-        t.end()
-      })
-      // Streams start in 'paused' mode and must be started.
-      // See https://nodejs.org/api/stream.html#stream_class_stream_readable
-      res.resume()
-    }
-  )
-  req.end()
+        res.once('end', () => {
+          done()
+        })
+        // Streams start in 'paused' mode and must be started.
+        // See https://nodejs.org/api/stream.html#stream_class_stream_readable
+        res.resume()
+      }
+    )
+    req.end()
+  })
 })


### PR DESCRIPTION
I wrapped some tests in `describe` scopes, which indented all the nested tests. Viewing the change-set [without whitespace](https://github.com/nock/nock/pull/2070/files?w=1) is easier.