### PR TITLE
fix(interceptor): don't require leading slash if Scope has a base pathname

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -32,8 +32,9 @@ module.exports = class Interceptor {
     // When enabled filteringScope ignores the passed URL entirely so we skip validation.
 
     if (
-      !scope.scopeOptions.filteringScope &&
       uriIsStr &&
+      !scope.scopeOptions.filteringScope &&
+      !scope.basePathname &&
       !uri.startsWith('/') &&
       !uri.startsWith('*')
     ) {


### PR DESCRIPTION
Fixes: #2042