### PR TITLE
chore(test) update/remove client specific tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,12 +34,10 @@
         "nyc": "^15.0.0",
         "prettier": "2.2.1",
         "proxyquire": "^2.1.0",
-        "request": "^2.83.0",
         "rimraf": "^3.0.0",
         "semantic-release": "^17.0.2",
         "sinon": "^9.0.0",
         "sinon-chai": "^3.3.0",
-        "superagent": "^6.1.0",
         "typescript": "^4.2.2"
       },
       "engines": {
@@ -56,23 +54,23 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.13.6",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.6.tgz",
-      "integrity": "sha512-VhgqKOWYVm7lQXlvbJnWOzwfAQATd2nV52koT0HZ/LdDH0m4DUDwkKYsH+IwpXb+bKPyBJzawA4I6nBKqZcpQw==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.8.tgz",
+      "integrity": "sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog==",
       "dev": true
     },
     "node_modules/@babel/core": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.1.tgz",
-      "integrity": "sha512-FzeKfFBG2rmFtGiiMdXZPFt/5R5DXubVi82uYhjGX4Msf+pgYQMCFIqFXZWs5vbIYbf14VeBIgdGI03CDOOM1w==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.8.tgz",
+      "integrity": "sha512-oYapIySGw1zGhEFRd6lzWNLWFX2s5dA/jm+Pw/+59ZdXtjyIuwlXbrId22Md0rgZVop+aVoqow2riXhBLNyuQg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
         "@babel/generator": "^7.13.0",
-        "@babel/helper-compilation-targets": "^7.13.0",
+        "@babel/helper-compilation-targets": "^7.13.8",
         "@babel/helper-module-transforms": "^7.13.0",
         "@babel/helpers": "^7.13.0",
-        "@babel/parser": "^7.13.0",
+        "@babel/parser": "^7.13.4",
         "@babel/template": "^7.12.13",
         "@babel/traverse": "^7.13.0",
         "@babel/types": "^7.13.0",
@@ -81,7 +79,7 @@
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.1.2",
         "lodash": "^4.17.19",
-        "semver": "7.0.0",
+        "semver": "^6.3.0",
         "source-map": "^0.5.0"
       },
       "engines": {
@@ -101,19 +99,10 @@
         "@babel/highlight": "^7.12.13"
       }
     },
-    "node_modules/@babel/core/node_modules/semver": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-      "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/generator": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.0.tgz",
-      "integrity": "sha512-zBZfgvBB/ywjx0Rgc2+BwoH/3H+lDtlgD4hBOpEv5LxRnYsm/753iRuLepqnYlynpjC3AdQxtxsoeHJoEEwOAw==",
+      "version": "7.13.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+      "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.13.0",
@@ -122,27 +111,18 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.0.tgz",
-      "integrity": "sha512-SOWD0JK9+MMIhTQiUVd4ng8f3NXhPVQvTv7D3UN4wbp/6cAHnB2EmMaU1zZA2Hh1gwme+THBrVSqTFxHczTh0Q==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.8.tgz",
+      "integrity": "sha512-pBljUGC1y3xKLn1nrx2eAhurLMA8OqBtBP/JwG4U8skN7kf8/aqwwxpV1N6T0e7r6+7uNitIa/fUxPFagSXp3A==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.13.0",
+        "@babel/compat-data": "^7.13.8",
         "@babel/helper-validator-option": "^7.12.17",
         "browserslist": "^4.14.5",
-        "semver": "7.0.0"
+        "semver": "^6.3.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-      "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-function-name": {
@@ -263,9 +243,9 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
-      "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.8.tgz",
+      "integrity": "sha512-4vrIhfJyfNf+lCtXC2ck1rKSzDwciqF7IWFhXXrSOUC2O5DrVp+w4c6ed4AllTxhTkUP5x2tYj41VaxdVMMRDw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.12.11",
@@ -345,9 +325,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.13.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.4.tgz",
-      "integrity": "sha512-uvoOulWHhI+0+1f9L4BoozY7U5cIkZ9PgJqvb041d6vypgUmtVPG4vmGm4pSggjl8BELzvHyUeJSUyEMY6b+qA==",
+      "version": "7.13.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.9.tgz",
+      "integrity": "sha512-nEUfRiARCcaVo3ny3ZQjURjHQZUo/JkEw7rLlSZy/psWGnvwXFtPcr6jb7Yb41DVW5LTe6KRq9LGleRNsg1Frw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -423,29 +403,29 @@
       }
     },
     "node_modules/@definitelytyped/header-parser": {
-      "version": "0.0.69",
-      "resolved": "https://registry.npmjs.org/@definitelytyped/header-parser/-/header-parser-0.0.69.tgz",
-      "integrity": "sha512-8WKD2I1wtrHWWNvyei7ncBBFJ2DfDUnsAgpS2z/O9JlR8LzoDhqUphH5CaB+EMr3kdHXi7KcAnf6ec7zJ5IsvA==",
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/header-parser/-/header-parser-0.0.71.tgz",
+      "integrity": "sha512-5iASXqlpqorWJ81D/QlwvbXmgnEOvcekv33aZTMSe7ubCJ1S/IdBwbTIBpPZbS3GnBzXbCT0749a1bVxG+wTfg==",
       "dev": true,
       "dependencies": {
-        "@definitelytyped/typescript-versions": "^0.0.69",
+        "@definitelytyped/typescript-versions": "^0.0.71",
         "@types/parsimmon": "^1.10.1",
         "parsimmon": "^1.13.0"
       }
     },
     "node_modules/@definitelytyped/typescript-versions": {
-      "version": "0.0.69",
-      "resolved": "https://registry.npmjs.org/@definitelytyped/typescript-versions/-/typescript-versions-0.0.69.tgz",
-      "integrity": "sha512-+0KTIEPFbH9+nehW5aZ93so9wqbScAxZ0uI5mstyWWegEz4a9YS9LgIRr6BMdHbt3NjKyfnJ5Kd2oicMN91BZg==",
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/typescript-versions/-/typescript-versions-0.0.71.tgz",
+      "integrity": "sha512-XJvyYfWQyntq+EdCqRinni9BwenPAoCXTZ3aaKfuir14bEbkIyeyQjuh1R0VkqdahIavyyAoGmYHe9OSYqFwTw==",
       "dev": true
     },
     "node_modules/@definitelytyped/utils": {
-      "version": "0.0.69",
-      "resolved": "https://registry.npmjs.org/@definitelytyped/utils/-/utils-0.0.69.tgz",
-      "integrity": "sha512-pd0aGoVilhahj+XRrEW9Q1/fJG9V1k+CkpGxg1nSk0fBdi15njovnPPU3iTSUzFlaUZloNoTs5+czTjgXJfg9Q==",
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/utils/-/utils-0.0.71.tgz",
+      "integrity": "sha512-/IueyLKglPxweW1d7VvuTlnFxBNVv1qcSL2Y+u/LW7aBMXfD8bcuHl7awAMVRAGhTeBpo7qGubrCqMSNfOlUyA==",
       "dev": true,
       "dependencies": {
-        "@definitelytyped/typescript-versions": "^0.0.69",
+        "@definitelytyped/typescript-versions": "^0.0.71",
         "@types/node": "^12.12.29",
         "charm": "^1.0.2",
         "fs-extra": "^8.1.0",
@@ -470,9 +450,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
-      "integrity": "sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
+      "integrity": "sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -482,7 +462,6 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.20",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
@@ -669,18 +648,18 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-5.1.1.tgz",
-      "integrity": "sha512-yMyaX9EDWCiyv7m85/K8L7bLFj1wrLdfDkKcZEZ6gNmepSW5mfSMFJnYwRINN7lF58wvevKPWvw0MYy6sxcFlQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-5.3.1.tgz",
+      "integrity": "sha512-TvVk2QuIA0lQZcIMd6xbdGaGDVeNYIOa3l1ZVagAIk5K3t/WMYbcg4BISNDhzdVhm/TgQB26frAgd/GV81aHJA==",
       "dev": true
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.10.0.tgz",
-      "integrity": "sha512-71OsKBSMcQEu/6lfVbhv5C5ikU1rn10rKot/WiV7do7fyfElQ2eCUQFogHPbj0ci5lnKAjvahOiMAr6lcvL8Qw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.11.0.tgz",
+      "integrity": "sha512-7L9xQank2G3r1dGqrVPo1z62V5utbykOUzlmNHPz87Pww/JpZQ9KyG5CHtUzgmB4n5iDRKYNK/86A8D98HP0yA==",
       "dev": true,
       "dependencies": {
-        "@octokit/types": "^6.10.0"
+        "@octokit/types": "^6.11.0"
       },
       "peerDependencies": {
         "@octokit/core": ">=2"
@@ -696,12 +675,12 @@
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.12.2.tgz",
-      "integrity": "sha512-5+MmGusB7wPw7OholtcGaMyjfrsFSpFqtJW8VsrbfU/TuaiQepY4wgVkS7P3TAObX257jrTbbGo/sJLcoGf16g==",
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.13.4.tgz",
+      "integrity": "sha512-MGxptzVfiP8O+aydC/riheYzS/yJ9P16M29OuvtZep/sF5sKuOCQP8Wf83YCKXRsQF+ZpYfke2snbPPSIMZKzg==",
       "dev": true,
       "dependencies": {
-        "@octokit/types": "^6.10.1",
+        "@octokit/types": "^6.12.0",
         "deprecation": "^2.3.1"
       },
       "peerDependencies": {
@@ -736,24 +715,24 @@
       }
     },
     "node_modules/@octokit/rest": {
-      "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.2.1.tgz",
-      "integrity": "sha512-DdQ1vps41JSyB2axyL1mBwJiXAPibgugIQPOmt0mL/yhwheQ6iuq2aKiJWgGWa9ldMfe3v9gIFYlrFgxQ5ThGQ==",
+      "version": "18.3.4",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.3.4.tgz",
+      "integrity": "sha512-NES0pHbwyFB1D0jrLkdnIXgEmze/gLE0JoSNgfAe4vwD77/qaQGO/lRWNuPPsoBVBjiW6mmA9CU5cYHujJTKQA==",
       "dev": true,
       "dependencies": {
         "@octokit/core": "^3.2.3",
         "@octokit/plugin-paginate-rest": "^2.6.2",
         "@octokit/plugin-request-log": "^1.0.2",
-        "@octokit/plugin-rest-endpoint-methods": "4.12.2"
+        "@octokit/plugin-rest-endpoint-methods": "4.13.4"
       }
     },
     "node_modules/@octokit/types": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.10.1.tgz",
-      "integrity": "sha512-hgNC5jxKG8/RlqxU/6GThkGrvFpz25+cPzjQjyiXTNBvhyltn2Z4GhFY25+kbtXwZ4Co4zM0goW5jak1KLp1ug==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.12.0.tgz",
+      "integrity": "sha512-KwOf16soD7aDEEi/PgNeJlHzjZPfrmmNy+7WezSdrpnqZ7YImBJcNnX9+5RUHt1MnA4h8oISRHTqaZDGsX9DRQ==",
       "dev": true,
       "dependencies": {
-        "@octokit/openapi-types": "^5.1.0"
+        "@octokit/openapi-types": "^5.3.0"
       }
     },
     "node_modules/@semantic-release/commit-analyzer": {
@@ -1425,8 +1404,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node_modules/archy": {
       "version": "1.0.0",
@@ -1439,7 +1417,6 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -1715,9 +1692,9 @@
       }
     },
     "node_modules/before-after-hook": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.1.tgz",
-      "integrity": "sha512-5ekuQOvO04MDj7kYZJaMab2S8SPjGJbotVNyv7QYFCOAwrGZs/YnoDNlh1U+m5hl7H2D/+n0taaAV/tfyd3KMA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.0.tgz",
+      "integrity": "sha512-jH6rKQIfroBbhEXVmI7XmXe3ix5S/PgJqpzdDPnR8JGLHWNYLsYZ6tK5iWOF/Ra3oqEX0NobXGlzbiylIzVphQ==",
       "dev": true
     },
     "node_modules/binary-extensions": {
@@ -1968,9 +1945,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001191",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001191.tgz",
-      "integrity": "sha512-xJJqzyd+7GCJXkcoBiQ1GuxEiOBCLQ0aVW9HMekifZsAVGdj5eJ4mFB9fEhSHipq9IOk/QXFJUiIr9lZT+EsGw==",
+      "version": "1.0.30001196",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001196.tgz",
+      "integrity": "sha512-CPvObjD3ovWrNBaXlAIGWmg2gQQuJ5YhuciUOjPRox6hIQttu8O+b51dx6VIpIY9ESd2d0Vac1RKpICdG4rGUg==",
       "dev": true
     },
     "node_modules/cardinal": {
@@ -1993,20 +1970,20 @@
       "dev": true
     },
     "node_modules/chai": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.0.tgz",
-      "integrity": "sha512-/BFd2J30EcOwmdOgXvVsmM48l0Br0nmZPlO0uOW4XKh6kpsUumRXBgPV+IlaqFaqr9cYbeoZAM1Npx0i4A+aiA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.3.tgz",
+      "integrity": "sha512-MPSLOZwxxnA0DhLE84klnGPojWFK5KuhP7/j5dTsxpr2S3XlkqJP5WbyYl1gCTWvG2Z5N+HD4F472WsbEZL6Pw==",
       "dev": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
         "deep-eql": "^3.0.1",
         "get-func-name": "^2.0.0",
-        "pathval": "^1.1.0",
+        "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/chalk": {
@@ -2106,9 +2083,9 @@
       }
     },
     "node_modules/cliui/node_modules/string-width": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
       "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -2156,9 +2133,9 @@
       "dev": true
     },
     "node_modules/colorette": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
     },
     "node_modules/colors": {
@@ -2210,12 +2187,6 @@
         "dot-prop": "^5.1.0"
       }
     },
-    "node_modules/component-emitter": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
-      "dev": true
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2241,8 +2212,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node_modules/contains-path": {
       "version": "0.1.0",
@@ -2337,12 +2307,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
-    },
-    "node_modules/cookiejar": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
       "dev": true
     },
     "node_modules/core-util-is": {
@@ -2552,9 +2516,9 @@
       }
     },
     "node_modules/defer-to-connect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
-      "integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -2622,8 +2586,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node_modules/deprecation": {
       "version": "2.3.1",
@@ -2761,9 +2724,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.673",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.673.tgz",
-      "integrity": "sha512-ms+QR2ckfrrpEAjXweLx6kNCbpAl66DcW//3BZD4BV5KhUgr0RZRce1ON/9J3QyA3JO28nzgb5Xv8DnPr05ILg==",
+      "version": "1.3.682",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.682.tgz",
+      "integrity": "sha512-zok2y37qR00U14uM6qBz/3iIjWHom2eRfC2S1StA0RslP7x34jX+j4mxv80t8OEOHLJPVG54ZPeaFxEI7gPrwg==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -2848,25 +2811,27 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.18.0-next.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
-      "integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+      "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2",
+        "get-intrinsic": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.2",
+        "has-symbols": "^1.0.2",
+        "is-callable": "^1.2.3",
         "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.1",
+        "is-regex": "^1.1.2",
+        "is-string": "^1.0.5",
         "object-inspect": "^1.9.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.3",
-        "string.prototype.trimstart": "^1.0.3"
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2920,13 +2885,13 @@
       }
     },
     "node_modules/eslint": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.20.0.tgz",
-      "integrity": "sha512-qGi0CTcOGP2OtCQBgWZlQjcTuP0XkIpYFj25XtRTQSHC+umNnp7UMshr2G8SLsRFYDdAPFeHOsiteadmMH02Yw==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.21.0.tgz",
+      "integrity": "sha512-W2aJbXpMNofUp0ztQaF40fveSsJBjlSCSWpy//gzfTvwC+USs/nceBrKmlJOiM8r1bLwP2EuYkCqArn/6QTIgg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.3.0",
+        "@eslint/eslintrc": "^0.4.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -2939,7 +2904,7 @@
         "espree": "^7.3.1",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^6.0.0",
+        "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
         "globals": "^12.1.0",
@@ -3139,9 +3104,9 @@
       "dev": true
     },
     "node_modules/eslint-plugin-mocha": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-8.0.0.tgz",
-      "integrity": "sha512-n67etbWDz6NQM+HnTwZHyBwz/bLlYPOxUbw7bPuCyFujv7ZpaT/Vn6KTAbT02gf7nRljtYIjWcTxK/n8a57rQQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-8.1.0.tgz",
+      "integrity": "sha512-1EgHvXKRl7W3mq3sntZAi5T24agRMyiTPL4bSXe+B4GksYOjAPEWYx+J3eJg4It1l2NMNZJtk0gQyQ6mfiPhQg==",
       "dev": true,
       "dependencies": {
         "eslint-utils": "^2.1.0",
@@ -3470,12 +3435,6 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "node_modules/fast-safe-stringify": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
-      "dev": true
-    },
     "node_modules/fastq": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
@@ -3722,15 +3681,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/formidable": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
-      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==",
-      "dev": true,
-      "funding": {
-        "url": "https://ko-fi.com/tunnckoCore/commissions"
-      }
-    },
     "node_modules/from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -3842,7 +3792,6 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -3859,7 +3808,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true,
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3869,7 +3817,6 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -4061,9 +4008,9 @@
       }
     },
     "node_modules/got": {
-      "version": "11.8.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.1.tgz",
-      "integrity": "sha512-9aYdZL+6nHmvJwHALLwKSUZ0hMwGaJGYv3hoPLPgnT8BoBXm1SjnZeky+91tfwJaDzun2s4RsBRy48IEYv2q2Q==",
+      "version": "11.8.2",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
+      "integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
       "dev": true,
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
@@ -4195,6 +4142,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4205,9 +4161,9 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -4220,8 +4176,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node_modules/hasha": {
       "version": "5.2.2",
@@ -4305,9 +4260,9 @@
       }
     },
     "node_modules/http2-wrapper": {
-      "version": "1.0.0-beta.5.2",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.0-beta.5.2.tgz",
-      "integrity": "sha512-xYz9goEyBnC8XwXDTuC/MZ6t+MrKVQZOk4s7+PaDkwIsQd8IwqvM+0M6bA/2lvG8GHXcPdf+MejTUeO2LCPCeQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
       "dev": true,
       "dependencies": {
         "quick-lru": "^5.1.1",
@@ -4464,6 +4419,15 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
+    "node_modules/is-bigint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
+      "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -4474,6 +4438,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
+      "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-callable": {
@@ -4564,6 +4543,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-obj": {
@@ -5220,9 +5211,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.0.tgz",
-      "integrity": "sha512-NqRSh2+LlN2NInpqTQnS614Y/3NkVMFFU6sJlRFEpxJ/LHuK/qJECH7/fXZjk4VZstPW/Pevjil/VtSONsLc7Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.1.tgz",
+      "integrity": "sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==",
       "dev": true,
       "bin": {
         "marked": "bin/marked"
@@ -5232,20 +5223,20 @@
       }
     },
     "node_modules/marked-terminal": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-4.1.0.tgz",
-      "integrity": "sha512-5KllfAOW02WS6hLRQ7cNvGOxvKW1BKuXELH4EtbWfyWgxQhROoMxEvuQ/3fTgkNjledR0J48F4HbapvYp1zWkQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-4.1.1.tgz",
+      "integrity": "sha512-t7Mdf6T3PvOEyN01c3tYxDzhyKZ8xnkp8Rs6Fohno63L/0pFTJ5Qtwto2AQVuDtbQiWzD+4E5AAu1Z2iLc8miQ==",
       "dev": true,
       "dependencies": {
         "ansi-escapes": "^4.3.1",
         "cardinal": "^2.1.1",
-        "chalk": "^4.0.0",
+        "chalk": "^4.1.0",
         "cli-table": "^0.3.1",
         "node-emoji": "^1.10.0",
         "supports-hyperlinks": "^2.1.0"
       },
       "peerDependencies": {
-        "marked": ">=0.4.0 <2.0.0"
+        "marked": "^1.0.0 || ^2.0.0"
       }
     },
     "node_modules/memorystream": {
@@ -5504,15 +5495,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/micromatch": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
@@ -5631,9 +5613,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.3.0.tgz",
-      "integrity": "sha512-TQqyC89V1J/Vxx0DhJIXlq9gbbL9XFNdeLQ1+JsnZsVaSOV1z3tWfw0qZmQJGQRIfkvZcs7snQnZnOCKoldq1Q==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.3.1.tgz",
+      "integrity": "sha512-5SBMxANWqOv5bw3Hx+HVgaWlcWcFEQDUdaUAr1AUU+qwtx6cowhn7gEDT/DwQP7uYxnvShdUOVLbTYAHOEGfDQ==",
       "dev": true,
       "dependencies": {
         "@ungap/promise-all-settled": "1.1.2",
@@ -5719,9 +5701,9 @@
       "dev": true
     },
     "node_modules/mocha/node_modules/string-width": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
       "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -6083,239 +6065,7 @@
         "validate-npm-package-name",
         "which",
         "worker-farm",
-        "write-file-atomic",
-        "agent-base",
-        "agentkeepalive",
-        "ansi-align",
-        "ansi-regex",
-        "ansi-styles",
-        "are-we-there-yet",
-        "asap",
-        "asn1",
-        "assert-plus",
-        "asynckit",
-        "aws-sign2",
-        "aws4",
-        "balanced-match",
-        "bcrypt-pbkdf",
-        "boxen",
-        "brace-expansion",
-        "buffer-from",
-        "builtins",
-        "byline",
-        "camelcase",
-        "capture-stack-trace",
-        "caseless",
-        "chalk",
-        "cidr-regex",
-        "cli-boxes",
-        "cliui",
-        "clone",
-        "code-point-at",
-        "color-convert",
-        "color-name",
-        "colors",
-        "combined-stream",
-        "concat-map",
-        "concat-stream",
-        "configstore",
-        "console-control-strings",
-        "copy-concurrently",
-        "core-util-is",
-        "create-error-class",
-        "cross-spawn",
-        "crypto-random-string",
-        "cyclist",
-        "dashdash",
-        "debug",
-        "decamelize",
-        "decode-uri-component",
-        "deep-extend",
-        "defaults",
-        "define-properties",
-        "delayed-stream",
-        "delegates",
-        "dot-prop",
-        "dotenv",
-        "duplexer3",
-        "duplexify",
-        "ecc-jsbn",
-        "emoji-regex",
-        "encoding",
-        "end-of-stream",
-        "env-paths",
-        "err-code",
-        "errno",
-        "es-abstract",
-        "es-to-primitive",
-        "es6-promise",
-        "es6-promisify",
-        "escape-string-regexp",
-        "execa",
-        "extend",
-        "extsprintf",
-        "fast-json-stable-stringify",
-        "flush-write-stream",
-        "forever-agent",
-        "form-data",
-        "from2",
-        "fs-minipass",
-        "fs.realpath",
-        "function-bind",
-        "gauge",
-        "genfun",
-        "get-caller-file",
-        "get-stream",
-        "getpass",
-        "global-dirs",
-        "got",
-        "har-schema",
-        "har-validator",
-        "has",
-        "has-flag",
-        "has-symbols",
-        "http-cache-semantics",
-        "http-proxy-agent",
-        "http-signature",
-        "https-proxy-agent",
-        "humanize-ms",
-        "iconv-lite",
-        "ignore-walk",
-        "import-lazy",
-        "ip",
-        "ip-regex",
-        "is-callable",
-        "is-ci",
-        "is-date-object",
-        "is-fullwidth-code-point",
-        "is-installed-globally",
-        "is-npm",
-        "is-obj",
-        "is-path-inside",
-        "is-redirect",
-        "is-regex",
-        "is-retry-allowed",
-        "is-stream",
-        "is-symbol",
-        "is-typedarray",
-        "isarray",
-        "isexe",
-        "isstream",
-        "jsbn",
-        "json-schema",
-        "json-stringify-safe",
-        "jsonparse",
-        "jsprim",
-        "latest-version",
-        "libnpmconfig",
-        "libnpmpublish",
-        "lodash._createset",
-        "lodash._root",
-        "lowercase-keys",
-        "make-dir",
-        "make-fetch-happen",
-        "mime-db",
-        "mime-types",
-        "minimatch",
-        "minimist",
-        "minizlib",
-        "ms",
-        "mute-stream",
-        "node-fetch-npm",
-        "npm-bundled",
-        "npm-logical-tree",
-        "npm-normalize-package-bin",
-        "npm-run-path",
-        "number-is-nan",
-        "oauth-sign",
-        "object-assign",
-        "object-keys",
-        "object.getownpropertydescriptors",
-        "os-homedir",
-        "os-tmpdir",
-        "p-finally",
-        "package-json",
-        "parallel-transform",
-        "path-exists",
-        "path-is-absolute",
-        "path-key",
-        "path-parse",
-        "performance-now",
-        "pify",
-        "prepend-http",
-        "process-nextick-args",
-        "promise-retry",
-        "promzard",
-        "proto-list",
-        "protoduck",
-        "prr",
-        "pseudomap",
-        "psl",
-        "pump",
-        "pumpify",
-        "punycode",
-        "qs",
-        "rc",
-        "registry-auth-token",
-        "registry-url",
-        "require-directory",
-        "require-main-filename",
-        "resolve-from",
-        "run-queue",
-        "safer-buffer",
-        "semver-diff",
-        "set-blocking",
-        "shebang-command",
-        "shebang-regex",
-        "signal-exit",
-        "smart-buffer",
-        "socks",
-        "socks-proxy-agent",
-        "spdx-correct",
-        "spdx-exceptions",
-        "spdx-expression-parse",
-        "spdx-license-ids",
-        "split-on-first",
-        "sshpk",
-        "stream-each",
-        "stream-iterate",
-        "stream-shift",
-        "strict-uri-encode",
-        "string_decoder",
-        "string-width",
-        "strip-ansi",
-        "strip-eof",
-        "strip-json-comments",
-        "supports-color",
-        "term-size",
-        "through",
-        "through2",
-        "timed-out",
-        "tough-cookie",
-        "tunnel-agent",
-        "tweetnacl",
-        "typedarray",
-        "unique-slug",
-        "unique-string",
-        "unzip-response",
-        "uri-js",
-        "url-parse-lax",
-        "util-deprecate",
-        "util-extend",
-        "util-promisify",
-        "verror",
-        "wcwidth",
-        "which-module",
-        "wide-align",
-        "widest-line",
-        "wrap-ansi",
-        "wrappy",
-        "xdg-basedir",
-        "xtend",
-        "y18n",
-        "yallist",
-        "yargs",
-        "yargs-parser"
+        "write-file-atomic"
       ],
       "dev": true,
       "dependencies": {
@@ -6680,16 +6430,12 @@
     },
     "node_modules/npm/node_modules/abbrev": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/agent-base": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6702,8 +6448,6 @@
     },
     "node_modules/npm/node_modules/agentkeepalive": {
       "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
-      "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6716,8 +6460,6 @@
     },
     "node_modules/npm/node_modules/ansi-align": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6727,8 +6469,6 @@
     },
     "node_modules/npm/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6738,8 +6478,6 @@
     },
     "node_modules/npm/node_modules/ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6752,40 +6490,30 @@
     },
     "node_modules/npm/node_modules/ansicolors": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/ansistyles": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
-      "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/aproba": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/are-we-there-yet": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6796,8 +6524,6 @@
     },
     "node_modules/npm/node_modules/are-we-there-yet/node_modules/readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6813,8 +6539,6 @@
     },
     "node_modules/npm/node_modules/are-we-there-yet/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6824,16 +6548,12 @@
     },
     "node_modules/npm/node_modules/asap": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/asn1": {
       "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6843,8 +6563,6 @@
     },
     "node_modules/npm/node_modules/assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6854,16 +6572,12 @@
     },
     "node_modules/npm/node_modules/asynckit": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -6873,24 +6587,18 @@
     },
     "node_modules/npm/node_modules/aws4": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -6901,8 +6609,6 @@
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-1.1.8.tgz",
-      "integrity": "sha512-KgmVfx+QqggqP9dA3iIc5pA4T1qEEEL+hOhOhNPaUm77OTrJoOXE/C05SJLNJe6m/2wUK7F1tDSou7n5TfCDzQ==",
       "dev": true,
       "inBundle": true,
       "license": "Artistic-2.0",
@@ -6917,16 +6623,12 @@
     },
     "node_modules/npm/node_modules/bluebird": {
       "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/boxen": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6945,8 +6647,6 @@
     },
     "node_modules/npm/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6957,24 +6657,18 @@
     },
     "node_modules/npm/node_modules/buffer-from": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/builtins": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/byline": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-      "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6984,8 +6678,6 @@
     },
     "node_modules/npm/node_modules/byte-size": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-5.0.1.tgz",
-      "integrity": "sha512-/XuKeqWocKsYa/cBY1YbSJSWWqTi4cFgr9S6OyM7PBaPbr9zvNGwWP33vt0uqGhwDdN+y3yhbXVILEUpnwEWGw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6995,8 +6687,6 @@
     },
     "node_modules/npm/node_modules/cacache": {
       "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
-      "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7020,16 +6710,12 @@
     },
     "node_modules/npm/node_modules/call-limit": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/call-limit/-/call-limit-1.1.1.tgz",
-      "integrity": "sha512-5twvci5b9eRBw2wCfPtN0GmlR2/gadZqyFpPhOK6CvMFoFgA+USnZ6Jpu1lhG9h85pQ3Ouil3PfXWRD4EUaRiQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/camelcase": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7039,8 +6725,6 @@
     },
     "node_modules/npm/node_modules/capture-stack-trace": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7050,16 +6734,12 @@
     },
     "node_modules/npm/node_modules/caseless": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/npm/node_modules/chalk": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7074,24 +6754,18 @@
     },
     "node_modules/npm/node_modules/chownr": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/ci-info": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/cidr-regex": {
       "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-2.0.10.tgz",
-      "integrity": "sha512-sB3ogMQXWvreNPbJUZMRApxuRYd+KoIo4RGQ81VatjmMW6WJPo+IJZ2846FGItr9VzKo5w7DXzijPLGtSd0N3Q==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -7104,8 +6778,6 @@
     },
     "node_modules/npm/node_modules/cli-boxes": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7115,8 +6787,6 @@
     },
     "node_modules/npm/node_modules/cli-columns": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cli-columns/-/cli-columns-3.1.2.tgz",
-      "integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7130,8 +6800,6 @@
     },
     "node_modules/npm/node_modules/cli-table3": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
-      "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7148,8 +6816,6 @@
     },
     "node_modules/npm/node_modules/cliui": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7161,8 +6827,6 @@
     },
     "node_modules/npm/node_modules/cliui/node_modules/ansi-regex": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7172,8 +6836,6 @@
     },
     "node_modules/npm/node_modules/cliui/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7183,8 +6845,6 @@
     },
     "node_modules/npm/node_modules/cliui/node_modules/string-width": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7199,8 +6859,6 @@
     },
     "node_modules/npm/node_modules/cliui/node_modules/strip-ansi": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7213,8 +6871,6 @@
     },
     "node_modules/npm/node_modules/clone": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7224,8 +6880,6 @@
     },
     "node_modules/npm/node_modules/cmd-shim": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-3.0.3.tgz",
-      "integrity": "sha512-DtGg+0xiFhQIntSBRzL2fRQBnmtAVwXIDo4Qq46HPpObYquxMaZS4sb82U9nH91qJrlosC1wa9gwr0QyL/HypA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7236,8 +6890,6 @@
     },
     "node_modules/npm/node_modules/code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7247,8 +6899,6 @@
     },
     "node_modules/npm/node_modules/color-convert": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7258,16 +6908,12 @@
     },
     "node_modules/npm/node_modules/color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/colors": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7278,8 +6924,6 @@
     },
     "node_modules/npm/node_modules/columnify": {
       "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
-      "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7290,8 +6934,6 @@
     },
     "node_modules/npm/node_modules/combined-stream": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7304,16 +6946,12 @@
     },
     "node_modules/npm/node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/concat-stream": {
       "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "engines": [
         "node >= 0.8"
@@ -7329,8 +6967,6 @@
     },
     "node_modules/npm/node_modules/concat-stream/node_modules/readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7346,8 +6982,6 @@
     },
     "node_modules/npm/node_modules/concat-stream/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7357,8 +6991,6 @@
     },
     "node_modules/npm/node_modules/config-chain": {
       "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
-      "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
       "dev": true,
       "inBundle": true,
       "dependencies": {
@@ -7368,8 +7000,6 @@
     },
     "node_modules/npm/node_modules/configstore": {
       "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.5.tgz",
-      "integrity": "sha512-nlOhI4+fdzoK5xmJ+NY+1gZK56bwEaWZr8fYuXohZ9Vkc1o3a4T/R3M+yE/w7x/ZVJ1zF8c+oaOvF0dztdUgmA==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -7387,16 +7017,12 @@
     },
     "node_modules/npm/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/copy-concurrently": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
-      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7411,32 +7037,24 @@
     },
     "node_modules/npm/node_modules/copy-concurrently/node_modules/aproba": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/copy-concurrently/node_modules/iferr": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/create-error-class": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7449,8 +7067,6 @@
     },
     "node_modules/npm/node_modules/cross-spawn": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7462,8 +7078,6 @@
     },
     "node_modules/npm/node_modules/cross-spawn/node_modules/lru-cache": {
       "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7474,16 +7088,12 @@
     },
     "node_modules/npm/node_modules/cross-spawn/node_modules/yallist": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/crypto-random-string": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7493,15 +7103,11 @@
     },
     "node_modules/npm/node_modules/cyclist": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
       "dev": true,
       "inBundle": true
     },
     "node_modules/npm/node_modules/dashdash": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7514,8 +7120,6 @@
     },
     "node_modules/npm/node_modules/debug": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7525,16 +7129,12 @@
     },
     "node_modules/npm/node_modules/debug/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/debuglog": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7544,8 +7144,6 @@
     },
     "node_modules/npm/node_modules/decamelize": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7555,8 +7153,6 @@
     },
     "node_modules/npm/node_modules/decode-uri-component": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7566,8 +7162,6 @@
     },
     "node_modules/npm/node_modules/deep-extend": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7577,8 +7171,6 @@
     },
     "node_modules/npm/node_modules/defaults": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7588,8 +7180,6 @@
     },
     "node_modules/npm/node_modules/define-properties": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7602,8 +7192,6 @@
     },
     "node_modules/npm/node_modules/delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7613,16 +7201,12 @@
     },
     "node_modules/npm/node_modules/delegates": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/detect-indent": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-      "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7632,8 +7216,6 @@
     },
     "node_modules/npm/node_modules/detect-newline": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7643,8 +7225,6 @@
     },
     "node_modules/npm/node_modules/dezalgo": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7655,8 +7235,6 @@
     },
     "node_modules/npm/node_modules/dot-prop": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
-      "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7669,8 +7247,6 @@
     },
     "node_modules/npm/node_modules/dotenv": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
-      "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -7680,16 +7256,12 @@
     },
     "node_modules/npm/node_modules/duplexer3": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/npm/node_modules/duplexify": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
-      "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7702,8 +7274,6 @@
     },
     "node_modules/npm/node_modules/duplexify/node_modules/readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7719,8 +7289,6 @@
     },
     "node_modules/npm/node_modules/duplexify/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7730,8 +7298,6 @@
     },
     "node_modules/npm/node_modules/ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7743,24 +7309,18 @@
     },
     "node_modules/npm/node_modules/editor": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
-      "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/encoding": {
       "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7770,8 +7330,6 @@
     },
     "node_modules/npm/node_modules/end-of-stream": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7781,8 +7339,6 @@
     },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
-      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7792,16 +7348,12 @@
     },
     "node_modules/npm/node_modules/err-code": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/errno": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7814,8 +7366,6 @@
     },
     "node_modules/npm/node_modules/es-abstract": {
       "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7832,8 +7382,6 @@
     },
     "node_modules/npm/node_modules/es-to-primitive": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7848,16 +7396,12 @@
     },
     "node_modules/npm/node_modules/es6-promise": {
       "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7867,8 +7411,6 @@
     },
     "node_modules/npm/node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7878,8 +7420,6 @@
     },
     "node_modules/npm/node_modules/execa": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7898,8 +7438,6 @@
     },
     "node_modules/npm/node_modules/execa/node_modules/get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7909,16 +7447,12 @@
     },
     "node_modules/npm/node_modules/extend": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true,
       "engines": [
         "node >=0.6.0"
@@ -7928,32 +7462,24 @@
     },
     "node_modules/npm/node_modules/fast-json-stable-stringify": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/figgy-pudding": {
       "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-      "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/find-npm-prefix": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz",
-      "integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/flush-write-stream": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
-      "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7964,8 +7490,6 @@
     },
     "node_modules/npm/node_modules/flush-write-stream/node_modules/readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7981,8 +7505,6 @@
     },
     "node_modules/npm/node_modules/flush-write-stream/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7992,8 +7514,6 @@
     },
     "node_modules/npm/node_modules/forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -8003,8 +7523,6 @@
     },
     "node_modules/npm/node_modules/form-data": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8019,8 +7537,6 @@
     },
     "node_modules/npm/node_modules/from2": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8031,8 +7547,6 @@
     },
     "node_modules/npm/node_modules/from2/node_modules/readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8048,8 +7562,6 @@
     },
     "node_modules/npm/node_modules/from2/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8059,8 +7571,6 @@
     },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8070,8 +7580,6 @@
     },
     "node_modules/npm/node_modules/fs-minipass/node_modules/minipass": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8082,8 +7590,6 @@
     },
     "node_modules/npm/node_modules/fs-vacuum": {
       "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
-      "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8095,8 +7601,6 @@
     },
     "node_modules/npm/node_modules/fs-write-stream-atomic": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
-      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8109,16 +7613,12 @@
     },
     "node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/iferr": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8134,8 +7634,6 @@
     },
     "node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8145,24 +7643,18 @@
     },
     "node_modules/npm/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/function-bind": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/gauge": {
       "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8179,16 +7671,12 @@
     },
     "node_modules/npm/node_modules/gauge/node_modules/aproba": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/gauge/node_modules/string-width": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8203,16 +7691,12 @@
     },
     "node_modules/npm/node_modules/genfun": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
-      "integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/gentle-fs": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/gentle-fs/-/gentle-fs-2.3.1.tgz",
-      "integrity": "sha512-OlwBBwqCFPcjm33rF2BjW+Pr6/ll2741l+xooiwTCeaX2CA1ZuclavyMBe0/KlR21/XGsgY6hzEQZ15BdNa13Q==",
       "dev": true,
       "inBundle": true,
       "license": "Artistic-2.0",
@@ -8232,24 +7716,18 @@
     },
     "node_modules/npm/node_modules/gentle-fs/node_modules/aproba": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/gentle-fs/node_modules/iferr": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8259,8 +7737,6 @@
     },
     "node_modules/npm/node_modules/get-stream": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8273,8 +7749,6 @@
     },
     "node_modules/npm/node_modules/getpass": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8284,8 +7758,6 @@
     },
     "node_modules/npm/node_modules/glob": {
       "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8306,8 +7778,6 @@
     },
     "node_modules/npm/node_modules/global-dirs": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8320,8 +7790,6 @@
     },
     "node_modules/npm/node_modules/got": {
       "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8344,8 +7812,6 @@
     },
     "node_modules/npm/node_modules/got/node_modules/get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8355,16 +7821,12 @@
     },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/har-schema": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8374,8 +7836,6 @@
     },
     "node_modules/npm/node_modules/har-validator": {
       "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "deprecated": "this library is no longer supported",
       "dev": true,
       "inBundle": true,
@@ -8390,8 +7850,6 @@
     },
     "node_modules/npm/node_modules/har-validator/node_modules/ajv": {
       "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8408,24 +7866,18 @@
     },
     "node_modules/npm/node_modules/har-validator/node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/har-validator/node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/has": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8438,8 +7890,6 @@
     },
     "node_modules/npm/node_modules/has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8449,8 +7899,6 @@
     },
     "node_modules/npm/node_modules/has-symbols": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8460,32 +7908,24 @@
     },
     "node_modules/npm/node_modules/has-unicode": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
       "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8499,8 +7939,6 @@
     },
     "node_modules/npm/node_modules/http-signature": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8516,8 +7954,6 @@
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
       "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8531,8 +7967,6 @@
     },
     "node_modules/npm/node_modules/humanize-ms": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8542,8 +7976,6 @@
     },
     "node_modules/npm/node_modules/iconv-lite": {
       "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8556,8 +7988,6 @@
     },
     "node_modules/npm/node_modules/iferr": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/iferr/-/iferr-1.0.2.tgz",
-      "integrity": "sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8567,8 +7997,6 @@
     },
     "node_modules/npm/node_modules/ignore-walk": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8578,8 +8006,6 @@
     },
     "node_modules/npm/node_modules/import-lazy": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8589,8 +8015,6 @@
     },
     "node_modules/npm/node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8600,16 +8024,12 @@
     },
     "node_modules/npm/node_modules/infer-owner": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8620,24 +8040,18 @@
     },
     "node_modules/npm/node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/ini": {
       "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/init-package-json": {
       "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.3.tgz",
-      "integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8654,16 +8068,12 @@
     },
     "node_modules/npm/node_modules/ip": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/ip-regex": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8673,8 +8083,6 @@
     },
     "node_modules/npm/node_modules/is-callable": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8684,8 +8092,6 @@
     },
     "node_modules/npm/node_modules/is-ci": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8698,16 +8104,12 @@
     },
     "node_modules/npm/node_modules/is-ci/node_modules/ci-info": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/is-cidr": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-3.0.0.tgz",
-      "integrity": "sha512-8Xnnbjsb0x462VoYiGlhEi+drY8SFwrHiSYuzc/CEwco55vkehTaxAyIjEdpi3EMvLPPJAJi9FlzP+h+03gp0Q==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -8720,8 +8122,6 @@
     },
     "node_modules/npm/node_modules/is-date-object": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8731,8 +8131,6 @@
     },
     "node_modules/npm/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8745,8 +8143,6 @@
     },
     "node_modules/npm/node_modules/is-installed-globally": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
-      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8760,8 +8156,6 @@
     },
     "node_modules/npm/node_modules/is-npm": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8771,8 +8165,6 @@
     },
     "node_modules/npm/node_modules/is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8782,8 +8174,6 @@
     },
     "node_modules/npm/node_modules/is-path-inside": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8796,8 +8186,6 @@
     },
     "node_modules/npm/node_modules/is-redirect": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8807,8 +8195,6 @@
     },
     "node_modules/npm/node_modules/is-regex": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8821,8 +8207,6 @@
     },
     "node_modules/npm/node_modules/is-retry-allowed": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8832,8 +8216,6 @@
     },
     "node_modules/npm/node_modules/is-stream": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8843,8 +8225,6 @@
     },
     "node_modules/npm/node_modules/is-symbol": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8857,40 +8237,30 @@
     },
     "node_modules/npm/node_modules/is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/isstream": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/jsbn": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8898,31 +8268,23 @@
     },
     "node_modules/npm/node_modules/json-parse-better-errors": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/json-schema": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true,
       "inBundle": true
     },
     "node_modules/npm/node_modules/json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true,
       "engines": [
         "node >= 0.2.0"
@@ -8932,8 +8294,6 @@
     },
     "node_modules/npm/node_modules/JSONStream": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
       "dev": true,
       "inBundle": true,
       "license": "(MIT OR Apache-2.0)",
@@ -8950,8 +8310,6 @@
     },
     "node_modules/npm/node_modules/jsprim": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
       "engines": [
         "node >=0.6.0"
@@ -8967,8 +8325,6 @@
     },
     "node_modules/npm/node_modules/latest-version": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8981,16 +8337,12 @@
     },
     "node_modules/npm/node_modules/lazy-property": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lazy-property/-/lazy-property-1.0.0.tgz",
-      "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libcipm": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/libcipm/-/libcipm-4.0.8.tgz",
-      "integrity": "sha512-IN3hh2yDJQtZZ5paSV4fbvJg4aHxCCg5tcZID/dSVlTuUiWktsgaldVljJv6Z5OUlYspx6xQkbR0efNodnIrOA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9014,8 +8366,6 @@
     },
     "node_modules/npm/node_modules/libnpm": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/libnpm/-/libnpm-3.0.1.tgz",
-      "integrity": "sha512-d7jU5ZcMiTfBqTUJVZ3xid44fE5ERBm9vBnmhp2ECD2Ls+FNXWxHSkO7gtvrnbLO78gwPdNPz1HpsF3W4rjkBQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9044,8 +8394,6 @@
     },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-3.0.2.tgz",
-      "integrity": "sha512-01512AK7MqByrI2mfC7h5j8N9V4I7MHJuk9buo8Gv+5QgThpOgpjB7sQBDDkeZqRteFb1QM/6YNdHfG7cDvfAQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9058,8 +8406,6 @@
     },
     "node_modules/npm/node_modules/libnpmconfig": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/libnpmconfig/-/libnpmconfig-1.2.1.tgz",
-      "integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9071,8 +8417,6 @@
     },
     "node_modules/npm/node_modules/libnpmconfig/node_modules/find-up": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9085,8 +8429,6 @@
     },
     "node_modules/npm/node_modules/libnpmconfig/node_modules/locate-path": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9100,8 +8442,6 @@
     },
     "node_modules/npm/node_modules/libnpmconfig/node_modules/p-limit": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9114,8 +8454,6 @@
     },
     "node_modules/npm/node_modules/libnpmconfig/node_modules/p-locate": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9128,8 +8466,6 @@
     },
     "node_modules/npm/node_modules/libnpmconfig/node_modules/p-try": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9139,8 +8475,6 @@
     },
     "node_modules/npm/node_modules/libnpmhook": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/libnpmhook/-/libnpmhook-5.0.3.tgz",
-      "integrity": "sha512-UdNLMuefVZra/wbnBXECZPefHMGsVDTq5zaM/LgKNE9Keyl5YXQTnGAzEo+nFOpdRqTWI9LYi4ApqF9uVCCtuA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9153,8 +8487,6 @@
     },
     "node_modules/npm/node_modules/libnpmorg": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/libnpmorg/-/libnpmorg-1.0.1.tgz",
-      "integrity": "sha512-0sRUXLh+PLBgZmARvthhYXQAWn0fOsa6T5l3JSe2n9vKG/lCVK4nuG7pDsa7uMq+uTt2epdPK+a2g6btcY11Ww==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9167,8 +8499,6 @@
     },
     "node_modules/npm/node_modules/libnpmpublish": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-1.1.2.tgz",
-      "integrity": "sha512-2yIwaXrhTTcF7bkJKIKmaCV9wZOALf/gsTDxVSu/Gu/6wiG3fA8ce8YKstiWKTxSFNC0R7isPUb6tXTVFZHt2g==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9186,8 +8516,6 @@
     },
     "node_modules/npm/node_modules/libnpmsearch": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/libnpmsearch/-/libnpmsearch-2.0.2.tgz",
-      "integrity": "sha512-VTBbV55Q6fRzTdzziYCr64+f8AopQ1YZ+BdPOv16UegIEaE8C0Kch01wo4s3kRTFV64P121WZJwgmBwrq68zYg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9199,8 +8527,6 @@
     },
     "node_modules/npm/node_modules/libnpmteam": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/libnpmteam/-/libnpmteam-1.0.2.tgz",
-      "integrity": "sha512-p420vM28Us04NAcg1rzgGW63LMM6rwe+6rtZpfDxCcXxM0zUTLl7nPFEnRF3JfFBF5skF/yuZDUthTsHgde8QA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9213,8 +8539,6 @@
     },
     "node_modules/npm/node_modules/libnpx": {
       "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/libnpx/-/libnpx-10.2.4.tgz",
-      "integrity": "sha512-BPc0D1cOjBeS8VIBKUu5F80s6njm0wbVt7CsGMrIcJ+SI7pi7V0uVPGpEMH9H5L8csOcclTxAXFE2VAsJXUhfA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9234,8 +8558,6 @@
     },
     "node_modules/npm/node_modules/lock-verify": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/lock-verify/-/lock-verify-2.1.0.tgz",
-      "integrity": "sha512-vcLpxnGvrqisKvLQ2C2v0/u7LVly17ak2YSgoK4PrdsYBXQIax19vhKiLfvKNFx7FRrpTnitrpzF/uuCMuorIg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9246,8 +8568,6 @@
     },
     "node_modules/npm/node_modules/lockfile": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
-      "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9257,16 +8577,12 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
-      "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._baseuniq": {
       "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
-      "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9277,24 +8593,18 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
-      "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
-      "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9304,72 +8614,54 @@
     },
     "node_modules/npm/node_modules/lodash._createset": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
-      "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._root": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash.clonedeep": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash.union": {
       "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash.uniq": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash.without": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
-      "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lowercase-keys": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9379,8 +8671,6 @@
     },
     "node_modules/npm/node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9390,8 +8680,6 @@
     },
     "node_modules/npm/node_modules/make-dir": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9404,8 +8692,6 @@
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
       "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.2.tgz",
-      "integrity": "sha512-07JHC0r1ykIoruKO8ifMXu+xEU8qOXDFETylktdug6vJDACnP+HKevOu3PXyNPzFyTSlz8vrBYlBO1JZRe8Cag==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9425,16 +8711,12 @@
     },
     "node_modules/npm/node_modules/meant": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/meant/-/meant-1.0.2.tgz",
-      "integrity": "sha512-KN+1uowN/NK+sT/Lzx7WSGIj2u+3xe5n2LbwObfjOhPZiA+cCfCm6idVl0RkEfjThkw5XJ96CyRcanq6GmKtUg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mime-db": {
       "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
-      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9444,8 +8726,6 @@
     },
     "node_modules/npm/node_modules/mime-types": {
       "version": "2.1.19",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
-      "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9458,8 +8738,6 @@
     },
     "node_modules/npm/node_modules/minimatch": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9472,16 +8750,12 @@
     },
     "node_modules/npm/node_modules/minimist": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/minizlib": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9491,8 +8765,6 @@
     },
     "node_modules/npm/node_modules/minizlib/node_modules/minipass": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9503,8 +8775,6 @@
     },
     "node_modules/npm/node_modules/mississippi": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
-      "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -9526,8 +8796,6 @@
     },
     "node_modules/npm/node_modules/mkdirp": {
       "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9540,16 +8808,12 @@
     },
     "node_modules/npm/node_modules/mkdirp/node_modules/minimist": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/move-concurrently": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
-      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9564,32 +8828,24 @@
     },
     "node_modules/npm/node_modules/move-concurrently/node_modules/aproba": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/ms": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/node-fetch-npm": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
-      "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9604,8 +8860,6 @@
     },
     "node_modules/npm/node_modules/node-gyp": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.1.0.tgz",
-      "integrity": "sha512-OUTryc5bt/P8zVgNUmC6xdXiDJxLMAW8cF5tLQOT9E5sOQj+UeQxnnPy74K3CLCa/SOjjBlbuzDLR8ANwA+wmw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9631,8 +8885,6 @@
     },
     "node_modules/npm/node_modules/nopt": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-      "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9646,8 +8898,6 @@
     },
     "node_modules/npm/node_modules/normalize-package-data": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -9660,8 +8910,6 @@
     },
     "node_modules/npm/node_modules/normalize-package-data/node_modules/resolve": {
       "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9671,8 +8919,6 @@
     },
     "node_modules/npm/node_modules/npm-audit-report": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/npm-audit-report/-/npm-audit-report-1.3.3.tgz",
-      "integrity": "sha512-8nH/JjsFfAWMvn474HB9mpmMjrnKb1Hx/oTAdjv4PT9iZBvBxiZ+wtDUapHCJwLqYGQVPaAfs+vL5+5k9QndXw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9683,8 +8929,6 @@
     },
     "node_modules/npm/node_modules/npm-bundled": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
-      "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9694,16 +8938,12 @@
     },
     "node_modules/npm/node_modules/npm-cache-filename": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
-      "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/npm-install-checks": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.2.tgz",
-      "integrity": "sha512-E4kzkyZDIWoin6uT5howP8VDvkM+E8IQDcHAycaAxMbwkqhIg5eEYALnXOl3Hq9MrkdQB/2/g1xwBINXdKSRkg==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -9713,8 +8953,6 @@
     },
     "node_modules/npm/node_modules/npm-lifecycle": {
       "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-3.1.5.tgz",
-      "integrity": "sha512-lDLVkjfZmvmfvpvBzA4vzee9cn+Me4orq0QF8glbswJVEbIcSNWib7qGOffolysc3teCqbbPZZkzbr3GQZTL1g==",
       "dev": true,
       "inBundle": true,
       "license": "Artistic-2.0",
@@ -9731,24 +8969,18 @@
     },
     "node_modules/npm/node_modules/npm-logical-tree": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/npm-logical-tree/-/npm-logical-tree-1.2.1.tgz",
-      "integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/npm-package-arg": {
       "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.1.tgz",
-      "integrity": "sha512-qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9761,8 +8993,6 @@
     },
     "node_modules/npm/node_modules/npm-packlist": {
       "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
-      "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9774,8 +9004,6 @@
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-3.0.2.tgz",
-      "integrity": "sha512-wNprTNg+X5nf+tDi+hbjdHhM4bX+mKqv6XmPh7B5eG+QY9VARfQPfCEH013H5GqfNj6ee8Ij2fg8yk0mzps1Vw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9787,8 +9015,6 @@
     },
     "node_modules/npm/node_modules/npm-profile": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/npm-profile/-/npm-profile-4.0.4.tgz",
-      "integrity": "sha512-Ta8xq8TLMpqssF0H60BXS1A90iMoM6GeKwsmravJ6wYjWwSzcYBTdyWa3DZCYqPutacBMEm7cxiOkiIeCUAHDQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9800,8 +9026,6 @@
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
       "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-4.0.7.tgz",
-      "integrity": "sha512-cny9v0+Mq6Tjz+e0erFAB+RYJ/AVGzkjnISiobqP8OWj9c9FLoZZu8/SPSKJWE17F1tk4018wfjV+ZbIbqC7fQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9817,8 +9041,6 @@
     },
     "node_modules/npm/node_modules/npm-registry-fetch/node_modules/safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true,
       "funding": [
         {
@@ -9839,8 +9061,6 @@
     },
     "node_modules/npm/node_modules/npm-run-path": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9853,16 +9073,12 @@
     },
     "node_modules/npm/node_modules/npm-user-validate": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.1.tgz",
-      "integrity": "sha512-uQwcd/tY+h1jnEaze6cdX/LrhWhoBxfSknxentoqmIuStxUExxjWd3ULMLFPiFUrZKbOVMowH6Jq2FRWfmhcEw==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/npmlog": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9875,8 +9091,6 @@
     },
     "node_modules/npm/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9886,8 +9100,6 @@
     },
     "node_modules/npm/node_modules/oauth-sign": {
       "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -9897,8 +9109,6 @@
     },
     "node_modules/npm/node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9908,8 +9118,6 @@
     },
     "node_modules/npm/node_modules/object-keys": {
       "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9919,8 +9127,6 @@
     },
     "node_modules/npm/node_modules/object.getownpropertydescriptors": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9934,8 +9140,6 @@
     },
     "node_modules/npm/node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9945,8 +9149,6 @@
     },
     "node_modules/npm/node_modules/opener": {
       "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
-      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
       "dev": true,
       "inBundle": true,
       "license": "(WTFPL OR MIT)",
@@ -9956,8 +9158,6 @@
     },
     "node_modules/npm/node_modules/os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9967,8 +9167,6 @@
     },
     "node_modules/npm/node_modules/os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9978,8 +9176,6 @@
     },
     "node_modules/npm/node_modules/osenv": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9990,8 +9186,6 @@
     },
     "node_modules/npm/node_modules/p-finally": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10001,8 +9195,6 @@
     },
     "node_modules/npm/node_modules/package-json": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10018,8 +9210,6 @@
     },
     "node_modules/npm/node_modules/pacote": {
       "version": "9.5.12",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-9.5.12.tgz",
-      "integrity": "sha512-BUIj/4kKbwWg4RtnBncXPJd15piFSVNpTzY0rysSr3VnMowTYgkGKcaHrbReepAkjTr8lH2CVWRi58Spg2CicQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10058,8 +9248,6 @@
     },
     "node_modules/npm/node_modules/pacote/node_modules/minipass": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10070,8 +9258,6 @@
     },
     "node_modules/npm/node_modules/parallel-transform": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
-      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10083,8 +9269,6 @@
     },
     "node_modules/npm/node_modules/parallel-transform/node_modules/readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10100,8 +9284,6 @@
     },
     "node_modules/npm/node_modules/parallel-transform/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10111,8 +9293,6 @@
     },
     "node_modules/npm/node_modules/path-exists": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10122,8 +9302,6 @@
     },
     "node_modules/npm/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10133,16 +9311,12 @@
     },
     "node_modules/npm/node_modules/path-is-inside": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true,
       "inBundle": true,
       "license": "(WTFPL OR MIT)"
     },
     "node_modules/npm/node_modules/path-key": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10152,24 +9326,18 @@
     },
     "node_modules/npm/node_modules/path-parse": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/performance-now": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/pify": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10179,8 +9347,6 @@
     },
     "node_modules/npm/node_modules/prepend-http": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10190,24 +9356,18 @@
     },
     "node_modules/npm/node_modules/process-nextick-args": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/promise-inflight": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/promise-retry": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
-      "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10221,8 +9381,6 @@
     },
     "node_modules/npm/node_modules/promise-retry/node_modules/retry": {
       "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-      "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10232,8 +9390,6 @@
     },
     "node_modules/npm/node_modules/promzard": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
-      "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10243,16 +9399,12 @@
     },
     "node_modules/npm/node_modules/proto-list": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/protoduck": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.1.tgz",
-      "integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10262,32 +9414,24 @@
     },
     "node_modules/npm/node_modules/prr": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/psl": {
       "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/pump": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10298,8 +9442,6 @@
     },
     "node_modules/npm/node_modules/pumpify": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10311,8 +9453,6 @@
     },
     "node_modules/npm/node_modules/pumpify/node_modules/pump": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10323,16 +9463,12 @@
     },
     "node_modules/npm/node_modules/punycode": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
-      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
       "dev": true,
       "inBundle": true,
       "bin": {
@@ -10341,8 +9477,6 @@
     },
     "node_modules/npm/node_modules/qs": {
       "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -10352,8 +9486,6 @@
     },
     "node_modules/npm/node_modules/query-string": {
       "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.2.tgz",
-      "integrity": "sha512-J3Qi8XZJXh93t2FiKyd/7Ec6GNifsjKXUsVFkSBj/kjLsDylWhnCz4NT1bkPcKotttPW+QbKGqqPH8OoI2pdqw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10368,16 +9500,12 @@
     },
     "node_modules/npm/node_modules/qw": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/qw/-/qw-1.0.1.tgz",
-      "integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/rc": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
@@ -10393,8 +9521,6 @@
     },
     "node_modules/npm/node_modules/read": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10407,8 +9533,6 @@
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.5.tgz",
-      "integrity": "sha512-v5yCqQ/7okKoZZkBQUAfTsQ3sVJtXdNfbPnI5cceppoxEVLYA3k+VtV2omkeo8MS94JCy4fSiUwlRBAwCVRPUA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10418,8 +9542,6 @@
     },
     "node_modules/npm/node_modules/read-installed": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
-      "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10437,8 +9559,6 @@
     },
     "node_modules/npm/node_modules/read-package-json": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.1.tgz",
-      "integrity": "sha512-dAiqGtVc/q5doFz6096CcnXhpYk0ZN8dEKVkGLU0CsASt8SrgF6SF7OTKAYubfvFhWaqofl+Y8HK19GR8jwW+A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10454,8 +9574,6 @@
     },
     "node_modules/npm/node_modules/read-package-tree": {
       "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.3.1.tgz",
-      "integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10467,8 +9585,6 @@
     },
     "node_modules/npm/node_modules/readable-stream": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10483,8 +9599,6 @@
     },
     "node_modules/npm/node_modules/readdir-scoped-modules": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
-      "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10497,8 +9611,6 @@
     },
     "node_modules/npm/node_modules/registry-auth-token": {
       "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
-      "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10509,8 +9621,6 @@
     },
     "node_modules/npm/node_modules/registry-url": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10523,8 +9633,6 @@
     },
     "node_modules/npm/node_modules/request": {
       "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -10556,8 +9664,6 @@
     },
     "node_modules/npm/node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10567,16 +9673,12 @@
     },
     "node_modules/npm/node_modules/require-main-filename": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10586,8 +9688,6 @@
     },
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10597,8 +9697,6 @@
     },
     "node_modules/npm/node_modules/rimraf": {
       "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10611,8 +9709,6 @@
     },
     "node_modules/npm/node_modules/run-queue": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
-      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10622,32 +9718,24 @@
     },
     "node_modules/npm/node_modules/run-queue/node_modules/aproba": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/semver": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10657,8 +9745,6 @@
     },
     "node_modules/npm/node_modules/semver-diff": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10671,16 +9757,12 @@
     },
     "node_modules/npm/node_modules/set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/sha": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/sha/-/sha-3.0.0.tgz",
-      "integrity": "sha512-DOYnM37cNsLNSGIG/zZWch5CKIRNoLdYUQTQlcgkRkoYIUwDYjqDyye16YcDZg/OPdcbUgTKMjc4SY6TB7ZAPw==",
       "dev": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT)",
@@ -10690,8 +9772,6 @@
     },
     "node_modules/npm/node_modules/shebang-command": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10704,8 +9784,6 @@
     },
     "node_modules/npm/node_modules/shebang-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10715,16 +9793,12 @@
     },
     "node_modules/npm/node_modules/signal-exit": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/slide": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10734,8 +9808,6 @@
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
-      "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10746,8 +9818,6 @@
     },
     "node_modules/npm/node_modules/socks": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
-      "integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10762,8 +9832,6 @@
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
-      "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10777,8 +9845,6 @@
     },
     "node_modules/npm/node_modules/socks-proxy-agent/node_modules/agent-base": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10791,16 +9857,12 @@
     },
     "node_modules/npm/node_modules/sorted-object": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
-      "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
       "dev": true,
       "inBundle": true,
       "license": "(WTFPL OR MIT)"
     },
     "node_modules/npm/node_modules/sorted-union-stream": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
-      "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10811,8 +9873,6 @@
     },
     "node_modules/npm/node_modules/sorted-union-stream/node_modules/from2": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
-      "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10823,16 +9883,12 @@
     },
     "node_modules/npm/node_modules/sorted-union-stream/node_modules/isarray": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/sorted-union-stream/node_modules/readable-stream": {
       "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10845,16 +9901,12 @@
     },
     "node_modules/npm/node_modules/sorted-union-stream/node_modules/string_decoder": {
       "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/spdx-correct": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -10865,16 +9917,12 @@
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
       "dev": true,
       "inBundle": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10885,16 +9933,12 @@
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/split-on-first": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10904,8 +9948,6 @@
     },
     "node_modules/npm/node_modules/sshpk": {
       "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10933,8 +9975,6 @@
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10944,8 +9984,6 @@
     },
     "node_modules/npm/node_modules/stream-each": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
-      "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10956,8 +9994,6 @@
     },
     "node_modules/npm/node_modules/stream-iterate": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
-      "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10968,8 +10004,6 @@
     },
     "node_modules/npm/node_modules/stream-iterate/node_modules/readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10985,8 +10019,6 @@
     },
     "node_modules/npm/node_modules/stream-iterate/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10996,16 +10028,12 @@
     },
     "node_modules/npm/node_modules/stream-shift": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/strict-uri-encode": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11015,8 +10043,6 @@
     },
     "node_modules/npm/node_modules/string_decoder": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11026,16 +10052,12 @@
     },
     "node_modules/npm/node_modules/string_decoder/node_modules/safe-buffer": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/string-width": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11049,8 +10071,6 @@
     },
     "node_modules/npm/node_modules/string-width/node_modules/ansi-regex": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11060,8 +10080,6 @@
     },
     "node_modules/npm/node_modules/string-width/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11071,8 +10089,6 @@
     },
     "node_modules/npm/node_modules/string-width/node_modules/strip-ansi": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11085,16 +10101,12 @@
     },
     "node_modules/npm/node_modules/stringify-package": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.1.tgz",
-      "integrity": "sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11107,8 +10119,6 @@
     },
     "node_modules/npm/node_modules/strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11118,8 +10128,6 @@
     },
     "node_modules/npm/node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11129,8 +10137,6 @@
     },
     "node_modules/npm/node_modules/supports-color": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11143,8 +10149,6 @@
     },
     "node_modules/npm/node_modules/tar": {
       "version": "4.4.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11163,8 +10167,6 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/minipass": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11175,8 +10177,6 @@
     },
     "node_modules/npm/node_modules/term-size": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11189,24 +10189,18 @@
     },
     "node_modules/npm/node_modules/text-table": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/through2": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11217,8 +10211,6 @@
     },
     "node_modules/npm/node_modules/through2/node_modules/readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11234,8 +10226,6 @@
     },
     "node_modules/npm/node_modules/through2/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11245,8 +10235,6 @@
     },
     "node_modules/npm/node_modules/timed-out": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11256,16 +10244,12 @@
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tiny-relative-date/-/tiny-relative-date-1.3.0.tgz",
-      "integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tough-cookie": {
       "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -11279,8 +10263,6 @@
     },
     "node_modules/npm/node_modules/tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -11293,8 +10275,6 @@
     },
     "node_modules/npm/node_modules/tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true,
       "inBundle": true,
       "license": "Unlicense",
@@ -11302,16 +10282,12 @@
     },
     "node_modules/npm/node_modules/typedarray": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/uid-number": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-      "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11321,16 +10297,12 @@
     },
     "node_modules/npm/node_modules/umask": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
-      "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/unique-filename": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11340,8 +10312,6 @@
     },
     "node_modules/npm/node_modules/unique-slug": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
-      "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11351,8 +10321,6 @@
     },
     "node_modules/npm/node_modules/unique-string": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11365,8 +10333,6 @@
     },
     "node_modules/npm/node_modules/unpipe": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11376,8 +10342,6 @@
     },
     "node_modules/npm/node_modules/unzip-response": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11387,8 +10351,6 @@
     },
     "node_modules/npm/node_modules/update-notifier": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
-      "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -11410,8 +10372,6 @@
     },
     "node_modules/npm/node_modules/uri-js": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -11421,8 +10381,6 @@
     },
     "node_modules/npm/node_modules/uri-js/node_modules/punycode": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11432,8 +10390,6 @@
     },
     "node_modules/npm/node_modules/url-parse-lax": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11446,24 +10402,18 @@
     },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/util-extend": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
-      "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/util-promisify": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/util-promisify/-/util-promisify-2.1.0.tgz",
-      "integrity": "sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11473,8 +10423,6 @@
     },
     "node_modules/npm/node_modules/uuid": {
       "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11484,8 +10432,6 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -11496,8 +10442,6 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11507,8 +10451,6 @@
     },
     "node_modules/npm/node_modules/verror": {
       "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "engines": [
         "node >=0.6.0"
@@ -11523,8 +10465,6 @@
     },
     "node_modules/npm/node_modules/wcwidth": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11534,8 +10474,6 @@
     },
     "node_modules/npm/node_modules/which": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11548,16 +10486,12 @@
     },
     "node_modules/npm/node_modules/which-module": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/wide-align": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11567,8 +10501,6 @@
     },
     "node_modules/npm/node_modules/wide-align/node_modules/string-width": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11583,8 +10515,6 @@
     },
     "node_modules/npm/node_modules/widest-line": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
-      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11597,8 +10527,6 @@
     },
     "node_modules/npm/node_modules/worker-farm": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
-      "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11608,8 +10536,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11624,8 +10550,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11635,8 +10559,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11646,8 +10568,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11662,8 +10582,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11676,16 +10594,12 @@
     },
     "node_modules/npm/node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/write-file-atomic": {
       "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11697,8 +10611,6 @@
     },
     "node_modules/npm/node_modules/xdg-basedir": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11708,8 +10620,6 @@
     },
     "node_modules/npm/node_modules/xtend": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11719,24 +10629,18 @@
     },
     "node_modules/npm/node_modules/y18n": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/yallist": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/yargs": {
       "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
-      "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11756,8 +10660,6 @@
     },
     "node_modules/npm/node_modules/yargs-parser": {
       "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-      "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11768,8 +10670,6 @@
     },
     "node_modules/npm/node_modules/yargs-parser/node_modules/camelcase": {
       "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11779,8 +10679,6 @@
     },
     "node_modules/npm/node_modules/yargs/node_modules/ansi-regex": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11790,8 +10688,6 @@
     },
     "node_modules/npm/node_modules/yargs/node_modules/find-up": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11804,8 +10700,6 @@
     },
     "node_modules/npm/node_modules/yargs/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11815,8 +10709,6 @@
     },
     "node_modules/npm/node_modules/yargs/node_modules/locate-path": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11830,8 +10722,6 @@
     },
     "node_modules/npm/node_modules/yargs/node_modules/p-limit": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11847,8 +10737,6 @@
     },
     "node_modules/npm/node_modules/yargs/node_modules/p-locate": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11861,8 +10749,6 @@
     },
     "node_modules/npm/node_modules/yargs/node_modules/p-try": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11872,8 +10758,6 @@
     },
     "node_modules/npm/node_modules/yargs/node_modules/string-width": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11888,8 +10772,6 @@
     },
     "node_modules/npm/node_modules/yargs/node_modules/strip-ansi": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11905,7 +10787,6 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -12038,7 +10919,6 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true,
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13232,9 +12112,9 @@
       "dev": true
     },
     "node_modules/semantic-release": {
-      "version": "17.3.9",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.3.9.tgz",
-      "integrity": "sha512-iPDySFcAXG+7KiM0JH4bvF++imkf85VmfXpIBPAyDxK/P4+pe19KNFCfkzTKwUJkTIAyLUIr7WOg3W5h5aMwNg==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.4.1.tgz",
+      "integrity": "sha512-o/Rjk0HCBUWEYxN99Vq04Th+XtRQAxbC+FN+pBQ49wpqQ5NW/cfwhfw0qyxeTEhbchQ/1/KGMPWqD4/rRScAag==",
       "dev": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^8.0.0",
@@ -13255,7 +12135,7 @@
         "hosted-git-info": "^3.0.0",
         "lodash": "^4.17.15",
         "marked": "^2.0.0",
-        "marked-terminal": "^4.0.0",
+        "marked-terminal": "^4.1.1",
         "micromatch": "^4.0.2",
         "p-each-series": "^2.1.0",
         "p-reduce": "^2.0.0",
@@ -13453,9 +12333,9 @@
       }
     },
     "node_modules/semantic-release/node_modules/string-width": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
       "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -14071,83 +12951,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/superagent": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
-      "integrity": "sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==",
-      "dev": true,
-      "dependencies": {
-        "component-emitter": "^1.3.0",
-        "cookiejar": "^2.1.2",
-        "debug": "^4.1.1",
-        "fast-safe-stringify": "^2.0.7",
-        "form-data": "^3.0.0",
-        "formidable": "^1.2.2",
-        "methods": "^1.1.2",
-        "mime": "^2.4.6",
-        "qs": "^6.9.4",
-        "readable-stream": "^3.6.0",
-        "semver": "^7.3.2"
-      },
-      "engines": {
-        "node": ">= 7.0.0"
-      }
-    },
-    "node_modules/superagent/node_modules/form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/superagent/node_modules/qs": {
-      "version": "6.9.6",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
-      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/superagent/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/superagent/node_modules/semver": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -14220,9 +13023,9 @@
       "dev": true
     },
     "node_modules/table/node_modules/string-width": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
       "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -14676,9 +13479,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.2.tgz",
-      "integrity": "sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
+      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -14689,9 +13492,9 @@
       }
     },
     "node_modules/uglify-js": {
-      "version": "3.12.8",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.8.tgz",
-      "integrity": "sha512-fvBeuXOsvqjecUtF/l1dwsrrf5y2BCUk9AOJGzGcm6tE7vegku5u/YvqjyDaAGr422PLoLnrxg3EnRvTqsdC1w==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.0.tgz",
+      "integrity": "sha512-TWYSWa9T2pPN4DIJYbU9oAjQx+5qdV5RUDxwARg8fmJZrD/V27Zj0JngW5xg1DFz42G0uDYl2XhzF6alSzD62w==",
       "dev": true,
       "optional": true,
       "bin": {
@@ -14699,6 +13502,18 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.0.tgz",
+      "integrity": "sha512-P/51NX+JXyxK/aigg1/ZgyccdAxm5K1+n8+tvqSntjOivPt19gvm1VC49RWYetsiub8WViUchdxl/KWHHB0kzA==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.0",
+        "has-symbols": "^1.0.0",
+        "which-boxed-primitive": "^1.0.1"
       }
     },
     "node_modules/unique-string": {
@@ -14759,9 +13574,9 @@
       }
     },
     "node_modules/v8-compile-cache": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
-      "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
     },
     "node_modules/validate-npm-package-license": {
@@ -14810,6 +13625,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "dependencies": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/which-module": {
@@ -14872,9 +13703,9 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
       "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -15074,9 +13905,9 @@
       }
     },
     "node_modules/yargs/node_modules/string-width": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
       "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -15124,23 +13955,23 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.13.6",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.6.tgz",
-      "integrity": "sha512-VhgqKOWYVm7lQXlvbJnWOzwfAQATd2nV52koT0HZ/LdDH0m4DUDwkKYsH+IwpXb+bKPyBJzawA4I6nBKqZcpQw==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.8.tgz",
+      "integrity": "sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.1.tgz",
-      "integrity": "sha512-FzeKfFBG2rmFtGiiMdXZPFt/5R5DXubVi82uYhjGX4Msf+pgYQMCFIqFXZWs5vbIYbf14VeBIgdGI03CDOOM1w==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.8.tgz",
+      "integrity": "sha512-oYapIySGw1zGhEFRd6lzWNLWFX2s5dA/jm+Pw/+59ZdXtjyIuwlXbrId22Md0rgZVop+aVoqow2riXhBLNyuQg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
         "@babel/generator": "^7.13.0",
-        "@babel/helper-compilation-targets": "^7.13.0",
+        "@babel/helper-compilation-targets": "^7.13.8",
         "@babel/helper-module-transforms": "^7.13.0",
         "@babel/helpers": "^7.13.0",
-        "@babel/parser": "^7.13.0",
+        "@babel/parser": "^7.13.4",
         "@babel/template": "^7.12.13",
         "@babel/traverse": "^7.13.0",
         "@babel/types": "^7.13.0",
@@ -15149,7 +13980,7 @@
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.1.2",
         "lodash": "^4.17.19",
-        "semver": "7.0.0",
+        "semver": "^6.3.0",
         "source-map": "^0.5.0"
       },
       "dependencies": {
@@ -15161,19 +13992,13 @@
           "requires": {
             "@babel/highlight": "^7.12.13"
           }
-        },
-        "semver": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-          "dev": true
         }
       }
     },
     "@babel/generator": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.0.tgz",
-      "integrity": "sha512-zBZfgvBB/ywjx0Rgc2+BwoH/3H+lDtlgD4hBOpEv5LxRnYsm/753iRuLepqnYlynpjC3AdQxtxsoeHJoEEwOAw==",
+      "version": "7.13.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+      "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.13.0",
@@ -15182,23 +14007,15 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.0.tgz",
-      "integrity": "sha512-SOWD0JK9+MMIhTQiUVd4ng8f3NXhPVQvTv7D3UN4wbp/6cAHnB2EmMaU1zZA2Hh1gwme+THBrVSqTFxHczTh0Q==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.8.tgz",
+      "integrity": "sha512-pBljUGC1y3xKLn1nrx2eAhurLMA8OqBtBP/JwG4U8skN7kf8/aqwwxpV1N6T0e7r6+7uNitIa/fUxPFagSXp3A==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.13.0",
+        "@babel/compat-data": "^7.13.8",
         "@babel/helper-validator-option": "^7.12.17",
         "browserslist": "^4.14.5",
-        "semver": "7.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-          "dev": true
-        }
+        "semver": "^6.3.0"
       }
     },
     "@babel/helper-function-name": {
@@ -15319,9 +14136,9 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
-      "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.8.tgz",
+      "integrity": "sha512-4vrIhfJyfNf+lCtXC2ck1rKSzDwciqF7IWFhXXrSOUC2O5DrVp+w4c6ed4AllTxhTkUP5x2tYj41VaxdVMMRDw==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
@@ -15388,9 +14205,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.13.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.4.tgz",
-      "integrity": "sha512-uvoOulWHhI+0+1f9L4BoozY7U5cIkZ9PgJqvb041d6vypgUmtVPG4vmGm4pSggjl8BELzvHyUeJSUyEMY6b+qA==",
+      "version": "7.13.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.9.tgz",
+      "integrity": "sha512-nEUfRiARCcaVo3ny3ZQjURjHQZUo/JkEw7rLlSZy/psWGnvwXFtPcr6jb7Yb41DVW5LTe6KRq9LGleRNsg1Frw==",
       "dev": true
     },
     "@babel/template": {
@@ -15461,29 +14278,29 @@
       }
     },
     "@definitelytyped/header-parser": {
-      "version": "0.0.69",
-      "resolved": "https://registry.npmjs.org/@definitelytyped/header-parser/-/header-parser-0.0.69.tgz",
-      "integrity": "sha512-8WKD2I1wtrHWWNvyei7ncBBFJ2DfDUnsAgpS2z/O9JlR8LzoDhqUphH5CaB+EMr3kdHXi7KcAnf6ec7zJ5IsvA==",
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/header-parser/-/header-parser-0.0.71.tgz",
+      "integrity": "sha512-5iASXqlpqorWJ81D/QlwvbXmgnEOvcekv33aZTMSe7ubCJ1S/IdBwbTIBpPZbS3GnBzXbCT0749a1bVxG+wTfg==",
       "dev": true,
       "requires": {
-        "@definitelytyped/typescript-versions": "^0.0.69",
+        "@definitelytyped/typescript-versions": "^0.0.71",
         "@types/parsimmon": "^1.10.1",
         "parsimmon": "^1.13.0"
       }
     },
     "@definitelytyped/typescript-versions": {
-      "version": "0.0.69",
-      "resolved": "https://registry.npmjs.org/@definitelytyped/typescript-versions/-/typescript-versions-0.0.69.tgz",
-      "integrity": "sha512-+0KTIEPFbH9+nehW5aZ93so9wqbScAxZ0uI5mstyWWegEz4a9YS9LgIRr6BMdHbt3NjKyfnJ5Kd2oicMN91BZg==",
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/typescript-versions/-/typescript-versions-0.0.71.tgz",
+      "integrity": "sha512-XJvyYfWQyntq+EdCqRinni9BwenPAoCXTZ3aaKfuir14bEbkIyeyQjuh1R0VkqdahIavyyAoGmYHe9OSYqFwTw==",
       "dev": true
     },
     "@definitelytyped/utils": {
-      "version": "0.0.69",
-      "resolved": "https://registry.npmjs.org/@definitelytyped/utils/-/utils-0.0.69.tgz",
-      "integrity": "sha512-pd0aGoVilhahj+XRrEW9Q1/fJG9V1k+CkpGxg1nSk0fBdi15njovnPPU3iTSUzFlaUZloNoTs5+czTjgXJfg9Q==",
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/utils/-/utils-0.0.71.tgz",
+      "integrity": "sha512-/IueyLKglPxweW1d7VvuTlnFxBNVv1qcSL2Y+u/LW7aBMXfD8bcuHl7awAMVRAGhTeBpo7qGubrCqMSNfOlUyA==",
       "dev": true,
       "requires": {
-        "@definitelytyped/typescript-versions": "^0.0.69",
+        "@definitelytyped/typescript-versions": "^0.0.71",
         "@types/node": "^12.12.29",
         "charm": "^1.0.2",
         "fs-extra": "^8.1.0",
@@ -15507,9 +14324,9 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
-      "integrity": "sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
+      "integrity": "sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -15519,7 +14336,6 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.20",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
@@ -15668,18 +14484,18 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-5.1.1.tgz",
-      "integrity": "sha512-yMyaX9EDWCiyv7m85/K8L7bLFj1wrLdfDkKcZEZ6gNmepSW5mfSMFJnYwRINN7lF58wvevKPWvw0MYy6sxcFlQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-5.3.1.tgz",
+      "integrity": "sha512-TvVk2QuIA0lQZcIMd6xbdGaGDVeNYIOa3l1ZVagAIk5K3t/WMYbcg4BISNDhzdVhm/TgQB26frAgd/GV81aHJA==",
       "dev": true
     },
     "@octokit/plugin-paginate-rest": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.10.0.tgz",
-      "integrity": "sha512-71OsKBSMcQEu/6lfVbhv5C5ikU1rn10rKot/WiV7do7fyfElQ2eCUQFogHPbj0ci5lnKAjvahOiMAr6lcvL8Qw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.11.0.tgz",
+      "integrity": "sha512-7L9xQank2G3r1dGqrVPo1z62V5utbykOUzlmNHPz87Pww/JpZQ9KyG5CHtUzgmB4n5iDRKYNK/86A8D98HP0yA==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^6.10.0"
+        "@octokit/types": "^6.11.0"
       }
     },
     "@octokit/plugin-request-log": {
@@ -15690,12 +14506,12 @@
       "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.12.2.tgz",
-      "integrity": "sha512-5+MmGusB7wPw7OholtcGaMyjfrsFSpFqtJW8VsrbfU/TuaiQepY4wgVkS7P3TAObX257jrTbbGo/sJLcoGf16g==",
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.13.4.tgz",
+      "integrity": "sha512-MGxptzVfiP8O+aydC/riheYzS/yJ9P16M29OuvtZep/sF5sKuOCQP8Wf83YCKXRsQF+ZpYfke2snbPPSIMZKzg==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^6.10.1",
+        "@octokit/types": "^6.12.0",
         "deprecation": "^2.3.1"
       }
     },
@@ -15727,24 +14543,24 @@
       }
     },
     "@octokit/rest": {
-      "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.2.1.tgz",
-      "integrity": "sha512-DdQ1vps41JSyB2axyL1mBwJiXAPibgugIQPOmt0mL/yhwheQ6iuq2aKiJWgGWa9ldMfe3v9gIFYlrFgxQ5ThGQ==",
+      "version": "18.3.4",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.3.4.tgz",
+      "integrity": "sha512-NES0pHbwyFB1D0jrLkdnIXgEmze/gLE0JoSNgfAe4vwD77/qaQGO/lRWNuPPsoBVBjiW6mmA9CU5cYHujJTKQA==",
       "dev": true,
       "requires": {
         "@octokit/core": "^3.2.3",
         "@octokit/plugin-paginate-rest": "^2.6.2",
         "@octokit/plugin-request-log": "^1.0.2",
-        "@octokit/plugin-rest-endpoint-methods": "4.12.2"
+        "@octokit/plugin-rest-endpoint-methods": "4.13.4"
       }
     },
     "@octokit/types": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.10.1.tgz",
-      "integrity": "sha512-hgNC5jxKG8/RlqxU/6GThkGrvFpz25+cPzjQjyiXTNBvhyltn2Z4GhFY25+kbtXwZ4Co4zM0goW5jak1KLp1ug==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.12.0.tgz",
+      "integrity": "sha512-KwOf16soD7aDEEi/PgNeJlHzjZPfrmmNy+7WezSdrpnqZ7YImBJcNnX9+5RUHt1MnA4h8oISRHTqaZDGsX9DRQ==",
       "dev": true,
       "requires": {
-        "@octokit/openapi-types": "^5.1.0"
+        "@octokit/openapi-types": "^5.3.0"
       }
     },
     "@semantic-release/commit-analyzer": {
@@ -16269,8 +15085,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "archy": {
       "version": "1.0.0",
@@ -16283,7 +15098,6 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "dev": true,
-      "optional": true,
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -16493,9 +15307,9 @@
       }
     },
     "before-after-hook": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.1.tgz",
-      "integrity": "sha512-5ekuQOvO04MDj7kYZJaMab2S8SPjGJbotVNyv7QYFCOAwrGZs/YnoDNlh1U+m5hl7H2D/+n0taaAV/tfyd3KMA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.0.tgz",
+      "integrity": "sha512-jH6rKQIfroBbhEXVmI7XmXe3ix5S/PgJqpzdDPnR8JGLHWNYLsYZ6tK5iWOF/Ra3oqEX0NobXGlzbiylIzVphQ==",
       "dev": true
     },
     "binary-extensions": {
@@ -16684,9 +15498,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001191",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001191.tgz",
-      "integrity": "sha512-xJJqzyd+7GCJXkcoBiQ1GuxEiOBCLQ0aVW9HMekifZsAVGdj5eJ4mFB9fEhSHipq9IOk/QXFJUiIr9lZT+EsGw==",
+      "version": "1.0.30001196",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001196.tgz",
+      "integrity": "sha512-CPvObjD3ovWrNBaXlAIGWmg2gQQuJ5YhuciUOjPRox6hIQttu8O+b51dx6VIpIY9ESd2d0Vac1RKpICdG4rGUg==",
       "dev": true
     },
     "cardinal": {
@@ -16706,16 +15520,16 @@
       "dev": true
     },
     "chai": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.0.tgz",
-      "integrity": "sha512-/BFd2J30EcOwmdOgXvVsmM48l0Br0nmZPlO0uOW4XKh6kpsUumRXBgPV+IlaqFaqr9cYbeoZAM1Npx0i4A+aiA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.3.tgz",
+      "integrity": "sha512-MPSLOZwxxnA0DhLE84klnGPojWFK5KuhP7/j5dTsxpr2S3XlkqJP5WbyYl1gCTWvG2Z5N+HD4F472WsbEZL6Pw==",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
         "deep-eql": "^3.0.1",
         "get-func-name": "^2.0.0",
-        "pathval": "^1.1.0",
+        "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
       }
     },
@@ -16793,9 +15607,9 @@
           "dev": true
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -16836,9 +15650,9 @@
       "dev": true
     },
     "colorette": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
     },
     "colors": {
@@ -16884,12 +15698,6 @@
         "dot-prop": "^5.1.0"
       }
     },
-    "component-emitter": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
-      "dev": true
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -16912,8 +15720,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "contains-path": {
       "version": "0.1.0",
@@ -16990,12 +15797,6 @@
           "dev": true
         }
       }
-    },
-    "cookiejar": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
-      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -17148,9 +15949,9 @@
       }
     },
     "defer-to-connect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
-      "integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
       "dev": true
     },
     "define-properties": {
@@ -17199,8 +16000,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "deprecation": {
       "version": "2.3.1",
@@ -17308,9 +16108,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.673",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.673.tgz",
-      "integrity": "sha512-ms+QR2ckfrrpEAjXweLx6kNCbpAl66DcW//3BZD4BV5KhUgr0RZRce1ON/9J3QyA3JO28nzgb5Xv8DnPr05ILg==",
+      "version": "1.3.682",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.682.tgz",
+      "integrity": "sha512-zok2y37qR00U14uM6qBz/3iIjWHom2eRfC2S1StA0RslP7x34jX+j4mxv80t8OEOHLJPVG54ZPeaFxEI7gPrwg==",
       "dev": true
     },
     "emoji-regex": {
@@ -17382,25 +16182,27 @@
       }
     },
     "es-abstract": {
-      "version": "1.18.0-next.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
-      "integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+      "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2",
+        "get-intrinsic": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.2",
+        "has-symbols": "^1.0.2",
+        "is-callable": "^1.2.3",
         "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.1",
+        "is-regex": "^1.1.2",
+        "is-string": "^1.0.5",
         "object-inspect": "^1.9.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.3",
-        "string.prototype.trimstart": "^1.0.3"
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.0"
       }
     },
     "es-to-primitive": {
@@ -17433,13 +16235,13 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.20.0.tgz",
-      "integrity": "sha512-qGi0CTcOGP2OtCQBgWZlQjcTuP0XkIpYFj25XtRTQSHC+umNnp7UMshr2G8SLsRFYDdAPFeHOsiteadmMH02Yw==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.21.0.tgz",
+      "integrity": "sha512-W2aJbXpMNofUp0ztQaF40fveSsJBjlSCSWpy//gzfTvwC+USs/nceBrKmlJOiM8r1bLwP2EuYkCqArn/6QTIgg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.3.0",
+        "@eslint/eslintrc": "^0.4.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -17452,7 +16254,7 @@
         "espree": "^7.3.1",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^6.0.0",
+        "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
         "globals": "^12.1.0",
@@ -17621,9 +16423,9 @@
       }
     },
     "eslint-plugin-mocha": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-8.0.0.tgz",
-      "integrity": "sha512-n67etbWDz6NQM+HnTwZHyBwz/bLlYPOxUbw7bPuCyFujv7ZpaT/Vn6KTAbT02gf7nRljtYIjWcTxK/n8a57rQQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-8.1.0.tgz",
+      "integrity": "sha512-1EgHvXKRl7W3mq3sntZAi5T24agRMyiTPL4bSXe+B4GksYOjAPEWYx+J3eJg4It1l2NMNZJtk0gQyQ6mfiPhQg==",
       "dev": true,
       "requires": {
         "eslint-utils": "^2.1.0",
@@ -17838,12 +16640,6 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "fast-safe-stringify": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
-      "dev": true
-    },
     "fastq": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
@@ -18025,12 +16821,6 @@
         "mime-types": "^2.1.12"
       }
     },
-    "formidable": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
-      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==",
-      "dev": true
-    },
     "from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -18117,7 +16907,6 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
-      "optional": true,
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -18133,15 +16922,13 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -18291,9 +17078,9 @@
       }
     },
     "got": {
-      "version": "11.8.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.1.tgz",
-      "integrity": "sha512-9aYdZL+6nHmvJwHALLwKSUZ0hMwGaJGYv3hoPLPgnT8BoBXm1SjnZeky+91tfwJaDzun2s4RsBRy48IEYv2q2Q==",
+      "version": "11.8.2",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
+      "integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
       "dev": true,
       "requires": {
         "@sindresorhus/is": "^4.0.0",
@@ -18390,6 +17177,12 @@
         }
       }
     },
+    "has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "dev": true
+    },
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -18397,17 +17190,16 @@
       "dev": true
     },
     "has-symbols": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
       "dev": true
     },
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "hasha": {
       "version": "5.2.2",
@@ -18472,9 +17264,9 @@
       }
     },
     "http2-wrapper": {
-      "version": "1.0.0-beta.5.2",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.0-beta.5.2.tgz",
-      "integrity": "sha512-xYz9goEyBnC8XwXDTuC/MZ6t+MrKVQZOk4s7+PaDkwIsQd8IwqvM+0M6bA/2lvG8GHXcPdf+MejTUeO2LCPCeQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
       "dev": true,
       "requires": {
         "quick-lru": "^5.1.1",
@@ -18586,6 +17378,12 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
+    "is-bigint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
+      "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==",
+      "dev": true
+    },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -18593,6 +17391,15 @@
       "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-boolean-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
+      "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0"
       }
     },
     "is-callable": {
@@ -18650,6 +17457,12 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-number-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
       "dev": true
     },
     "is-obj": {
@@ -19166,20 +17979,20 @@
       "dev": true
     },
     "marked": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.0.tgz",
-      "integrity": "sha512-NqRSh2+LlN2NInpqTQnS614Y/3NkVMFFU6sJlRFEpxJ/LHuK/qJECH7/fXZjk4VZstPW/Pevjil/VtSONsLc7Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.1.tgz",
+      "integrity": "sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==",
       "dev": true
     },
     "marked-terminal": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-4.1.0.tgz",
-      "integrity": "sha512-5KllfAOW02WS6hLRQ7cNvGOxvKW1BKuXELH4EtbWfyWgxQhROoMxEvuQ/3fTgkNjledR0J48F4HbapvYp1zWkQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-4.1.1.tgz",
+      "integrity": "sha512-t7Mdf6T3PvOEyN01c3tYxDzhyKZ8xnkp8Rs6Fohno63L/0pFTJ5Qtwto2AQVuDtbQiWzD+4E5AAu1Z2iLc8miQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.3.1",
         "cardinal": "^2.1.1",
-        "chalk": "^4.0.0",
+        "chalk": "^4.1.0",
         "cli-table": "^0.3.1",
         "node-emoji": "^1.10.0",
         "supports-hyperlinks": "^2.1.0"
@@ -19378,12 +18191,6 @@
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
     },
-    "methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-      "dev": true
-    },
     "micromatch": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
@@ -19469,9 +18276,9 @@
       }
     },
     "mocha": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.3.0.tgz",
-      "integrity": "sha512-TQqyC89V1J/Vxx0DhJIXlq9gbbL9XFNdeLQ1+JsnZsVaSOV1z3tWfw0qZmQJGQRIfkvZcs7snQnZnOCKoldq1Q==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.3.1.tgz",
+      "integrity": "sha512-5SBMxANWqOv5bw3Hx+HVgaWlcWcFEQDUdaUAr1AUU+qwtx6cowhn7gEDT/DwQP7uYxnvShdUOVLbTYAHOEGfDQ==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
@@ -19540,9 +18347,9 @@
           "dev": true
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -19865,15 +18672,11 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "bundled": true,
           "dev": true
         },
         "agent-base": {
           "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -19882,8 +18685,6 @@
         },
         "agentkeepalive": {
           "version": "3.5.2",
-          "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
-          "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -19892,8 +18693,6 @@
         },
         "ansi-align": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-          "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -19902,15 +18701,11 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "bundled": true,
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -19919,36 +18714,26 @@
         },
         "ansicolors": {
           "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-          "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
           "bundled": true,
           "dev": true
         },
         "ansistyles": {
           "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
-          "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
           "bundled": true,
           "dev": true
         },
         "aproba": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-          "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
           "bundled": true,
           "dev": true
         },
         "archy": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "bundled": true,
           "dev": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -19958,8 +18743,6 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -19974,8 +18757,6 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -19986,15 +18767,11 @@
         },
         "asap": {
           "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-          "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
           "bundled": true,
           "dev": true
         },
         "asn1": {
           "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-          "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20003,43 +18780,31 @@
         },
         "assert-plus": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "bundled": true,
           "dev": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
           "bundled": true,
           "dev": true
         },
         "aws-sign2": {
           "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
           "bundled": true,
           "dev": true
         },
         "aws4": {
           "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-          "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
           "bundled": true,
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "bundled": true,
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-          "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -20049,8 +18814,6 @@
         },
         "bin-links": {
           "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-1.1.8.tgz",
-          "integrity": "sha512-KgmVfx+QqggqP9dA3iIc5pA4T1qEEEL+hOhOhNPaUm77OTrJoOXE/C05SJLNJe6m/2wUK7F1tDSou7n5TfCDzQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20064,15 +18827,11 @@
         },
         "bluebird": {
           "version": "3.5.5",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-          "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
           "bundled": true,
           "dev": true
         },
         "boxen": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-          "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20087,8 +18846,6 @@
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20098,36 +18855,26 @@
         },
         "buffer-from": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-          "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
           "bundled": true,
           "dev": true
         },
         "builtins": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-          "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
           "bundled": true,
           "dev": true
         },
         "byline": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-          "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
           "bundled": true,
           "dev": true
         },
         "byte-size": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-5.0.1.tgz",
-          "integrity": "sha512-/XuKeqWocKsYa/cBY1YbSJSWWqTi4cFgr9S6OyM7PBaPbr9zvNGwWP33vt0uqGhwDdN+y3yhbXVILEUpnwEWGw==",
           "bundled": true,
           "dev": true
         },
         "cacache": {
           "version": "12.0.3",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
-          "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20150,36 +18897,26 @@
         },
         "call-limit": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/call-limit/-/call-limit-1.1.1.tgz",
-          "integrity": "sha512-5twvci5b9eRBw2wCfPtN0GmlR2/gadZqyFpPhOK6CvMFoFgA+USnZ6Jpu1lhG9h85pQ3Ouil3PfXWRD4EUaRiQ==",
           "bundled": true,
           "dev": true
         },
         "camelcase": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "bundled": true,
           "dev": true
         },
         "capture-stack-trace": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-          "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
           "bundled": true,
           "dev": true
         },
         "caseless": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
           "bundled": true,
           "dev": true
         },
         "chalk": {
           "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20190,22 +18927,16 @@
         },
         "chownr": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
           "bundled": true,
           "dev": true
         },
         "ci-info": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
           "bundled": true,
           "dev": true
         },
         "cidr-regex": {
           "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-2.0.10.tgz",
-          "integrity": "sha512-sB3ogMQXWvreNPbJUZMRApxuRYd+KoIo4RGQ81VatjmMW6WJPo+IJZ2846FGItr9VzKo5w7DXzijPLGtSd0N3Q==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20214,15 +18945,11 @@
         },
         "cli-boxes": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-          "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
           "bundled": true,
           "dev": true
         },
         "cli-columns": {
           "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/cli-columns/-/cli-columns-3.1.2.tgz",
-          "integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20232,8 +18959,6 @@
         },
         "cli-table3": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
-          "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20244,8 +18969,6 @@
         },
         "cliui": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20256,22 +18979,16 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
               "bundled": true,
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "bundled": true,
               "dev": true
             },
             "string-width": {
               "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -20282,8 +18999,6 @@
             },
             "strip-ansi": {
               "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -20294,15 +19009,11 @@
         },
         "clone": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
           "bundled": true,
           "dev": true
         },
         "cmd-shim": {
           "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-3.0.3.tgz",
-          "integrity": "sha512-DtGg+0xiFhQIntSBRzL2fRQBnmtAVwXIDo4Qq46HPpObYquxMaZS4sb82U9nH91qJrlosC1wa9gwr0QyL/HypA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20312,15 +19023,11 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "bundled": true,
           "dev": true
         },
         "color-convert": {
           "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-          "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20329,23 +19036,17 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "bundled": true,
           "dev": true
         },
         "colors": {
           "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-          "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "columnify": {
           "version": "1.5.4",
-          "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
-          "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20355,8 +19056,6 @@
         },
         "combined-stream": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20365,15 +19064,11 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "bundled": true,
           "dev": true
         },
         "concat-stream": {
           "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20385,8 +19080,6 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -20401,8 +19094,6 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -20413,8 +19104,6 @@
         },
         "config-chain": {
           "version": "1.1.12",
-          "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
-          "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20424,8 +19113,6 @@
         },
         "configstore": {
           "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.5.tgz",
-          "integrity": "sha512-nlOhI4+fdzoK5xmJ+NY+1gZK56bwEaWZr8fYuXohZ9Vkc1o3a4T/R3M+yE/w7x/ZVJ1zF8c+oaOvF0dztdUgmA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20439,15 +19126,11 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "bundled": true,
           "dev": true
         },
         "copy-concurrently": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
-          "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20461,15 +19144,11 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "bundled": true,
               "dev": true
             },
             "iferr": {
               "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "bundled": true,
               "dev": true
             }
@@ -20477,15 +19156,11 @@
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "bundled": true,
           "dev": true
         },
         "create-error-class": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-          "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20494,8 +19169,6 @@
         },
         "cross-spawn": {
           "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20506,8 +19179,6 @@
           "dependencies": {
             "lru-cache": {
               "version": "4.1.5",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-              "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -20517,8 +19188,6 @@
             },
             "yallist": {
               "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-              "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
               "bundled": true,
               "dev": true
             }
@@ -20526,22 +19195,16 @@
         },
         "crypto-random-string": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-          "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
           "bundled": true,
           "dev": true
         },
         "cyclist": {
           "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-          "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
           "bundled": true,
           "dev": true
         },
         "dashdash": {
           "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20550,8 +19213,6 @@
         },
         "debug": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20560,8 +19221,6 @@
           "dependencies": {
             "ms": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
               "bundled": true,
               "dev": true
             }
@@ -20569,36 +19228,26 @@
         },
         "debuglog": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-          "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
           "bundled": true,
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "bundled": true,
           "dev": true
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
           "bundled": true,
           "dev": true
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "bundled": true,
           "dev": true
         },
         "defaults": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-          "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20607,8 +19256,6 @@
         },
         "define-properties": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20617,36 +19264,26 @@
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
           "bundled": true,
           "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "bundled": true,
           "dev": true
         },
         "detect-indent": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
           "bundled": true,
           "dev": true
         },
         "detect-newline": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-          "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
           "bundled": true,
           "dev": true
         },
         "dezalgo": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-          "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20656,8 +19293,6 @@
         },
         "dot-prop": {
           "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
-          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20666,22 +19301,16 @@
         },
         "dotenv": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
-          "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
           "bundled": true,
           "dev": true
         },
         "duplexer3": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
           "bundled": true,
           "dev": true
         },
         "duplexify": {
           "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
-          "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20693,8 +19322,6 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -20709,8 +19336,6 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -20721,8 +19346,6 @@
         },
         "ecc-jsbn": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-          "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -20733,22 +19356,16 @@
         },
         "editor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
-          "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
           "bundled": true,
           "dev": true
         },
         "emoji-regex": {
           "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "bundled": true,
           "dev": true
         },
         "encoding": {
           "version": "0.1.12",
-          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-          "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20757,8 +19374,6 @@
         },
         "end-of-stream": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-          "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20767,22 +19382,16 @@
         },
         "env-paths": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
-          "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
           "bundled": true,
           "dev": true
         },
         "err-code": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-          "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
           "bundled": true,
           "dev": true
         },
         "errno": {
           "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-          "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20791,8 +19400,6 @@
         },
         "es-abstract": {
           "version": "1.12.0",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-          "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20805,8 +19412,6 @@
         },
         "es-to-primitive": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-          "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20817,15 +19422,11 @@
         },
         "es6-promise": {
           "version": "4.2.8",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-          "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
           "bundled": true,
           "dev": true
         },
         "es6-promisify": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20834,15 +19435,11 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "bundled": true,
           "dev": true
         },
         "execa": {
           "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20857,8 +19454,6 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
               "bundled": true,
               "dev": true
             }
@@ -20866,43 +19461,31 @@
         },
         "extend": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
           "bundled": true,
           "dev": true
         },
         "extsprintf": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
           "bundled": true,
           "dev": true
         },
         "fast-json-stable-stringify": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-          "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
           "bundled": true,
           "dev": true
         },
         "figgy-pudding": {
           "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-          "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
           "bundled": true,
           "dev": true
         },
         "find-npm-prefix": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz",
-          "integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==",
           "bundled": true,
           "dev": true
         },
         "flush-write-stream": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
-          "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20912,8 +19495,6 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -20928,8 +19509,6 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -20940,15 +19519,11 @@
         },
         "forever-agent": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
           "bundled": true,
           "dev": true
         },
         "form-data": {
           "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20959,8 +19534,6 @@
         },
         "from2": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-          "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20970,8 +19543,6 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -20986,8 +19557,6 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -20998,8 +19567,6 @@
         },
         "fs-minipass": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-          "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21008,8 +19575,6 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -21021,8 +19586,6 @@
         },
         "fs-vacuum": {
           "version": "1.2.10",
-          "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
-          "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21033,8 +19596,6 @@
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
-          "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21046,15 +19607,11 @@
           "dependencies": {
             "iferr": {
               "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "bundled": true,
               "dev": true
             },
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -21069,8 +19626,6 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -21081,22 +19636,16 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "bundled": true,
           "dev": true
         },
         "function-bind": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
           "bundled": true,
           "dev": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21112,15 +19661,11 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "bundled": true,
               "dev": true
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -21133,15 +19678,11 @@
         },
         "genfun": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
-          "integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
           "bundled": true,
           "dev": true
         },
         "gentle-fs": {
           "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/gentle-fs/-/gentle-fs-2.3.1.tgz",
-          "integrity": "sha512-OlwBBwqCFPcjm33rF2BjW+Pr6/ll2741l+xooiwTCeaX2CA1ZuclavyMBe0/KlR21/XGsgY6hzEQZ15BdNa13Q==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21160,15 +19701,11 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "bundled": true,
               "dev": true
             },
             "iferr": {
               "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "bundled": true,
               "dev": true
             }
@@ -21176,15 +19713,11 @@
         },
         "get-caller-file": {
           "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
           "bundled": true,
           "dev": true
         },
         "get-stream": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21193,8 +19726,6 @@
         },
         "getpass": {
           "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21203,8 +19734,6 @@
         },
         "glob": {
           "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21218,8 +19747,6 @@
         },
         "global-dirs": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-          "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21228,8 +19755,6 @@
         },
         "got": {
           "version": "6.7.1",
-          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21248,8 +19773,6 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
               "bundled": true,
               "dev": true
             }
@@ -21257,22 +19780,16 @@
         },
         "graceful-fs": {
           "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
           "bundled": true,
           "dev": true
         },
         "har-schema": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
           "bundled": true,
           "dev": true
         },
         "har-validator": {
           "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-          "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21282,8 +19799,6 @@
           "dependencies": {
             "ajv": {
               "version": "6.12.6",
-              "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-              "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -21295,15 +19810,11 @@
             },
             "fast-deep-equal": {
               "version": "3.1.3",
-              "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-              "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
               "bundled": true,
               "dev": true
             },
             "json-schema-traverse": {
               "version": "0.4.1",
-              "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-              "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
               "bundled": true,
               "dev": true
             }
@@ -21311,8 +19822,6 @@
         },
         "has": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21321,43 +19830,31 @@
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "bundled": true,
           "dev": true
         },
         "has-symbols": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-          "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
           "bundled": true,
           "dev": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "bundled": true,
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.8.8",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
           "bundled": true,
           "dev": true
         },
         "http-cache-semantics": {
           "version": "3.8.1",
-          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-          "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
           "bundled": true,
           "dev": true
         },
         "http-proxy-agent": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-          "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21367,8 +19864,6 @@
         },
         "http-signature": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21379,8 +19874,6 @@
         },
         "https-proxy-agent": {
           "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-          "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21390,8 +19883,6 @@
         },
         "humanize-ms": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-          "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21400,8 +19891,6 @@
         },
         "iconv-lite": {
           "version": "0.4.23",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21410,15 +19899,11 @@
         },
         "iferr": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/iferr/-/iferr-1.0.2.tgz",
-          "integrity": "sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg==",
           "bundled": true,
           "dev": true
         },
         "ignore-walk": {
           "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-          "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21427,29 +19912,21 @@
         },
         "import-lazy": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-          "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
           "bundled": true,
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "bundled": true,
           "dev": true
         },
         "infer-owner": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-          "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
           "bundled": true,
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21459,22 +19936,16 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
           "bundled": true,
           "dev": true
         },
         "ini": {
           "version": "1.3.8",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-          "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
           "bundled": true,
           "dev": true
         },
         "init-package-json": {
           "version": "1.10.3",
-          "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.3.tgz",
-          "integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21490,29 +19961,21 @@
         },
         "ip": {
           "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
           "bundled": true,
           "dev": true
         },
         "ip-regex": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-          "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
           "bundled": true,
           "dev": true
         },
         "is-callable": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-          "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
           "bundled": true,
           "dev": true
         },
         "is-ci": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-          "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21521,8 +19984,6 @@
           "dependencies": {
             "ci-info": {
               "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-              "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
               "bundled": true,
               "dev": true
             }
@@ -21530,8 +19991,6 @@
         },
         "is-cidr": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-3.0.0.tgz",
-          "integrity": "sha512-8Xnnbjsb0x462VoYiGlhEi+drY8SFwrHiSYuzc/CEwco55vkehTaxAyIjEdpi3EMvLPPJAJi9FlzP+h+03gp0Q==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21540,15 +19999,11 @@
         },
         "is-date-object": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-          "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
           "bundled": true,
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21557,8 +20012,6 @@
         },
         "is-installed-globally": {
           "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
-          "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21568,22 +20021,16 @@
         },
         "is-npm": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-          "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
           "bundled": true,
           "dev": true
         },
         "is-obj": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
           "bundled": true,
           "dev": true
         },
         "is-path-inside": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-          "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21592,15 +20039,11 @@
         },
         "is-redirect": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
           "bundled": true,
           "dev": true
         },
         "is-regex": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-          "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21609,22 +20052,16 @@
         },
         "is-retry-allowed": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-          "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
           "bundled": true,
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "bundled": true,
           "dev": true
         },
         "is-symbol": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-          "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21633,72 +20070,52 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
           "bundled": true,
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "bundled": true,
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "bundled": true,
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
           "bundled": true,
           "dev": true
         },
         "jsbn": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-          "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
           "bundled": true,
           "dev": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
           "bundled": true,
           "dev": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
           "bundled": true,
           "dev": true
         },
         "jsonparse": {
           "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-          "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
           "bundled": true,
           "dev": true
         },
         "JSONStream": {
           "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-          "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21708,8 +20125,6 @@
         },
         "jsprim": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21721,8 +20136,6 @@
         },
         "latest-version": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-          "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21731,15 +20144,11 @@
         },
         "lazy-property": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lazy-property/-/lazy-property-1.0.0.tgz",
-          "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
           "bundled": true,
           "dev": true
         },
         "libcipm": {
           "version": "4.0.8",
-          "resolved": "https://registry.npmjs.org/libcipm/-/libcipm-4.0.8.tgz",
-          "integrity": "sha512-IN3hh2yDJQtZZ5paSV4fbvJg4aHxCCg5tcZID/dSVlTuUiWktsgaldVljJv6Z5OUlYspx6xQkbR0efNodnIrOA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21762,8 +20171,6 @@
         },
         "libnpm": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/libnpm/-/libnpm-3.0.1.tgz",
-          "integrity": "sha512-d7jU5ZcMiTfBqTUJVZ3xid44fE5ERBm9vBnmhp2ECD2Ls+FNXWxHSkO7gtvrnbLO78gwPdNPz1HpsF3W4rjkBQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21791,8 +20198,6 @@
         },
         "libnpmaccess": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-3.0.2.tgz",
-          "integrity": "sha512-01512AK7MqByrI2mfC7h5j8N9V4I7MHJuk9buo8Gv+5QgThpOgpjB7sQBDDkeZqRteFb1QM/6YNdHfG7cDvfAQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21804,8 +20209,6 @@
         },
         "libnpmconfig": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/libnpmconfig/-/libnpmconfig-1.2.1.tgz",
-          "integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21816,8 +20219,6 @@
           "dependencies": {
             "find-up": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -21826,8 +20227,6 @@
             },
             "locate-path": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -21837,8 +20236,6 @@
             },
             "p-limit": {
               "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-              "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -21847,8 +20244,6 @@
             },
             "p-locate": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -21857,8 +20252,6 @@
             },
             "p-try": {
               "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
               "bundled": true,
               "dev": true
             }
@@ -21866,8 +20259,6 @@
         },
         "libnpmhook": {
           "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/libnpmhook/-/libnpmhook-5.0.3.tgz",
-          "integrity": "sha512-UdNLMuefVZra/wbnBXECZPefHMGsVDTq5zaM/LgKNE9Keyl5YXQTnGAzEo+nFOpdRqTWI9LYi4ApqF9uVCCtuA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21879,8 +20270,6 @@
         },
         "libnpmorg": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/libnpmorg/-/libnpmorg-1.0.1.tgz",
-          "integrity": "sha512-0sRUXLh+PLBgZmARvthhYXQAWn0fOsa6T5l3JSe2n9vKG/lCVK4nuG7pDsa7uMq+uTt2epdPK+a2g6btcY11Ww==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21892,8 +20281,6 @@
         },
         "libnpmpublish": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-1.1.2.tgz",
-          "integrity": "sha512-2yIwaXrhTTcF7bkJKIKmaCV9wZOALf/gsTDxVSu/Gu/6wiG3fA8ce8YKstiWKTxSFNC0R7isPUb6tXTVFZHt2g==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21910,8 +20297,6 @@
         },
         "libnpmsearch": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/libnpmsearch/-/libnpmsearch-2.0.2.tgz",
-          "integrity": "sha512-VTBbV55Q6fRzTdzziYCr64+f8AopQ1YZ+BdPOv16UegIEaE8C0Kch01wo4s3kRTFV64P121WZJwgmBwrq68zYg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21922,8 +20307,6 @@
         },
         "libnpmteam": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/libnpmteam/-/libnpmteam-1.0.2.tgz",
-          "integrity": "sha512-p420vM28Us04NAcg1rzgGW63LMM6rwe+6rtZpfDxCcXxM0zUTLl7nPFEnRF3JfFBF5skF/yuZDUthTsHgde8QA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21935,8 +20318,6 @@
         },
         "libnpx": {
           "version": "10.2.4",
-          "resolved": "https://registry.npmjs.org/libnpx/-/libnpx-10.2.4.tgz",
-          "integrity": "sha512-BPc0D1cOjBeS8VIBKUu5F80s6njm0wbVt7CsGMrIcJ+SI7pi7V0uVPGpEMH9H5L8csOcclTxAXFE2VAsJXUhfA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21952,8 +20333,6 @@
         },
         "lock-verify": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/lock-verify/-/lock-verify-2.1.0.tgz",
-          "integrity": "sha512-vcLpxnGvrqisKvLQ2C2v0/u7LVly17ak2YSgoK4PrdsYBXQIax19vhKiLfvKNFx7FRrpTnitrpzF/uuCMuorIg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21963,8 +20342,6 @@
         },
         "lockfile": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
-          "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21973,15 +20350,11 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
-          "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
           "bundled": true,
           "dev": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
-          "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21991,22 +20364,16 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-          "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
           "bundled": true,
           "dev": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
-          "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
           "bundled": true,
           "dev": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
-          "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22015,71 +20382,51 @@
         },
         "lodash._createset": {
           "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
-          "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
           "bundled": true,
           "dev": true
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
           "bundled": true,
           "dev": true
         },
         "lodash._root": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-          "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
           "bundled": true,
           "dev": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-          "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
           "bundled": true,
           "dev": true
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
           "bundled": true,
           "dev": true
         },
         "lodash.union": {
           "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-          "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
           "bundled": true,
           "dev": true
         },
         "lodash.uniq": {
           "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-          "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
           "bundled": true,
           "dev": true
         },
         "lodash.without": {
           "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
-          "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
           "bundled": true,
           "dev": true
         },
         "lowercase-keys": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-          "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
           "bundled": true,
           "dev": true
         },
         "lru-cache": {
           "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22088,8 +20435,6 @@
         },
         "make-dir": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22098,8 +20443,6 @@
         },
         "make-fetch-happen": {
           "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.2.tgz",
-          "integrity": "sha512-07JHC0r1ykIoruKO8ifMXu+xEU8qOXDFETylktdug6vJDACnP+HKevOu3PXyNPzFyTSlz8vrBYlBO1JZRe8Cag==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22118,22 +20461,16 @@
         },
         "meant": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/meant/-/meant-1.0.2.tgz",
-          "integrity": "sha512-KN+1uowN/NK+sT/Lzx7WSGIj2u+3xe5n2LbwObfjOhPZiA+cCfCm6idVl0RkEfjThkw5XJ96CyRcanq6GmKtUg==",
           "bundled": true,
           "dev": true
         },
         "mime-db": {
           "version": "1.35.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
-          "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
           "bundled": true,
           "dev": true
         },
         "mime-types": {
           "version": "2.1.19",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
-          "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22142,8 +20479,6 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22152,15 +20487,11 @@
         },
         "minimist": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "bundled": true,
           "dev": true
         },
         "minizlib": {
           "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-          "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22169,8 +20500,6 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -22182,8 +20511,6 @@
         },
         "mississippi": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
-          "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22201,8 +20528,6 @@
         },
         "mkdirp": {
           "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22211,8 +20536,6 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
               "bundled": true,
               "dev": true
             }
@@ -22220,8 +20543,6 @@
         },
         "move-concurrently": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
-          "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22235,8 +20556,6 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "bundled": true,
               "dev": true
             }
@@ -22244,22 +20563,16 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "bundled": true,
           "dev": true
         },
         "mute-stream": {
           "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
           "bundled": true,
           "dev": true
         },
         "node-fetch-npm": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
-          "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22270,8 +20583,6 @@
         },
         "node-gyp": {
           "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.1.0.tgz",
-          "integrity": "sha512-OUTryc5bt/P8zVgNUmC6xdXiDJxLMAW8cF5tLQOT9E5sOQj+UeQxnnPy74K3CLCa/SOjjBlbuzDLR8ANwA+wmw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22290,8 +20601,6 @@
         },
         "nopt": {
           "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-          "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22301,8 +20610,6 @@
         },
         "normalize-package-data": {
           "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22314,8 +20621,6 @@
           "dependencies": {
             "resolve": {
               "version": "1.10.0",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-              "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -22326,8 +20631,6 @@
         },
         "npm-audit-report": {
           "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/npm-audit-report/-/npm-audit-report-1.3.3.tgz",
-          "integrity": "sha512-8nH/JjsFfAWMvn474HB9mpmMjrnKb1Hx/oTAdjv4PT9iZBvBxiZ+wtDUapHCJwLqYGQVPaAfs+vL5+5k9QndXw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22337,8 +20640,6 @@
         },
         "npm-bundled": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
-          "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22347,15 +20648,11 @@
         },
         "npm-cache-filename": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
-          "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
           "bundled": true,
           "dev": true
         },
         "npm-install-checks": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.2.tgz",
-          "integrity": "sha512-E4kzkyZDIWoin6uT5howP8VDvkM+E8IQDcHAycaAxMbwkqhIg5eEYALnXOl3Hq9MrkdQB/2/g1xwBINXdKSRkg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22364,8 +20661,6 @@
         },
         "npm-lifecycle": {
           "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-3.1.5.tgz",
-          "integrity": "sha512-lDLVkjfZmvmfvpvBzA4vzee9cn+Me4orq0QF8glbswJVEbIcSNWib7qGOffolysc3teCqbbPZZkzbr3GQZTL1g==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22381,22 +20676,16 @@
         },
         "npm-logical-tree": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/npm-logical-tree/-/npm-logical-tree-1.2.1.tgz",
-          "integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg==",
           "bundled": true,
           "dev": true
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-          "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
           "bundled": true,
           "dev": true
         },
         "npm-package-arg": {
           "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.1.tgz",
-          "integrity": "sha512-qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22408,8 +20697,6 @@
         },
         "npm-packlist": {
           "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
-          "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22420,8 +20707,6 @@
         },
         "npm-pick-manifest": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-3.0.2.tgz",
-          "integrity": "sha512-wNprTNg+X5nf+tDi+hbjdHhM4bX+mKqv6XmPh7B5eG+QY9VARfQPfCEH013H5GqfNj6ee8Ij2fg8yk0mzps1Vw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22432,8 +20717,6 @@
         },
         "npm-profile": {
           "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/npm-profile/-/npm-profile-4.0.4.tgz",
-          "integrity": "sha512-Ta8xq8TLMpqssF0H60BXS1A90iMoM6GeKwsmravJ6wYjWwSzcYBTdyWa3DZCYqPutacBMEm7cxiOkiIeCUAHDQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22444,8 +20727,6 @@
         },
         "npm-registry-fetch": {
           "version": "4.0.7",
-          "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-4.0.7.tgz",
-          "integrity": "sha512-cny9v0+Mq6Tjz+e0erFAB+RYJ/AVGzkjnISiobqP8OWj9c9FLoZZu8/SPSKJWE17F1tk4018wfjV+ZbIbqC7fQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22460,8 +20741,6 @@
           "dependencies": {
             "safe-buffer": {
               "version": "5.2.1",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-              "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
               "bundled": true,
               "dev": true
             }
@@ -22469,8 +20748,6 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22479,15 +20756,11 @@
         },
         "npm-user-validate": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.1.tgz",
-          "integrity": "sha512-uQwcd/tY+h1jnEaze6cdX/LrhWhoBxfSknxentoqmIuStxUExxjWd3ULMLFPiFUrZKbOVMowH6Jq2FRWfmhcEw==",
           "bundled": true,
           "dev": true
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22499,36 +20772,26 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "bundled": true,
           "dev": true
         },
         "oauth-sign": {
           "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
           "bundled": true,
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "bundled": true,
           "dev": true
         },
         "object-keys": {
           "version": "1.0.12",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-          "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
           "bundled": true,
           "dev": true
         },
         "object.getownpropertydescriptors": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-          "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22538,8 +20801,6 @@
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22548,29 +20809,21 @@
         },
         "opener": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
-          "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
           "bundled": true,
           "dev": true
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "bundled": true,
           "dev": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "bundled": true,
           "dev": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22580,15 +20833,11 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "bundled": true,
           "dev": true
         },
         "package-json": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22600,8 +20849,6 @@
         },
         "pacote": {
           "version": "9.5.12",
-          "resolved": "https://registry.npmjs.org/pacote/-/pacote-9.5.12.tgz",
-          "integrity": "sha512-BUIj/4kKbwWg4RtnBncXPJd15piFSVNpTzY0rysSr3VnMowTYgkGKcaHrbReepAkjTr8lH2CVWRi58Spg2CicQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22639,8 +20886,6 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -22652,8 +20897,6 @@
         },
         "parallel-transform": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
-          "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22664,8 +20907,6 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -22680,8 +20921,6 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -22692,78 +20931,56 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "bundled": true,
           "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "bundled": true,
           "dev": true
         },
         "path-is-inside": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
           "bundled": true,
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "bundled": true,
           "dev": true
         },
         "path-parse": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
           "bundled": true,
           "dev": true
         },
         "performance-now": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
           "bundled": true,
           "dev": true
         },
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "bundled": true,
           "dev": true
         },
         "prepend-http": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
           "bundled": true,
           "dev": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "bundled": true,
           "dev": true
         },
         "promise-inflight": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-          "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
           "bundled": true,
           "dev": true
         },
         "promise-retry": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
-          "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22773,8 +20990,6 @@
           "dependencies": {
             "retry": {
               "version": "0.10.1",
-              "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-              "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
               "bundled": true,
               "dev": true
             }
@@ -22782,8 +20997,6 @@
         },
         "promzard": {
           "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
-          "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22792,15 +21005,11 @@
         },
         "proto-list": {
           "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-          "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
           "bundled": true,
           "dev": true
         },
         "protoduck": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.1.tgz",
-          "integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22809,29 +21018,21 @@
         },
         "prr": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-          "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
           "bundled": true,
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "bundled": true,
           "dev": true
         },
         "psl": {
           "version": "1.1.29",
-          "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-          "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
           "bundled": true,
           "dev": true
         },
         "pump": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22841,8 +21042,6 @@
         },
         "pumpify": {
           "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-          "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22853,8 +21052,6 @@
           "dependencies": {
             "pump": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-              "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -22866,29 +21063,21 @@
         },
         "punycode": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "bundled": true,
           "dev": true
         },
         "qrcode-terminal": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
-          "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
           "bundled": true,
           "dev": true
         },
         "qs": {
           "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
           "bundled": true,
           "dev": true
         },
         "query-string": {
           "version": "6.8.2",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.2.tgz",
-          "integrity": "sha512-J3Qi8XZJXh93t2FiKyd/7Ec6GNifsjKXUsVFkSBj/kjLsDylWhnCz4NT1bkPcKotttPW+QbKGqqPH8OoI2pdqw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22899,15 +21088,11 @@
         },
         "qw": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/qw/-/qw-1.0.1.tgz",
-          "integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=",
           "bundled": true,
           "dev": true
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22919,8 +21104,6 @@
         },
         "read": {
           "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-          "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22929,8 +21112,6 @@
         },
         "read-cmd-shim": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.5.tgz",
-          "integrity": "sha512-v5yCqQ/7okKoZZkBQUAfTsQ3sVJtXdNfbPnI5cceppoxEVLYA3k+VtV2omkeo8MS94JCy4fSiUwlRBAwCVRPUA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22939,8 +21120,6 @@
         },
         "read-installed": {
           "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
-          "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22955,8 +21134,6 @@
         },
         "read-package-json": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.1.tgz",
-          "integrity": "sha512-dAiqGtVc/q5doFz6096CcnXhpYk0ZN8dEKVkGLU0CsASt8SrgF6SF7OTKAYubfvFhWaqofl+Y8HK19GR8jwW+A==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22969,8 +21146,6 @@
         },
         "read-package-tree": {
           "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.3.1.tgz",
-          "integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22981,8 +21156,6 @@
         },
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22993,8 +21166,6 @@
         },
         "readdir-scoped-modules": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
-          "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23006,8 +21177,6 @@
         },
         "registry-auth-token": {
           "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
-          "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23017,8 +21186,6 @@
         },
         "registry-url": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23027,8 +21194,6 @@
         },
         "request": {
           "version": "2.88.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23056,36 +21221,26 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "bundled": true,
           "dev": true
         },
         "require-main-filename": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
           "bundled": true,
           "dev": true
         },
         "resolve-from": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "bundled": true,
           "dev": true
         },
         "retry": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-          "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
           "bundled": true,
           "dev": true
         },
         "rimraf": {
           "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23094,8 +21249,6 @@
         },
         "run-queue": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
-          "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23104,8 +21257,6 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "bundled": true,
               "dev": true
             }
@@ -23113,29 +21264,21 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "bundled": true,
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "bundled": true,
           "dev": true
         },
         "semver": {
           "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "bundled": true,
           "dev": true
         },
         "semver-diff": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-          "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23144,15 +21287,11 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "bundled": true,
           "dev": true
         },
         "sha": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/sha/-/sha-3.0.0.tgz",
-          "integrity": "sha512-DOYnM37cNsLNSGIG/zZWch5CKIRNoLdYUQTQlcgkRkoYIUwDYjqDyye16YcDZg/OPdcbUgTKMjc4SY6TB7ZAPw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23161,8 +21300,6 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23171,36 +21308,26 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "bundled": true,
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "bundled": true,
           "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
           "bundled": true,
           "dev": true
         },
         "smart-buffer": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
-          "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
           "bundled": true,
           "dev": true
         },
         "socks": {
           "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
-          "integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23210,8 +21337,6 @@
         },
         "socks-proxy-agent": {
           "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
-          "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23221,8 +21346,6 @@
           "dependencies": {
             "agent-base": {
               "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-              "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23233,15 +21356,11 @@
         },
         "sorted-object": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
-          "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
           "bundled": true,
           "dev": true
         },
         "sorted-union-stream": {
           "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
-          "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23251,8 +21370,6 @@
           "dependencies": {
             "from2": {
               "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
-              "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23262,15 +21379,11 @@
             },
             "isarray": {
               "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
               "bundled": true,
               "dev": true
             },
             "readable-stream": {
               "version": "1.1.14",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23282,8 +21395,6 @@
             },
             "string_decoder": {
               "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
               "bundled": true,
               "dev": true
             }
@@ -23291,8 +21402,6 @@
         },
         "spdx-correct": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-          "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23302,15 +21411,11 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-          "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
           "bundled": true,
           "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23320,22 +21425,16 @@
         },
         "spdx-license-ids": {
           "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-          "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
           "bundled": true,
           "dev": true
         },
         "split-on-first": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-          "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
           "bundled": true,
           "dev": true
         },
         "sshpk": {
           "version": "1.14.2",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-          "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23352,8 +21451,6 @@
         },
         "ssri": {
           "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23362,8 +21459,6 @@
         },
         "stream-each": {
           "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
-          "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23373,8 +21468,6 @@
         },
         "stream-iterate": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
-          "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23384,8 +21477,6 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23400,8 +21491,6 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23412,22 +21501,16 @@
         },
         "stream-shift": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-          "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
           "bundled": true,
           "dev": true
         },
         "strict-uri-encode": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-          "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
           "bundled": true,
           "dev": true
         },
         "string_decoder": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23436,8 +21519,6 @@
           "dependencies": {
             "safe-buffer": {
               "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-              "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
               "bundled": true,
               "dev": true
             }
@@ -23445,8 +21526,6 @@
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23456,22 +21535,16 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "bundled": true,
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "bundled": true,
               "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23482,15 +21555,11 @@
         },
         "stringify-package": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.1.tgz",
-          "integrity": "sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==",
           "bundled": true,
           "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23499,22 +21568,16 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "bundled": true,
           "dev": true
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "bundled": true,
           "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23523,8 +21586,6 @@
         },
         "tar": {
           "version": "4.4.13",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23539,8 +21600,6 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23552,8 +21611,6 @@
         },
         "term-size": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-          "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23562,22 +21619,16 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
           "bundled": true,
           "dev": true
         },
         "through": {
           "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
           "bundled": true,
           "dev": true
         },
         "through2": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23587,8 +21638,6 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23603,8 +21652,6 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23615,22 +21662,16 @@
         },
         "timed-out": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
           "bundled": true,
           "dev": true
         },
         "tiny-relative-date": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/tiny-relative-date/-/tiny-relative-date-1.3.0.tgz",
-          "integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A==",
           "bundled": true,
           "dev": true
         },
         "tough-cookie": {
           "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23640,8 +21681,6 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23650,37 +21689,27 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "typedarray": {
           "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
           "bundled": true,
           "dev": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
           "bundled": true,
           "dev": true
         },
         "umask": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
-          "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
           "bundled": true,
           "dev": true
         },
         "unique-filename": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-          "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23689,8 +21718,6 @@
         },
         "unique-slug": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
-          "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23699,8 +21726,6 @@
         },
         "unique-string": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-          "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23709,22 +21734,16 @@
         },
         "unpipe": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
           "bundled": true,
           "dev": true
         },
         "unzip-response": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
           "bundled": true,
           "dev": true
         },
         "update-notifier": {
           "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
-          "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23742,8 +21761,6 @@
         },
         "uri-js": {
           "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-          "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23752,8 +21769,6 @@
           "dependencies": {
             "punycode": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-              "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
               "bundled": true,
               "dev": true
             }
@@ -23761,8 +21776,6 @@
         },
         "url-parse-lax": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23771,22 +21784,16 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "bundled": true,
           "dev": true
         },
         "util-extend": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
-          "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
           "bundled": true,
           "dev": true
         },
         "util-promisify": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/util-promisify/-/util-promisify-2.1.0.tgz",
-          "integrity": "sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23795,15 +21802,11 @@
         },
         "uuid": {
           "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-          "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
           "bundled": true,
           "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-          "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23813,8 +21816,6 @@
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-          "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23823,8 +21824,6 @@
         },
         "verror": {
           "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23835,8 +21834,6 @@
         },
         "wcwidth": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-          "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23845,8 +21842,6 @@
         },
         "which": {
           "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23855,15 +21850,11 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "bundled": true,
           "dev": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23872,8 +21863,6 @@
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23886,8 +21875,6 @@
         },
         "widest-line": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
-          "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23896,8 +21883,6 @@
         },
         "worker-farm": {
           "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
-          "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23906,8 +21891,6 @@
         },
         "wrap-ansi": {
           "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23918,22 +21901,16 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
               "bundled": true,
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "bundled": true,
               "dev": true
             },
             "string-width": {
               "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23944,8 +21921,6 @@
             },
             "strip-ansi": {
               "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -23956,15 +21931,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "bundled": true,
           "dev": true
         },
         "write-file-atomic": {
           "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-          "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23975,36 +21946,26 @@
         },
         "xdg-basedir": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-          "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
           "bundled": true,
           "dev": true
         },
         "xtend": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "bundled": true,
           "dev": true
         },
         "y18n": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "bundled": true,
           "dev": true
         },
         "yallist": {
           "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "bundled": true,
           "dev": true
         },
         "yargs": {
           "version": "14.2.3",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
-          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24023,15 +21984,11 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
               "bundled": true,
               "dev": true
             },
             "find-up": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -24040,15 +21997,11 @@
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "bundled": true,
               "dev": true
             },
             "locate-path": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -24058,8 +22011,6 @@
             },
             "p-limit": {
               "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -24068,8 +22019,6 @@
             },
             "p-locate": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -24078,15 +22027,11 @@
             },
             "p-try": {
               "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
               "bundled": true,
               "dev": true
             },
             "string-width": {
               "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -24097,8 +22042,6 @@
             },
             "strip-ansi": {
               "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -24109,8 +22052,6 @@
         },
         "yargs-parser": {
           "version": "15.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -24120,8 +22061,6 @@
           "dependencies": {
             "camelcase": {
               "version": "5.3.1",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
               "bundled": true,
               "dev": true
             }
@@ -24315,7 +22254,6 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -24419,8 +22357,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "object-inspect": {
       "version": "1.9.0",
@@ -25297,9 +23234,9 @@
       "dev": true
     },
     "semantic-release": {
-      "version": "17.3.9",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.3.9.tgz",
-      "integrity": "sha512-iPDySFcAXG+7KiM0JH4bvF++imkf85VmfXpIBPAyDxK/P4+pe19KNFCfkzTKwUJkTIAyLUIr7WOg3W5h5aMwNg==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.4.1.tgz",
+      "integrity": "sha512-o/Rjk0HCBUWEYxN99Vq04Th+XtRQAxbC+FN+pBQ49wpqQ5NW/cfwhfw0qyxeTEhbchQ/1/KGMPWqD4/rRScAag==",
       "dev": true,
       "requires": {
         "@semantic-release/commit-analyzer": "^8.0.0",
@@ -25320,7 +23257,7 @@
         "hosted-git-info": "^3.0.0",
         "lodash": "^4.17.15",
         "marked": "^2.0.0",
-        "marked-terminal": "^4.0.0",
+        "marked-terminal": "^4.1.1",
         "micromatch": "^4.0.2",
         "p-each-series": "^2.1.0",
         "p-reduce": "^2.0.0",
@@ -25460,9 +23397,9 @@
           }
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -25957,64 +23894,6 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
-    "superagent": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
-      "integrity": "sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==",
-      "dev": true,
-      "requires": {
-        "component-emitter": "^1.3.0",
-        "cookiejar": "^2.1.2",
-        "debug": "^4.1.1",
-        "fast-safe-stringify": "^2.0.7",
-        "form-data": "^3.0.0",
-        "formidable": "^1.2.2",
-        "methods": "^1.1.2",
-        "mime": "^2.4.6",
-        "qs": "^6.9.4",
-        "readable-stream": "^3.6.0",
-        "semver": "^7.3.2"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "qs": {
-          "version": "6.9.6",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
-          "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
-      }
-    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -26071,9 +23950,9 @@
           "dev": true
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -26437,17 +24316,29 @@
       }
     },
     "typescript": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.2.tgz",
-      "integrity": "sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
+      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
       "dev": true
     },
     "uglify-js": {
-      "version": "3.12.8",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.8.tgz",
-      "integrity": "sha512-fvBeuXOsvqjecUtF/l1dwsrrf5y2BCUk9AOJGzGcm6tE7vegku5u/YvqjyDaAGr422PLoLnrxg3EnRvTqsdC1w==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.0.tgz",
+      "integrity": "sha512-TWYSWa9T2pPN4DIJYbU9oAjQx+5qdV5RUDxwARg8fmJZrD/V27Zj0JngW5xg1DFz42G0uDYl2XhzF6alSzD62w==",
       "dev": true,
       "optional": true
+    },
+    "unbox-primitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.0.tgz",
+      "integrity": "sha512-P/51NX+JXyxK/aigg1/ZgyccdAxm5K1+n8+tvqSntjOivPt19gvm1VC49RWYetsiub8WViUchdxl/KWHHB0kzA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.0",
+        "has-symbols": "^1.0.0",
+        "which-boxed-primitive": "^1.0.1"
+      }
     },
     "unique-string": {
       "version": "2.0.0",
@@ -26498,9 +24389,9 @@
       "dev": true
     },
     "v8-compile-cache": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
-      "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -26540,6 +24431,19 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
+      }
+    },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
       }
     },
     "which-module": {
@@ -26593,9 +24497,9 @@
           "dev": true
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -26710,9 +24614,9 @@
           }
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -48,12 +48,10 @@
     "nyc": "^15.0.0",
     "prettier": "2.2.1",
     "proxyquire": "^2.1.0",
-    "request": "^2.83.0",
     "rimraf": "^3.0.0",
     "semantic-release": "^17.0.2",
     "sinon": "^9.0.0",
     "sinon-chai": "^3.3.0",
-    "superagent": "^6.1.0",
     "typescript": "^4.2.2"
   },
   "scripts": {

--- a/tests/test_fake_timer.js
+++ b/tests/test_fake_timer.js
@@ -1,20 +1,16 @@
 'use strict'
 
-const { expect } = require('chai')
-const request = require('request')
 const fakeTimers = require('@sinonjs/fake-timers')
 const nock = require('..')
+const got = require('./got_client')
 
 // https://github.com/nock/nock/issues/1334
-it('should still return successfully when fake timer is enabled', done => {
+it('should still return successfully when fake timer is enabled', async () => {
   const clock = fakeTimers.install()
-  nock('http://example.test').get('/').reply(200)
+  const scope = nock('http://example.test').get('/').reply()
 
-  request.get('http://example.test', function (err, resp) {
-    clock.uninstall()
+  await got('http://example.test')
 
-    expect(err).to.be.null()
-    expect(resp.statusCode).to.equal(200)
-    done()
-  })
+  clock.uninstall()
+  scope.done()
 })


### PR DESCRIPTION
There were three tests simply using `superagent`, but not testing anything Nock related, so they were removed.
Two tests were using `request`, but were easily converted to `got`.
One test was testing an issue related to `request` strictSSL. The underlying issue was discovered, commented, and the test updated to use `https` instead.
And one test ("test request timeout option") wasn't actually testing anything Nock related, so it was removed.

Closes: #1777