### PR TITLE
fix: revert #2350 (Push persisted interceptors to the end instead of ignore on remove)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1005,7 +1005,7 @@ const scope = nock('http://example.com')
   .reply(200, 'Persisting all the way')
 ```
 
-Note that while a persisted scope will always intercept the requests, it is considered "done" after the first interception, and they are pushed to the bottom of the stack after consumption.
+Note that while a persisted scope will always intercept the requests, it is considered "done" after the first interception.
 
 If you want to stop persisting an individual persisted mock you can call `persist(false)`:
 

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -110,7 +110,7 @@ function addInterceptor(key, interceptor, scope, scopeOptions, host) {
 }
 
 function remove(interceptor) {
-  if (--interceptor.counter > 0) {
+  if (interceptor.__nock_scope.shouldPersist() || --interceptor.counter > 0) {
     return
   }
 
@@ -122,12 +122,6 @@ function remove(interceptor) {
   // matching instance. I'm also not sure why we couldn't delete _all_
   // matching instances.
   interceptors.some(function (thisInterceptor, i) {
-    if (interceptor.__nock_scope.shouldPersist()) {
-      return thisInterceptor === interceptor
-        ? interceptors.push(interceptors.splice(i, 1)[0])
-        : false
-    }
-
     return thisInterceptor === interceptor ? interceptors.splice(i, 1) : false
   })
 }

--- a/tests/test_persist_optionally.js
+++ b/tests/test_persist_optionally.js
@@ -144,25 +144,6 @@ describe('`persist()`', () => {
     expect(scope.isDone()).to.be.true()
   })
 
-  it('persisted mocks go to the bottom of the stack after matching', async () => {
-    const scope = nock('http://example.test')
-      .persist()
-      .get('/')
-      .reply(200, 'Persisting all the way')
-
-    const specificTestScope = nock('http://example.test')
-      .get('/')
-      .reply(201, 'return different response once')
-
-    await got('http://example.test/')
-
-    expect(scope.isDone()).to.be.true()
-
-    await got('http://example.test/')
-
-    expect(specificTestScope.isDone()).to.be.true()
-  })
-
   it('persisted mocks appear in `pendingMocks()`', async () => {
     const scope = nock('http://example.test')
       .get('/abc')


### PR DESCRIPTION
This reverts commit 8aab603f2b884f49618fbfdcc3c9529cccdc8975.  See #2500
