### PR TITLE
disabled netconnect should throw if allowunmocked

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -405,17 +405,28 @@ function activate() {
       )
 
       if (!matches && allowUnmocked) {
-        let req
-        if (proto === 'https') {
-          const { ClientRequest } = http
-          http.ClientRequest = originalClientRequest
-          req = overriddenRequest(options, callback)
-          http.ClientRequest = ClientRequest
+        // When there is an interceptors and no matching condition in the same base path
+        // Needs to check connection status and throw instead of making the external call
+        if (isEnabledForNetConnect(options)) {
+          let req
+
+          if (proto === 'https') {
+            const { ClientRequest } = http
+            http.ClientRequest = originalClientRequest
+            req = overriddenRequest(options, callback)
+            http.ClientRequest = ClientRequest
+          } else {
+            req = overriddenRequest(options, callback)
+          }
+          globalEmitter.emit('no match', req)
+          return req
         } else {
-          req = overriddenRequest(options, callback)
+          const error = new NetConnectNotAllowedError(
+            options.host,
+            options.path
+          )
+          return new ErroringClientRequest(error)
         }
-        globalEmitter.emit('no match', req)
-        return req
       }
 
       //  NOTE: Since we already overrode the http.ClientRequest we are in fact constructing

--- a/tests/test_net_connect.js
+++ b/tests/test_net_connect.js
@@ -20,6 +20,19 @@ describe('`disableNetConnect()`', () => {
     )
   })
 
+  it('prevents connection to mocked hosts but allow unmocked active', async () => {
+    nock.disableNetConnect()
+
+    nock('https://same.host.test', { allowUnmocked: true })
+      .get('/some/path/value')
+      .reply(200)
+
+    await assertRejects(
+      got('https://same.host.test/some/path/other'),
+      /Nock: Disallowed net connect for "same.host.test:443\/some\/path\/other"/
+    )
+  })
+
   it('prevents connections when no hosts are mocked', async () => {
     nock.disableNetConnect()
 


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18rwjQoSoyFlJP7msUI3KMmDlRv2zD7UGw%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=B1K2eEl)