### PR TITLE
chore(deps-dev): migrate dtslint to @definitelytyped/dtslint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,11 @@
         "propagate": "^2.0.0"
       },
       "devDependencies": {
+        "@definitelytyped/dtslint": "^0.0.103",
         "@sinonjs/fake-timers": "^9.0.0",
         "assert-rejects": "^1.0.0",
         "chai": "^4.1.2",
         "dirty-chai": "^2.0.1",
-        "dtslint": "^4.0.4",
         "eslint": "^8.8.0",
         "eslint-config-prettier": "^8.1.0",
         "eslint-config-standard": "^17.0.0-0",
@@ -95,15 +95,6 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/generator": {
       "version": "7.16.8",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.8.tgz",
@@ -134,15 +125,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
@@ -436,30 +418,76 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@definitelytyped/header-parser": {
+    "node_modules/@definitelytyped/dts-critic": {
       "version": "0.0.103",
-      "resolved": "https://registry.npmjs.org/@definitelytyped/header-parser/-/header-parser-0.0.103.tgz",
-      "integrity": "sha512-MZRm+Sx8h+oT587QmbQeFbctqMQk0NS9WVrrYtDXkui36NFsyjhCPgVVuU8fZoJxTGvoNVAoziZQ7TzCZPXI6Q==",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/dts-critic/-/dts-critic-0.0.103.tgz",
+      "integrity": "sha512-QI0/MIf8RcZbxBJCykiq48tH+QDo722ks3I8lst6A7hVa2+7m3dx7LqCCh0Bs6h2moewgvIaX++qebokZitKfQ==",
       "dev": true,
       "dependencies": {
-        "@definitelytyped/typescript-versions": "^0.0.103",
+        "@definitelytyped/header-parser": "latest",
+        "command-exists": "^1.2.8",
+        "rimraf": "^3.0.2",
+        "semver": "^6.2.0",
+        "tmp": "^0.2.1",
+        "yargs": "^15.3.1"
+      },
+      "engines": {
+        "node": ">=10.17.0"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/@definitelytyped/dtslint": {
+      "version": "0.0.103",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/dtslint/-/dtslint-0.0.103.tgz",
+      "integrity": "sha512-BjRioCLzf77VRNCgl97uirKYvhirlh4wPIL28BS+pYdy5UxFALlZBDVY91h/KXZRXySp6QsxO0XF6jbWeqhJqA==",
+      "dev": true,
+      "dependencies": {
+        "@definitelytyped/dts-critic": "^0.0.103",
+        "@definitelytyped/header-parser": "0.0.93",
+        "@definitelytyped/typescript-versions": "0.0.93",
+        "@definitelytyped/utils": "0.0.93",
+        "fs-extra": "^6.0.1",
+        "json-stable-stringify": "^1.0.1",
+        "strip-json-comments": "^2.0.1",
+        "tslint": "5.14.0",
+        "yargs": "^15.1.0"
+      },
+      "bin": {
+        "dtslint": "bin/src/index.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">= 3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.7.0-dev || >= 3.8.0-dev || >= 3.9.0-dev || >= 4.0.0-dev"
+      }
+    },
+    "node_modules/@definitelytyped/header-parser": {
+      "version": "0.0.93",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/header-parser/-/header-parser-0.0.93.tgz",
+      "integrity": "sha512-ywrpndOfwQ1CLG6n9DVQYICDW1CPglb/XxzhKMOonYrw2qifuWMeLioszsQsOYpg5jnwCwa8V7moK2TfkI5ztQ==",
+      "dev": true,
+      "dependencies": {
+        "@definitelytyped/typescript-versions": "^0.0.93",
         "@types/parsimmon": "^1.10.1",
         "parsimmon": "^1.13.0"
       }
     },
     "node_modules/@definitelytyped/typescript-versions": {
-      "version": "0.0.103",
-      "resolved": "https://registry.npmjs.org/@definitelytyped/typescript-versions/-/typescript-versions-0.0.103.tgz",
-      "integrity": "sha512-OzwYh4O3egHmlV16a/VSbb+fXz9YYIlIQn3d1GJyPS//prCaZBbvDg4cxJ+k1T78C6vNL7Iky1MUb7r3DUkfkw==",
+      "version": "0.0.93",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/typescript-versions/-/typescript-versions-0.0.93.tgz",
+      "integrity": "sha512-ymWcBsmZykBMOXy4fF4WsBnJp7qCM3rropPXDfH5V8n2Ie2cK3Ths1kAxD1k80IWCish7EdznWPP4ZRxurycBw==",
       "dev": true
     },
     "node_modules/@definitelytyped/utils": {
-      "version": "0.0.103",
-      "resolved": "https://registry.npmjs.org/@definitelytyped/utils/-/utils-0.0.103.tgz",
-      "integrity": "sha512-6QsbhSx2FiP6RVewnNV+P3yU1bGT44kXlouae6iQ5zFb1BVo3E2LOG13R3IBabU6o8HqOz8Qz3Bhge0v/PInqQ==",
+      "version": "0.0.93",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/utils/-/utils-0.0.93.tgz",
+      "integrity": "sha512-FBZhEoSxWtUTbwfwpehTssTyzgiEraAv4PBKjRr2sVVU1H3lIFTG/DlZO2ymfs3EbPr1zS5S0yt05RQFZlFjAQ==",
       "dev": true,
       "dependencies": {
-        "@definitelytyped/typescript-versions": "^0.0.103",
+        "@definitelytyped/typescript-versions": "^0.0.93",
         "@qiwi/npm-registry-client": "^8.9.1",
         "@types/node": "^14.14.35",
         "charm": "^1.0.2",
@@ -859,6 +887,21 @@
         "npmlog": "2 || ^3.1.0 || ^4.0.0"
       }
     },
+    "node_modules/@qiwi/npm-registry-client/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@semantic-release/commit-analyzer": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-9.0.2.tgz",
@@ -1071,6 +1114,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@semantic-release/npm/node_modules/type-fest": {
@@ -1978,9 +2036,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001304",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001304.tgz",
-      "integrity": "sha512-bdsfZd6K6ap87AGqSHJP/s1V+U6Z5lyrcbBu3ovbCCf8cSYpwTtGrCBObMpJqwxfTbLW6YTIdbb1jEeTelcpYQ==",
+      "version": "1.0.30001305",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001305.tgz",
+      "integrity": "sha512-p7d9YQMji8haf0f+5rbcv9WlQ+N5jMPfRAnUmZRlNxsNeBO3Yr7RYG6M2uTY1h9tCVdlkJg6YNNc4kiAiBLdWA==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -2325,15 +2383,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/conventional-changelog-writer/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/conventional-commits-filter": {
@@ -2732,62 +2781,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/dts-critic": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/dts-critic/-/dts-critic-3.3.11.tgz",
-      "integrity": "sha512-HMO2f9AO7ge44YO8OK18f+cxm/IaE1CFuyNFbfJRCEbyazWj5X5wWDF6W4CGdo5Ax0ILYVfJ7L/rOwuUN1fzWw==",
-      "dev": true,
-      "dependencies": {
-        "@definitelytyped/header-parser": "latest",
-        "command-exists": "^1.2.8",
-        "rimraf": "^3.0.2",
-        "semver": "^6.2.0",
-        "tmp": "^0.2.1",
-        "yargs": "^15.3.1"
-      },
-      "engines": {
-        "node": ">=10.17.0"
-      },
-      "peerDependencies": {
-        "typescript": "*"
-      }
-    },
-    "node_modules/dts-critic/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/dtslint": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/dtslint/-/dtslint-4.2.1.tgz",
-      "integrity": "sha512-57mWY9osUEfS6k62ATS9RSgug1dZcuN4O31hO76u+iEexa6VUEbKoPGaA2mNtc0FQDcdTl0zEUtti79UQKSQyQ==",
-      "dev": true,
-      "dependencies": {
-        "@definitelytyped/header-parser": "latest",
-        "@definitelytyped/typescript-versions": "latest",
-        "@definitelytyped/utils": "latest",
-        "dts-critic": "latest",
-        "fs-extra": "^6.0.1",
-        "json-stable-stringify": "^1.0.1",
-        "strip-json-comments": "^2.0.1",
-        "tslint": "5.14.0",
-        "tsutils": "^2.29.0",
-        "yargs": "^15.1.0"
-      },
-      "bin": {
-        "dtslint": "bin/index.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "typescript": ">= 3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.7.0-dev || >= 3.8.0-dev || >= 3.9.0-dev || >= 4.0.0-dev"
-      }
-    },
     "node_modules/duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -2844,9 +2837,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.60",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.60.tgz",
-      "integrity": "sha512-h53hbEiKC6hijelDgxgkgAUC3PKyR7TmIfvjHnBjUGPMg/3sBuTyG6eDormw+lY24uUJvHkUPzB8dpK8b2u3Sw==",
+      "version": "1.4.61",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.61.tgz",
+      "integrity": "sha512-kpzCOOFlx63C9qKRyIDEsKIUgzoe98ump7T4gU+/OLzj8gYkkWf2SIyBjhTSE0keAjMAp3i7C262YtkQOMYrGw==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -3237,16 +3230,6 @@
         "eslint": ">=7.0.0"
       }
     },
-    "node_modules/eslint-plugin-n/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/eslint-plugin-node": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
@@ -3308,15 +3291,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/eslint-plugin-node/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-plugin-promise": {
@@ -4989,15 +4963,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/istanbul-lib-processinfo": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
@@ -5438,15 +5403,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/map-obj": {
@@ -6041,6 +5997,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -6228,6 +6199,21 @@
         "hosted-git-info": "^4.0.1",
         "semver": "^7.3.4",
         "validate-npm-package-name": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm-package-arg/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
@@ -10510,6 +10496,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/semantic-release/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/semantic-release/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -10569,18 +10570,12 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/semver-diff": {
@@ -10593,15 +10588,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/semver-diff/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/semver-regex": {
@@ -12148,14 +12134,6 @@
         "json5": "^2.1.2",
         "semver": "^6.3.0",
         "source-map": "^0.5.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
       }
     },
     "@babel/generator": {
@@ -12179,14 +12157,6 @@
         "@babel/helper-validator-option": "^7.16.7",
         "browserslist": "^4.17.5",
         "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
       }
     },
     "@babel/helper-environment-visitor": {
@@ -12415,30 +12385,61 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@definitelytyped/header-parser": {
+    "@definitelytyped/dts-critic": {
       "version": "0.0.103",
-      "resolved": "https://registry.npmjs.org/@definitelytyped/header-parser/-/header-parser-0.0.103.tgz",
-      "integrity": "sha512-MZRm+Sx8h+oT587QmbQeFbctqMQk0NS9WVrrYtDXkui36NFsyjhCPgVVuU8fZoJxTGvoNVAoziZQ7TzCZPXI6Q==",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/dts-critic/-/dts-critic-0.0.103.tgz",
+      "integrity": "sha512-QI0/MIf8RcZbxBJCykiq48tH+QDo722ks3I8lst6A7hVa2+7m3dx7LqCCh0Bs6h2moewgvIaX++qebokZitKfQ==",
       "dev": true,
       "requires": {
-        "@definitelytyped/typescript-versions": "^0.0.103",
+        "@definitelytyped/header-parser": "latest",
+        "command-exists": "^1.2.8",
+        "rimraf": "^3.0.2",
+        "semver": "^6.2.0",
+        "tmp": "^0.2.1",
+        "yargs": "^15.3.1"
+      }
+    },
+    "@definitelytyped/dtslint": {
+      "version": "0.0.103",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/dtslint/-/dtslint-0.0.103.tgz",
+      "integrity": "sha512-BjRioCLzf77VRNCgl97uirKYvhirlh4wPIL28BS+pYdy5UxFALlZBDVY91h/KXZRXySp6QsxO0XF6jbWeqhJqA==",
+      "dev": true,
+      "requires": {
+        "@definitelytyped/dts-critic": "^0.0.103",
+        "@definitelytyped/header-parser": "0.0.93",
+        "@definitelytyped/typescript-versions": "0.0.93",
+        "@definitelytyped/utils": "0.0.93",
+        "fs-extra": "^6.0.1",
+        "json-stable-stringify": "^1.0.1",
+        "strip-json-comments": "^2.0.1",
+        "tslint": "5.14.0",
+        "yargs": "^15.1.0"
+      }
+    },
+    "@definitelytyped/header-parser": {
+      "version": "0.0.93",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/header-parser/-/header-parser-0.0.93.tgz",
+      "integrity": "sha512-ywrpndOfwQ1CLG6n9DVQYICDW1CPglb/XxzhKMOonYrw2qifuWMeLioszsQsOYpg5jnwCwa8V7moK2TfkI5ztQ==",
+      "dev": true,
+      "requires": {
+        "@definitelytyped/typescript-versions": "^0.0.93",
         "@types/parsimmon": "^1.10.1",
         "parsimmon": "^1.13.0"
       }
     },
     "@definitelytyped/typescript-versions": {
-      "version": "0.0.103",
-      "resolved": "https://registry.npmjs.org/@definitelytyped/typescript-versions/-/typescript-versions-0.0.103.tgz",
-      "integrity": "sha512-OzwYh4O3egHmlV16a/VSbb+fXz9YYIlIQn3d1GJyPS//prCaZBbvDg4cxJ+k1T78C6vNL7Iky1MUb7r3DUkfkw==",
+      "version": "0.0.93",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/typescript-versions/-/typescript-versions-0.0.93.tgz",
+      "integrity": "sha512-ymWcBsmZykBMOXy4fF4WsBnJp7qCM3rropPXDfH5V8n2Ie2cK3Ths1kAxD1k80IWCish7EdznWPP4ZRxurycBw==",
       "dev": true
     },
     "@definitelytyped/utils": {
-      "version": "0.0.103",
-      "resolved": "https://registry.npmjs.org/@definitelytyped/utils/-/utils-0.0.103.tgz",
-      "integrity": "sha512-6QsbhSx2FiP6RVewnNV+P3yU1bGT44kXlouae6iQ5zFb1BVo3E2LOG13R3IBabU6o8HqOz8Qz3Bhge0v/PInqQ==",
+      "version": "0.0.93",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/utils/-/utils-0.0.93.tgz",
+      "integrity": "sha512-FBZhEoSxWtUTbwfwpehTssTyzgiEraAv4PBKjRr2sVVU1H3lIFTG/DlZO2ymfs3EbPr1zS5S0yt05RQFZlFjAQ==",
       "dev": true,
       "requires": {
-        "@definitelytyped/typescript-versions": "^0.0.103",
+        "@definitelytyped/typescript-versions": "^0.0.93",
         "@qiwi/npm-registry-client": "^8.9.1",
         "@types/node": "^14.14.35",
         "charm": "^1.0.2",
@@ -12772,6 +12773,17 @@
         "semver": "2 >=2.2.1 || 3.x || 4 || 5 || 7",
         "slide": "^1.1.6",
         "ssri": "^8.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@semantic-release/commit-analyzer": {
@@ -12944,6 +12956,15 @@
             "normalize-package-data": "^2.5.0",
             "parse-json": "^5.0.0",
             "type-fest": "^0.6.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
           }
         },
         "type-fest": {
@@ -13660,9 +13681,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001304",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001304.tgz",
-      "integrity": "sha512-bdsfZd6K6ap87AGqSHJP/s1V+U6Z5lyrcbBu3ovbCCf8cSYpwTtGrCBObMpJqwxfTbLW6YTIdbb1jEeTelcpYQ==",
+      "version": "1.0.30001305",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001305.tgz",
+      "integrity": "sha512-p7d9YQMji8haf0f+5rbcv9WlQ+N5jMPfRAnUmZRlNxsNeBO3Yr7RYG6M2uTY1h9tCVdlkJg6YNNc4kiAiBLdWA==",
       "dev": true
     },
     "cardinal": {
@@ -13936,14 +13957,6 @@
         "semver": "^6.0.0",
         "split": "^1.0.0",
         "through2": "^4.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
       }
     },
     "conventional-commits-filter": {
@@ -14245,46 +14258,6 @@
         "is-obj": "^2.0.0"
       }
     },
-    "dts-critic": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/dts-critic/-/dts-critic-3.3.11.tgz",
-      "integrity": "sha512-HMO2f9AO7ge44YO8OK18f+cxm/IaE1CFuyNFbfJRCEbyazWj5X5wWDF6W4CGdo5Ax0ILYVfJ7L/rOwuUN1fzWw==",
-      "dev": true,
-      "requires": {
-        "@definitelytyped/header-parser": "latest",
-        "command-exists": "^1.2.8",
-        "rimraf": "^3.0.2",
-        "semver": "^6.2.0",
-        "tmp": "^0.2.1",
-        "yargs": "^15.3.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
-      }
-    },
-    "dtslint": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/dtslint/-/dtslint-4.2.1.tgz",
-      "integrity": "sha512-57mWY9osUEfS6k62ATS9RSgug1dZcuN4O31hO76u+iEexa6VUEbKoPGaA2mNtc0FQDcdTl0zEUtti79UQKSQyQ==",
-      "dev": true,
-      "requires": {
-        "@definitelytyped/header-parser": "latest",
-        "@definitelytyped/typescript-versions": "latest",
-        "@definitelytyped/utils": "latest",
-        "dts-critic": "latest",
-        "fs-extra": "^6.0.1",
-        "json-stable-stringify": "^1.0.1",
-        "strip-json-comments": "^2.0.1",
-        "tslint": "5.14.0",
-        "tsutils": "^2.29.0",
-        "yargs": "^15.1.0"
-      }
-    },
     "duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -14343,9 +14316,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.60",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.60.tgz",
-      "integrity": "sha512-h53hbEiKC6hijelDgxgkgAUC3PKyR7TmIfvjHnBjUGPMg/3sBuTyG6eDormw+lY24uUJvHkUPzB8dpK8b2u3Sw==",
+      "version": "1.4.61",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.61.tgz",
+      "integrity": "sha512-kpzCOOFlx63C9qKRyIDEsKIUgzoe98ump7T4gU+/OLzj8gYkkWf2SIyBjhTSE0keAjMAp3i7C262YtkQOMYrGw==",
       "dev": true
     },
     "emoji-regex": {
@@ -14648,15 +14621,6 @@
         "minimatch": "^3.0.4",
         "resolve": "^1.10.1",
         "semver": "^6.1.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true,
-          "peer": true
-        }
       }
     },
     "eslint-plugin-node": {
@@ -14696,12 +14660,6 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
           "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
@@ -15928,14 +15886,6 @@
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.0.0",
         "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
       }
     },
     "istanbul-lib-processinfo": {
@@ -16301,14 +16251,6 @@
       "dev": true,
       "requires": {
         "semver": "^6.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
       }
     },
     "map-obj": {
@@ -16742,6 +16684,17 @@
         "is-core-module": "^2.5.0",
         "semver": "^7.3.4",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "normalize-path": {
@@ -18853,6 +18806,17 @@
         "hosted-git-info": "^4.0.1",
         "semver": "^7.3.4",
         "validate-npm-package-name": "^3.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "npm-run-all": {
@@ -19986,6 +19950,15 @@
           "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
           "dev": true
         },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
         "string-width": {
           "version": "4.2.3",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -20032,13 +20005,10 @@
       }
     },
     "semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^6.0.0"
-      }
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
     },
     "semver-diff": {
       "version": "3.1.1",
@@ -20047,14 +20017,6 @@
       "dev": true,
       "requires": {
         "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
       }
     },
     "semver-regex": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/nock/nock.git"
   },
   "bugs": {
-    "url": "http://github.com/nock/nock/issues"
+    "url": "https://github.com/nock/nock/issues"
   },
   "engines": {
     "node": ">= 10.13"
@@ -28,11 +28,11 @@
     "propagate": "^2.0.0"
   },
   "devDependencies": {
+    "@definitelytyped/dtslint": "^0.0.103",
     "@sinonjs/fake-timers": "^9.0.0",
     "assert-rejects": "^1.0.0",
     "chai": "^4.1.2",
     "dirty-chai": "^2.0.1",
-    "dtslint": "^4.0.4",
     "eslint": "^8.8.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-config-standard": "^17.0.0-0",

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "dtslint/dtslint.json",
+  "extends": "@definitelytyped/dtslint/dtslint.json",
   "rules": {
     "semicolon": false,
     "space-before-function-paren": false


### PR DESCRIPTION
Same tool, DefinitelyTypes simply moved the project into their monorepo.

I did attempt to move away from dtslint all together, in favor of ESLint, which is preferred for proper Typescript projects. However, ESLint still lacks a lot of functionality for only declaration files and tests, like Nock has. So dtslint is still the way to go (until we migrate Nock to TS 😄  ).