### PR TITLE
fix: remove duplicates from `activeMocks()` and `pendingMocks()`

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -350,7 +350,8 @@ function interceptorScopes() {
   const nestedInterceptors = Object.values(allInterceptors).map(
     i => i.interceptors,
   )
-  return [].concat(...nestedInterceptors).map(i => i.scope)
+  const scopes = new Set([].concat(...nestedInterceptors).map(i => i.scope))
+  return [...scopes]
 }
 
 function isDone() {

--- a/tests/got/test_nock_lifecycle.js
+++ b/tests/got/test_nock_lifecycle.js
@@ -166,9 +166,12 @@ describe('Nock lifecycle functions', () => {
 
     it("activeMocks doesn't return duplicate mocks", () => {
       nock('http://example.test')
-        .get('/').reply()
-        .get('/second').reply()
-        .get('/third').reply()
+        .get('/')
+        .reply()
+        .get('/second')
+        .reply()
+        .get('/third')
+        .reply()
 
       expect(nock.activeMocks()).to.deep.equal([
         'GET http://example.test:80/',

--- a/tests/got/test_nock_lifecycle.js
+++ b/tests/got/test_nock_lifecycle.js
@@ -163,6 +163,19 @@ describe('Nock lifecycle functions', () => {
       await got('http://example.test/')
       expect(nock.activeMocks()).to.be.empty()
     })
+
+    it("activeMocks doesn't return duplicate mocks", () => {
+      nock('http://example.test')
+        .get('/').reply()
+        .get('/second').reply()
+        .get('/third').reply()
+
+      expect(nock.activeMocks()).to.deep.equal([
+        'GET http://example.test:80/',
+        'GET http://example.test:80/second',
+        'GET http://example.test:80/third',
+      ])
+    })
   })
 
   describe('resetting nock catastrophically while a request is in progress', () => {


### PR DESCRIPTION
The `interceptorScopes()` function is used by `activeMocks()` and `pendingMocks()` to retrieve the list of all scopes. That list is built by concatenating the scopes of every interceptor. When multiple interceptors are registered on the same scope, the scope will be returned multiple times, causing `activeMocks()` and `pendingMocks()` to include duplicates.

This PR fixes the issue by ensuring there is no duplicate returned by `interceptorScopes()`.

Fixes #2352 (and #600, which also reported this issue)