### PR TITLE
chore(scope): narrow event type of "on"

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -129,7 +129,18 @@ declare namespace nock {
     pendingMocks(): string[]
     activeMocks(): string[]
 
-    on(event: 'request' | 'replied', listener: (...args: any[]) => void): this
+    on(
+      event: 'request',
+      listener: (
+        req: ClientRequest,
+        interceptor: Interceptor,
+        body: string
+      ) => void
+    ): this
+    on(
+      event: 'replied',
+      listener: (req: ClientRequest, interceptor: Interceptor) => void
+    ): this
   }
 
   interface Interceptor {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -128,6 +128,8 @@ declare namespace nock {
     isDone(): boolean
     pendingMocks(): string[]
     activeMocks(): string[]
+
+    on(event: 'request' | 'replied', listener: (...args: any[]) => void): this
   }
 
   interface Interceptor {

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -1,6 +1,7 @@
-import nock from 'nock'
+import nock, { Interceptor } from 'nock'
 import * as fs from 'fs'
 import url, { URLSearchParams } from 'url'
+import { ClientRequest } from 'http'
 
 let scope: nock.Scope = nock('http://example.test')
 let inst: nock.Interceptor
@@ -16,6 +17,12 @@ const objWithUndefinedValue: { a: string; b?: string } = { a: 'a' }
 const regex = /test/
 
 scope.head(str) // $ExpectType Interceptor
+
+scope.on(
+  'request',
+  (req: ClientRequest, interceptor: Interceptor, body: string) => {}
+)
+scope.on('replied', (req: ClientRequest, interceptor: Interceptor) => {})
 
 inst = scope.get(str)
 inst = scope.get(str, str)


### PR DESCRIPTION
Hello maintainers,
Thank you all for always developing this awesome library!

I was writing some tests and looking for a way to assert on the actual request payload submitted, then I figured that it's possible with the `scope.on` method, as is documented. (huge thanks)

Unfortunately, TypeScript-wise, Node.js' **original** type definition of the `on` method is not so friendly... :(

```typescript
class EventEmitter {
  on(event: string | symbol, listener: (...args: any[]) => void): this;
  // some other properties goes on
}
```

So, I tried to annotate the type in correspondence to the documented [Events](https://github.com/nock/nock#events).

However, it was very very hard to accurately type `req`, `interceptor` nor `body`.

I was only able to narrow the event type from `string | symbol` to the string literal types of the presumable ones that may be emitted(`request` or `replied`).

If there's anyone out there who uses `scope.emit` with some other custom event name, this could be a breaking change, but I'm thinking that's a relatively rare, ignorable case 🤔 .