### PR TITLE
fix: call `fs.createReadStream` lazily

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -199,11 +199,15 @@ module.exports = class Interceptor {
       throw new Error('No fs')
     }
     this.filePath = filePath
-    return this.reply(statusCode, () =>  {
-      const readStream = fs.createReadStream(filePath)
-      readStream.pause()
-      return readStream
-    }, headers)
+    return this.reply(
+      statusCode,
+      () => {
+        const readStream = fs.createReadStream(filePath)
+        readStream.pause()
+        return readStream
+      },
+      headers,
+    )
   }
 
   // Also match request headers

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -198,10 +198,12 @@ module.exports = class Interceptor {
     if (!fs) {
       throw new Error('No fs')
     }
-    const readStream = fs.createReadStream(filePath)
-    readStream.pause()
     this.filePath = filePath
-    return this.reply(statusCode, readStream, headers)
+    return this.reply(statusCode, () =>  {
+      const readStream = fs.createReadStream(filePath)
+      readStream.pause()
+      return readStream
+    }, headers)
   }
 
   // Also match request headers
@@ -452,15 +454,6 @@ module.exports = class Interceptor {
 
   markConsumed() {
     this.interceptionCounter++
-
-    if (
-      (this.scope.shouldPersist() || this.counter > 0) &&
-      this.interceptionCounter > 1 &&
-      this.filePath
-    ) {
-      this.body = fs.createReadStream(this.filePath)
-      this.body.pause()
-    }
 
     remove(this)
 

--- a/tests/got/test_reply_with_file.js
+++ b/tests/got/test_reply_with_file.js
@@ -64,6 +64,29 @@ describe('`replyWithFile()`', () => {
     scope.done()
   })
 
+  it('reply with file with persist', async () => {
+    sinon.spy(fs)
+
+    const scope = nock('http://example.test')
+      .persist()
+      .get('/')
+      .replyWithFile(200, binaryFilePath, {
+        'content-encoding': 'gzip',
+      })
+
+    const response1 = await got('http://example.test/')
+    expect(response1.statusCode).to.equal(200)
+    expect(response1.body).to.have.lengthOf(20)
+
+    const response2 = await got('http://example.test/')
+    expect(response2.statusCode).to.equal(200)
+    expect(response2.body).to.have.lengthOf(20)
+
+    expect(fs.createReadStream.callCount).to.equal(2)
+
+    scope.done()
+  })
+
   describe('with no fs', () => {
     const { Scope } = proxyquire('../../lib/scope', {
       './interceptor': proxyquire('../../lib/interceptor', {

--- a/tests/got/test_reply_with_file.js
+++ b/tests/got/test_reply_with_file.js
@@ -102,4 +102,16 @@ describe('`replyWithFile()`', () => {
       ).to.throw(Error, 'No fs')
     })
   })
+
+  it('does not create ReadStream eagerly', async () => {
+    sinon.spy(fs)
+
+    nock('http://example.test')
+      .get('/')
+      .replyWithFile(200, binaryFilePath, {
+        'content-encoding': 'gzip',
+      })
+
+    expect(fs.createReadStream.callCount).to.equal(0)
+  })
 })

--- a/tests/got/test_reply_with_file.js
+++ b/tests/got/test_reply_with_file.js
@@ -106,11 +106,9 @@ describe('`replyWithFile()`', () => {
   it('does not create ReadStream eagerly', async () => {
     sinon.spy(fs)
 
-    nock('http://example.test')
-      .get('/')
-      .replyWithFile(200, binaryFilePath, {
-        'content-encoding': 'gzip',
-      })
+    nock('http://example.test').get('/').replyWithFile(200, binaryFilePath, {
+      'content-encoding': 'gzip',
+    })
 
     expect(fs.createReadStream.callCount).to.equal(0)
   })


### PR DESCRIPTION
When using `replyWithFile`, a ReadStream is immediately created wih the file path. When the mock is hit, another ReadStream is created immediately if the interceptor is configured to be set again or if its scope has `_persist` set. When calling `nock.removeInterceptor`, the ReadStream isn't closed. 

As a result, it's not possible to delete the folder where the file exists on Windows unless implementing a workaround like multiple `fs.rm` calls.

This PR removes the eager `fs.createReadStream` call when setting up the interceptor and instead configures the route to create 
 the stream lazily, in a callback invoked when intercepting a call. There is no longer any need for `replyWithFile`-related logic in `Interceptor#markConsumed()`.

I also added an extra test for `replyWithFile` + `persist()`, which I think makes coverage a bit more complete.

Fixes #2354 