### PR TITLE
Simple interceptor enable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ This means that you can intercept 2 or more calls to the same URL and return dif
 It also means that you must setup one interceptor for each request you are going to have, otherwise nock will throw an error because that URL was not present in the interceptor list.
 If you don’t want interceptors to be removed as they are used, you can use the [.persist()](#persist) method.
 
+> You can always disable an interceptor by setting `Interceptor.enabled` to false
+
 ### Specifying hostname
 
 The request hostname can be a string or a RegExp.
@@ -1064,7 +1066,7 @@ Only for cases where nock has been deactivated using [nock.restore()](#restoring
 nock.activate()
 ```
 
-**note**: To check if nock HTTP interceptor is active or inactive, use [nock.isActive()](#isactive).
+**note**: To check if nock HTTP interceptor is active or inactive, use [nock.isActive()](#isactive). This will not check for the property `.enabled`
 
 ## Turning Nock Off (experimental!)
 
@@ -1300,6 +1302,8 @@ nock.recorder.rec({
 
 This allows removing a specific interceptor. This can be either an interceptor instance or options for a url. It's useful when there's a list of common interceptors shared between tests, where an individual test requires one of the shared interceptors to behave differently.
 
+> If you expect to use the interceptor later, you can set the `Interceptor.enabled` property to `false` to temporarily disable the interceptor
+
 Examples:
 
 ```js
@@ -1333,6 +1337,11 @@ nock.removeInterceptor(interceptor)
 const interceptor = nock('http://example.org').get('somePath')
 interceptor.reply(200, 'OK')
 nock.removeInterceptor(interceptor)
+```
+
+```js
+const interceptor = nock('http://example.org').get('somePath')
+interceptor.enabled = false
 ```
 
 ## Events

--- a/lib/intercepted_request_router.js
+++ b/lib/intercepted_request_router.js
@@ -285,8 +285,8 @@ class InterceptedRequestRouter {
       requestBodyIsUtf8Representable ? 'utf8' : 'hex'
     )
 
-    const matchedInterceptor = interceptors.find(i =>
-      i.match(req, options, requestBodyString)
+    const matchedInterceptor = interceptors.find(
+      i => i.match(req, options, requestBodyString) && i.enabled
     )
 
     if (matchedInterceptor) {

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -53,6 +53,7 @@ module.exports = class Interceptor {
     this.interceptorMatchHeaders = []
     this.method = method.toUpperCase()
     this.uri = uri
+    this.enabled = true
     this._key = `${this.method} ${scope.basePath}${scope.basePathname}${
       uriIsStr ? '' : '/'
     }${uri}`

--- a/tests/test_intercept_toggle.js
+++ b/tests/test_intercept_toggle.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const { expect } = require('chai')
+const nock = require('..')
+
+const got = require('./got_client')
+const servers = require('./servers')
+
+// Tests for unnocking via "enabled" property
+
+describe('toggling interceptors', () => {
+  it('interceptor is enabled', async () => {
+    const { origin } = await servers.startHttpServer((req, res) => {
+      res.json(JSON.stringify({ status: false }))
+    })
+
+    const interceptor = nock(`${origin}/`)
+
+    interceptor.get('/').reply(200, { status: true })
+
+    let { body } = await got(`${origin}/`)
+
+    body = JSON.parse(body)
+
+    expect(body.status).to.equal(true)
+  })
+
+  it('interceptor is disabled', async () => {
+    const { origin } = await servers.startHttpServer((req, res) => {
+      res.writeHead(200)
+      res.end(JSON.stringify({ status: false }))
+    })
+
+    const interceptor = nock(`${origin}/`)
+
+    interceptor.enabled = false
+
+    let { body } = await got(`${origin}/`)
+
+    body = JSON.parse(body)
+
+    expect(body.status).to.equal(false)
+  })
+})


### PR DESCRIPTION
This PR allows a simple `enabled` property to be processed

Before:
 * In order to temporary remove an interceptor, one must call `.removeInterceptor` and call `.get` on the interceptor with the same function call again

After:
 * Just set `enabled` property to false

What this PR covers
 * Code changes
 * Unit tests (2 more)
 * Documentation update

Summary of code change:
 * Created new property called `enabled` in `Interceptor`
 * Added an additional filter condition in `InterceptedRequestRouter#startPlayback` for `matchedInterceptor` list