### PR TITLE
Use correct option property in nockBack example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1425,7 +1425,7 @@ function prepareScope(scope) {
   }
 }
 
-nockBack('exampleFixture.json', { before: prepareScope }, nockDone => {
+nockBack('exampleFixture.json', { after: prepareScope }, nockDone => {
   request.get('http://example.com', function (err, res, body) {
     // do your tests
     nockDone()


### PR DESCRIPTION
`prepareScope` needs a `Scope` to work, so it should be using the `after` option not `before` which uses a `Definition`