### PR TITLE
fix(type): add `update` type for record mode

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -240,7 +240,7 @@ declare namespace nock {
     options?: Options
   }
 
-  type BackMode = 'wild' | 'dryrun' | 'record' | 'lockdown'
+  type BackMode = 'wild' | 'dryrun' | 'record' | 'update' | 'lockdown'
 
   interface Back {
     currentMode: BackMode


### PR DESCRIPTION
Included `'update'` in the `BackMode` union, following [the introduction of the update mode](//github.com/nock/nock/pull/2241).