### PR TITLE
fix(types): add missing argument to optionally()

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -198,7 +198,7 @@ declare namespace nock {
     once(): this
     twice(): this
     thrice(): this
-    optionally(): this
+    optionally(flag?: boolean): this
 
     delay(opts: number | { head?: number; body?: number }): this
     delayBody(timeMs: number): this


### PR DESCRIPTION
I noticed that the type for `Interceptor.optionally()` was missing the optional `flag` parameter. This PR fixes that.