### PR TITLE
docs(readme): remove Dependabot badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![npm](https://img.shields.io/npm/v/nock.svg)][npmjs]
 [![Build Status](https://travis-ci.org/nock/nock.svg)][build]
 ![Coverage Status](http://img.shields.io/badge/coverage-100%25-brightgreen.svg)
-![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=nock/nock)
 [![Backers on Open Collective](https://opencollective.com/nock/backers/badge.svg)](#backers)
 [![Sponsors on Open Collective](https://opencollective.com/nock/sponsors/badge.svg)](#sponsors)
 


### PR DESCRIPTION
## Changes:

- Remove "inactive" Dependabot badge

## Context:

The readme has a Dependabot badge, that says that Dependabot is not working.
This is not true, as you do have Dependabot, just the GitHub native one.

GitHub native Dependabot doesn't have a functioning badge from GitHub themselves.
You could take a look at shields.io to create your own Dependabot badge and put that in the README.

There's an issue that asks for Dependabot to provide a working badge here: https://github.com/dependabot/dependabot-core/issues/1912