### PR TITLE
docs: add async/await example for nock back

### DIFF
--- a/README.md
+++ b/README.md
@@ -1402,6 +1402,14 @@ return nockBack('promisedFixture.json').then(({ nockDone, context }) => {
 })
 ```
 
+Or, with async/await:
+
+```js
+const { nockDone, context } = await nockBack('promisedFixture.json')
+//  your test code
+nockDone()
+```
+
 #### Options
 
 As an optional second parameter you can pass the following options


### PR DESCRIPTION
This pull request adds an async/await example for the nock back functionality.