### PR TITLE
docs(RFC): fix typo in rfc-001.md

### DIFF
--- a/rfcs/rfc-001.md
+++ b/rfcs/rfc-001.md
@@ -5,7 +5,7 @@
 
 In Nock v10/v11, the lifecycle methods are confusingly named, difficult to
 understand, and at times inconvenient. Unless they are studied carefully, it
-is easy to inadvertantly leave unwanted state in Nock.
+is easy to inadvertently leave unwanted state in Nock.
 
 Nock doesn't automatically provide a way to assert that mocks have been
 satisfied; it's the caller's responsibility to do this for each mock.


### PR DESCRIPTION
inadvertantly -> inadvertently