### PR TITLE
fix axios adapter docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1541,7 +1541,7 @@ import test from 'ava' // You can use any test framework.
 // References:
 // https://github.com/nock/nock/issues/699#issuecomment-272708264
 // https://github.com/axios/axios/issues/305
-axios.defaults.adapter = require('axios/lib/adapters/http')
+axios.defaults.adapter = 'http'
 
 test('can fetch test response', async t => {
   // Set up the mock request.


### PR DESCRIPTION
axios stopped exporting the adapters (you will get `Cannot find module 'axios/lib/adapters/http'` errors) but you can now specify the adapter as a string.