### PR TITLE
Fix Duplicate Headers

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -202,7 +202,7 @@ function headersFieldNamesToLowerCase(headers) {
   const lowerCaseHeaders = {}
   Object.entries(headers).forEach(([fieldName, fieldValue]) => {
     const key = fieldName.toLowerCase()
-    const regex = new RegExp(fieldValue, 'i');
+    const regex = new RegExp(`^{fieldValue}$`, 'i');
     if(fieldValue instanceof RegExp && lowerCaseHeaders[key] === undefined) {
       lowerCaseHeaders[key] = fieldValue
     } else if (!regex.test(lowerCaseHeaders[key])) {

--- a/lib/common.js
+++ b/lib/common.js
@@ -202,7 +202,7 @@ function headersFieldNamesToLowerCase(headers) {
   const lowerCaseHeaders = {}
   Object.entries(headers).forEach(([fieldName, fieldValue]) => {
     const key = fieldName.toLowerCase()
-    const regex = new RegExp(`^{fieldValue}$`, 'i');
+    const regex = new RegExp(`^${fieldValue}$`, 'i');
     if(fieldValue instanceof RegExp && lowerCaseHeaders[key] === undefined) {
       lowerCaseHeaders[key] = fieldValue
     } else if (!regex.test(lowerCaseHeaders[key])) {

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -170,9 +170,11 @@ describe('`headersFieldNamesToLowerCase()`', () => {
       hOsT: 'example.test',
       HoSt: 'example.test',
       HOST: 'final.example.test',
+      hosts: 'final.example.test'
     })
     const expected = {
       host: 'final.example.test',
+      hosts: 'final.example.test'
     }
 
     expect(results).to.deep.equal(expected)


### PR DESCRIPTION
- Changed the headersFieldNamesToLowerCase method to handle duplicate headers taking the last value provided.
- Updated tests to reflect changes.
- Likely fixes:  #2235

This is my first PR to nock please let me know if there are any additional steps needed.