### PR TITLE
fix: `InterceptedRequestRouter.handleWrite` arity issue

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -27,6 +27,9 @@ rules:
   # TODO These are included in standard and should be cleaned up and turned on.
   n/no-deprecated-api: 'off' # we still make heavy use of url.parse
 
+  # TODO remove once we drop support for Node 10
+  node/no-deprecated-api: 'off'
+
   # Nock additions.
   strict: ['error', 'safe']
   no-console: 'error'

--- a/lib/intercepted_request_router.js
+++ b/lib/intercepted_request_router.js
@@ -146,7 +146,7 @@ class InterceptedRequestRouter {
   handleWrite(...args) {
     debug('request write')
 
-    let [buffer, encoding] = args;
+    let [buffer, encoding] = args
 
     const { req } = this
 

--- a/lib/intercepted_request_router.js
+++ b/lib/intercepted_request_router.js
@@ -144,7 +144,7 @@ class InterceptedRequestRouter {
   // from docs: When write function is called with empty string or buffer, it does nothing and waits for more input.
   // However, actually implementation checks the state of finished and aborted before checking if the first arg is empty.
   handleWrite(...args) {
-    let [buffer, encoding ] = args ?? [];
+    let [buffer, encoding] = args || []
     debug('request write')
     const { req } = this
 
@@ -172,9 +172,9 @@ class InterceptedRequestRouter {
     }
     this.requestBodyBuffers.push(buffer)
 
-    // writable.write encoding is param is optional 
+    // writable.write encoding is param is optional
     // so if callback is present it's the last argument
-    const callback = args?.[args.length -1]; 
+    const callback = args ? args[args.length - 1] : undefined
     // can't use instanceof Function because some test runners
     // run tests in vm.runInNewContext where Function is not same
     // as that in the current context

--- a/lib/intercepted_request_router.js
+++ b/lib/intercepted_request_router.js
@@ -143,7 +143,8 @@ class InterceptedRequestRouter {
 
   // from docs: When write function is called with empty string or buffer, it does nothing and waits for more input.
   // However, actually implementation checks the state of finished and aborted before checking if the first arg is empty.
-  handleWrite(buffer, encoding, callback) {
+  handleWrite(...args) {
+    let [buffer, encoding ] = args ?? [];
     debug('request write')
     const { req } = this
 
@@ -171,6 +172,9 @@ class InterceptedRequestRouter {
     }
     this.requestBodyBuffers.push(buffer)
 
+    // writable.write encoding is param is optional 
+    // so if callback is present it's the last argument
+    const callback = args?.[args.length -1]; 
     // can't use instanceof Function because some test runners
     // run tests in vm.runInNewContext where Function is not same
     // as that in the current context

--- a/lib/intercepted_request_router.js
+++ b/lib/intercepted_request_router.js
@@ -144,8 +144,10 @@ class InterceptedRequestRouter {
   // from docs: When write function is called with empty string or buffer, it does nothing and waits for more input.
   // However, actually implementation checks the state of finished and aborted before checking if the first arg is empty.
   handleWrite(...args) {
-    let [buffer, encoding] = args || []
     debug('request write')
+
+    let [buffer, encoding] = args;
+
     const { req } = this
 
     if (req.finished) {
@@ -172,9 +174,9 @@ class InterceptedRequestRouter {
     }
     this.requestBodyBuffers.push(buffer)
 
-    // writable.write encoding is param is optional
+    // writable.write encoding param is optional
     // so if callback is present it's the last argument
-    const callback = args ? args[args.length - 1] : undefined
+    const callback = args.length > 1 ? args[args.length - 1] : undefined
     // can't use instanceof Function because some test runners
     // run tests in vm.runInNewContext where Function is not same
     // as that in the current context


### PR DESCRIPTION
Hi, i found an issue with `InterceptedRequestRouter.handleWrite`:

`Http.ClientRequest.write()` can be invoked with a callback and no encoding, currently the code expected the callback to be the 3rd argument so if invoked the callback was never called.

BTW: this is my first contribution ever, so If I'm doing something wrong let me know