### PR TITLE
fix(interceptor): don't hang, don't leak resources

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -442,12 +442,16 @@ module.exports = class Interceptor {
   markConsumed() {
     this.interceptionCounter++
 
-    remove(this)
-
-    if ((this.scope.shouldPersist() || this.counter > 0) && this.filePath) {
+    if (
+      (this.scope.shouldPersist() || this.counter > 0) &&
+      this.interceptionCounter > 1 &&
+      this.filePath
+    ) {
       this.body = fs.createReadStream(this.filePath)
       this.body.pause()
     }
+
+    remove(this)
 
     if (!this.scope.shouldPersist() && this.counter < 1) {
       this.scope.remove(this._key, this)

--- a/tests/test_reply_with_file.js
+++ b/tests/test_reply_with_file.js
@@ -2,7 +2,9 @@
 
 // Tests for `.replyWithFile()`.
 
+const fs = require('fs')
 const path = require('path')
+const sinon = require('sinon')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire').preserveCache()
 const nock = require('..')
@@ -36,6 +38,29 @@ describe('`replyWithFile()`', () => {
 
     expect(statusCode).to.equal(200)
     expect(body).to.have.lengthOf(20)
+    scope.done()
+  })
+
+  it('reply with file with repeated', async () => {
+    sinon.spy(fs)
+
+    const scope = nock('http://example.test')
+      .get('/')
+      .times(2)
+      .replyWithFile(200, binaryFilePath, {
+        'content-encoding': 'gzip',
+      })
+
+    const response1 = await got('http://example.test/')
+    expect(response1.statusCode).to.equal(200)
+    expect(response1.body).to.have.lengthOf(20)
+
+    const response2 = await got('http://example.test/')
+    expect(response2.statusCode).to.equal(200)
+    expect(response2.body).to.have.lengthOf(20)
+
+    expect(fs.createReadStream.callCount).to.equal(2)
+
     scope.done()
   })
 


### PR DESCRIPTION
 - The first commit fixes an issue that caused the last request to hang when using a combination of `.times()` and `.replyWithFile()` - the counter was being decremented too early, which meant the `if` on the next line didn't pass and the last request didn't get a fresh `body`
 - The second commit fixes a resource leak - because a stream is created [here](https://github.com/nock/nock/blob/eb742c20367e7b149ed63d4ffd14f8676222fdc0/lib/interceptor.js#L196) when calling `.replyWithFile()`, it should be consumed on the first call, and a new one should only be created [here](https://github.com/nock/nock/blob/eb742c20367e7b149ed63d4ffd14f8676222fdc0/lib/interceptor.js#L450) on the 2nd call.

The added test catches both of these issues.