### PR TITLE
fix(types): Adding conditionally to Options

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -211,6 +211,7 @@ declare namespace nock {
     badheaders?: string[]
     filteringScope?: { (scope: string): boolean }
     encodedQueryParams?: boolean
+    conditionally?: () => boolean
   }
 
   interface Recorder {


### PR DESCRIPTION
I noticed that the `nock.Options` type is missing the [`conditionally` function](https://www.npmjs.com/package/nock#conditional-scope-filtering).

I wasn't 100% sure what is the type of the expected return value, as [interceptor.js](https://github.com/nock/nock/blob/546e2819e038548de8e8bab6f9a3fb3093d56ff7/lib/interceptor.js#L299) just checks `!this.scope.scopeOptions.conditionally()` so technically speaking `conditionally` can return anything (boolean, string etc), but I assume the intention is to return a boolean.