### PR TITLE
Make replyContentLength to work on strings and buffers

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -155,6 +155,14 @@ module.exports = class Interceptor {
       this.rawHeaders.concat(this.scope._defaultReplyHeaders)
     )
 
+    if (body && this.scope.contentLen) {
+      if (typeof body === 'string') {
+        this.rawHeaders.push('Content-Length', body.length);
+      } else if (Buffer.isBuffer(body)) {
+        this.rawHeaders.push('Content-Length', body.byteLength);
+      }
+    }
+
     //  If the content is not encoded we may need to transform the response body.
     //  Otherwise we leave it as it is.
     if (

--- a/tests/test_reply_headers.js
+++ b/tests/test_reply_headers.js
@@ -331,6 +331,34 @@ describe('`replyContentLength()`', () => {
     )
     scope.done()
   })
+
+  it('sends explicit content-length header with string response', async () => {
+    const response = '<html><body>...</body></html>'
+
+    const scope = nock('http://example.test')
+      .replyContentLength()
+      .get('/')
+      .reply(200, response)
+
+    const { headers } = await got('http://example.test/')
+
+    expect(headers['content-length']).to.equal(`${response.length}`)
+    scope.done()
+  })
+
+  it('sends explicit content-length header with buffer response', async () => {
+    const response = Buffer.from([1, 2, 3, 4, 5, 6]);
+
+    const scope = nock('http://example.test')
+      .replyContentLength()
+      .get('/')
+      .reply(200, response)
+
+    const { headers } = await got('http://example.test/')
+
+    expect(headers['content-length']).to.equal(`${response.byteLength}`)
+    scope.done()
+  })
 })
 
 describe('`replyDate()`', () => {


### PR DESCRIPTION
Use case:

```
nock('http://example.test')
  .replyContentLength()
  .get('/')
  .reply(200, 'foobarbaz')
```