### PR TITLE
fix: `nock.removeInterceptor` can remove the wrong Intercept

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -208,7 +208,6 @@ function removeInterceptor(options) {
   let baseUrl, key, method, proto
   if (options instanceof Interceptor) {
     baseUrl = options.basePath
-    key = options._key
   } else {
     proto = options.proto ? options.proto : 'http'
 
@@ -224,7 +223,7 @@ function removeInterceptor(options) {
   ) {
     for (let i = 0; i < allInterceptors[baseUrl].interceptors.length; i++) {
       const interceptor = allInterceptors[baseUrl].interceptors[i]
-      if (interceptor._key === key) {
+      if (interceptor === options || interceptor._key === key) {
         allInterceptors[baseUrl].interceptors.splice(i, 1)
         interceptor.scope.remove(key, interceptor)
         break

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -224,7 +224,7 @@ function removeInterceptor(options) {
   ) {
     for (let i = 0; i < allInterceptors[baseUrl].interceptors.length; i++) {
       const interceptor = allInterceptors[baseUrl].interceptors[i]
-      if (interceptor._key === key) {
+      if (options instanceof Interceptor ? interceptor === options : interceptor._key === key) {
         allInterceptors[baseUrl].interceptors.splice(i, 1)
         interceptor.scope.remove(key, interceptor)
         break

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -224,7 +224,11 @@ function removeInterceptor(options) {
   ) {
     for (let i = 0; i < allInterceptors[baseUrl].interceptors.length; i++) {
       const interceptor = allInterceptors[baseUrl].interceptors[i]
-      if (options instanceof Interceptor ? interceptor === options : interceptor._key === key) {
+      if (
+        options instanceof Interceptor
+          ? interceptor === options
+          : interceptor._key === key
+      ) {
         allInterceptors[baseUrl].interceptors.splice(i, 1)
         interceptor.scope.remove(key, interceptor)
         break

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -208,6 +208,7 @@ function removeInterceptor(options) {
   let baseUrl, key, method, proto
   if (options instanceof Interceptor) {
     baseUrl = options.basePath
+    key = options._key
   } else {
     proto = options.proto ? options.proto : 'http'
 
@@ -223,7 +224,7 @@ function removeInterceptor(options) {
   ) {
     for (let i = 0; i < allInterceptors[baseUrl].interceptors.length; i++) {
       const interceptor = allInterceptors[baseUrl].interceptors[i]
-      if (interceptor === options || interceptor._key === key) {
+      if (interceptor._key === key) {
         allInterceptors[baseUrl].interceptors.splice(i, 1)
         interceptor.scope.remove(key, interceptor)
         break

--- a/tests/test_remove_interceptor.js
+++ b/tests/test_remove_interceptor.js
@@ -7,14 +7,13 @@ const got = require('./got_client')
 describe('`removeInterceptor()`', () => {
   context('when invoked with an Interceptor instance', () => {
     it('remove interceptor removes given interceptor', async () => {
+      const newScope = nock('http://example.test')
+        .get('/somepath')
+        .reply(202, 'other-content')
       const givenInterceptor = nock('http://example.test').get('/somepath')
       givenInterceptor.reply(200, 'hey')
 
       expect(nock.removeInterceptor(givenInterceptor)).to.be.true()
-
-      const newScope = nock('http://example.test')
-        .get('/somepath')
-        .reply(202, 'other-content')
 
       const { statusCode, body } = await got('http://example.test/somepath')
 


### PR DESCRIPTION
If you agree with the general solution, I'll add a proper test and fix the current tests.

Fix #2418