### PR TITLE
Fix Jest memory leak from nock.restore()

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -67,15 +67,26 @@ let requestOverrides = {}
  *   - callback - the callback of the issued request
  */
 function overrideRequests(newRequest) {
-  debug('overriding requests')
-  ;['http', 'https'].forEach(function (proto) {
+  debug('overriding requests');
+
+  const modules = {
+    http: require('http'),
+    https: require('https'),
+  };
+
+  Object.keys(modules).forEach(function (proto) {
     debug('- overriding request for', proto)
 
     const moduleName = proto // 1 to 1 match of protocol and module is fortunate :)
-    const module = {
-      http: require('http'),
-      https: require('https'),
-    }[moduleName]
+
+    // TODO - this imports both modules twice in Jest
+    // const module = {
+    //   http: require('http'),
+    //   https: require('https'),
+    // }[moduleName]
+
+    const module = modules[moduleName];
+
     const overriddenRequest = module.request
     const overriddenGet = module.get
 
@@ -126,9 +137,13 @@ function restoreOverriddenRequests() {
       module.request = request
       module.get = get
       debug('- restored request for', proto)
+
+      delete requestOverrides[proto];
     }
   )
-  requestOverrides = {}
+
+  // TODO - Node 16 wasn't freeing the overridden modules with an explicit delete
+  // requestOverrides = {}
 }
 
 /**

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -366,8 +366,6 @@ function activate() {
     throw new Error('Nock already active')
   }
 
-  overrideClientRequest()
-
   // ----- Overriding http.request and https.request:
 
   common.overrideRequests(function (proto, overriddenRequest, args) {
@@ -431,6 +429,9 @@ function activate() {
       }
     }
   })
+
+  // TODO - moving this AFTER common.overrideRequests fixes another Jest leak
+  overrideClientRequest()
 }
 
 module.exports = {


### PR DESCRIPTION
Jest appears to be losing reference to the patched `http` and `https` libs when required inside a loop.

Resolves https://github.com/nock/nock/issues/2383