### PR TITLE
Fix issue when post call had also searchParams

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -358,7 +358,7 @@ module.exports = class Interceptor {
 
     this.scope.logger(`matching ${matchKey}${path} to ${this._key}: ${matches}`)
 
-    if (matches && this._requestBody !== undefined) {
+    if (!matches && this._requestBody !== undefined) {
       if (this.scope.transformRequestBodyFunction) {
         body = this.scope.transformRequestBodyFunction(body, this._requestBody)
       }

--- a/tests/test_body_match.js
+++ b/tests/test_body_match.js
@@ -164,6 +164,26 @@ describe('`matchBody()`', () => {
     scope.done()
   })
 
+  it('match body with form multipart with search params', async () => {
+    const form = new FormData()
+    form.append('field', 'value')
+
+    const scope = nock('http://example.test')
+      .post(
+        '/',
+        /value/gi
+      )
+      .reply(200, (uri) => ['OK', uri, 'match=>/value/gi'].join(' '))
+
+    const { statusCode, body } = await got.post('http://example.test', { body: form, searchParams: {a: 'b'} })
+
+    expect(statusCode).to.equal(200)
+    expect(body).to.equal('OK /?a=b match=>/value/gi')
+    
+    scope.done()
+  })
+
+
   it('array like urlencoded form posts are correctly parsed', async () => {
     const scope = nock('http://example.test')
       .post('/', {


### PR DESCRIPTION
Related to discussion on #2322 . 

The call from `flickr-sdk` is doing a post with `multipart/data` and also is sending a few params on the `searchParams` therefore the matches variable was always `false` and couldn't check the `_requestBody`