### PR TITLE
fix(typescript): support `nock(new URL('https://example.test/'))`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1142,7 +1142,7 @@ nock.enableNetConnect(/(amazon|github)\.com/)
 
 // Or a Function
 nock.enableNetConnect(
-  host => host.includes('amazon.com') || host.includes('github.com')
+  host => host.includes('amazon.com') || host.includes('github.com'),
 )
 
 http.get('http://www.amazon.com/')
@@ -1248,7 +1248,7 @@ nocks.forEach(function (nock) {
         /(timestamp):([0-9]+)/g,
         function (match, key, value) {
           return key + ':' + recordedTimestamp
-        }
+        },
       )
     } else {
       return body
@@ -1467,7 +1467,7 @@ function prepareScope(scope) {
       const recordedTimestamp = recordedBodyResult[1]
       return body.replace(
         /(timestamp):([0-9]+)/g,
-        (match, key, value) => `${key}:${recordedTimestamp}`
+        (match, key, value) => `${key}:${recordedTimestamp}`,
       )
     } else {
       return body

--- a/examples/binary-reply.js
+++ b/examples/binary-reply.js
@@ -6,7 +6,7 @@ const nock = require('../')
 
 const readFile = function () {
   return fs.readFileSync(
-    path.resolve(__dirname, '../tests/assets/reply_file_2.txt.gz')
+    path.resolve(__dirname, '../tests/assets/reply_file_2.txt.gz'),
   )
 }
 
@@ -29,7 +29,7 @@ http.get('http://binary.com/binary', function (res) {
     console.log(
       Buffer.compare(readFile(), buffer) === 0
         ? 'Received the file.'
-        : 'Received something else.'
+        : 'Received something else.',
     )
   })
 })

--- a/lib/back.js
+++ b/lib/back.js
@@ -49,7 +49,7 @@ function Back(fixtureName, options, nockedFn) {
     throw new Error(
       'Back requires nock.back.fixtures to be set\n' +
         'Ex:\n' +
-        "\trequire(nock).back.fixtures = '/path/to/fixtures/'"
+        "\trequire(nock).back.fixtures = '/path/to/fixtures/'",
     )
   }
 
@@ -300,8 +300,8 @@ function assertScopes(scopes, fixture) {
       format(
         '%j was not used, consider removing %s to rerecord fixture',
         [].concat(...pending),
-        fixture
-      )
+        fixture,
+      ),
     )
   }
 }

--- a/lib/common.js
+++ b/lib/common.js
@@ -81,7 +81,7 @@ function overrideRequests(newRequest) {
 
     if (requestOverrides[moduleName]) {
       throw new Error(
-        `Module's request already overridden for ${moduleName} protocol.`
+        `Module's request already overridden for ${moduleName} protocol.`,
       )
     }
 
@@ -126,7 +126,7 @@ function restoreOverriddenRequests() {
       module.request = request
       module.get = get
       debug('- restored request for', proto)
-    }
+    },
   )
   requestOverrides = {}
 }
@@ -206,11 +206,11 @@ function headersFieldNamesToLowerCase(headers, throwOnDuplicate) {
     if (lowerCaseHeaders[key] !== undefined) {
       if (throwOnDuplicate) {
         throw Error(
-          `Failed to convert header keys to lower case due to field name conflict: ${key}`
+          `Failed to convert header keys to lower case due to field name conflict: ${key}`,
         )
       } else {
         debug(
-          `Duplicate header provided in request: ${key}. Only the last value can be matched.`
+          `Duplicate header provided in request: ${key}. Only the last value can be matched.`,
         )
       }
     }
@@ -244,7 +244,7 @@ function headersInputToRawArray(headers) {
     // but throw an error if there aren't an even number of items in the array
     if (headers.length % 2) {
       throw new Error(
-        `Raw headers must be provided as an array with an even number of items. [fieldName, value, ...]`
+        `Raw headers must be provided as an array with an even number of items. [fieldName, value, ...]`,
       )
     }
     return [...headers]
@@ -260,7 +260,7 @@ function headersInputToRawArray(headers) {
   }
 
   throw new Error(
-    `Headers must be provided as an array of raw values, a Map, or a plain Object. ${headers}`
+    `Headers must be provided as an array of raw values, a Map, or a plain Object. ${headers}`,
   )
 }
 
@@ -600,7 +600,7 @@ function deepEqual(expected, actual) {
 
   if (isPlainObject(expected) && isPlainObject(actual)) {
     const allKeys = Array.from(
-      new Set(Object.keys(expected).concat(Object.keys(actual)))
+      new Set(Object.keys(expected).concat(Object.keys(actual))),
     )
 
     return allKeys.every(key => deepEqual(expected[key], actual[key]))

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -151,7 +151,7 @@ function interceptorsFor(options) {
 
   // First try to use filteringScope if any of the interceptors has it defined.
   for (const { key, interceptors, allowUnmocked } of Object.values(
-    allInterceptors
+    allInterceptors,
   )) {
     for (const interceptor of interceptors) {
       const { filteringScope } = interceptor.__nock_scopeOptions
@@ -185,7 +185,7 @@ function interceptorsFor(options) {
         debug(
           `matched base path (${interceptors.length} interceptor${
             interceptors.length > 1 ? 's' : ''
-          })`
+          })`,
         )
         return interceptors
       }
@@ -243,7 +243,7 @@ function ErroringClientRequest(error) {
   process.nextTick(
     function () {
       this.emit('error', error)
-    }.bind(this)
+    }.bind(this),
   )
 }
 
@@ -272,7 +272,7 @@ function overrideClientRequest() {
       // https://github.com/nock/nock/pull/1386
       // https://github.com/nock/nock/pull/1440
       throw Error(
-        'Creating a ClientRequest with empty `options` is not supported in Nock'
+        'Creating a ClientRequest with empty `options` is not supported in Nock',
       )
     }
 
@@ -308,10 +308,10 @@ function overrideClientRequest() {
           function () {
             const error = new NetConnectNotAllowedError(
               options.host,
-              options.path
+              options.path,
             )
             this.emit('error', error)
-          }.bind(this)
+          }.bind(this),
         )
       }
     }
@@ -348,7 +348,7 @@ function isActive() {
 
 function interceptorScopes() {
   const nestedInterceptors = Object.values(allInterceptors).map(
-    i => i.interceptors
+    i => i.interceptors,
   )
   return [].concat(...nestedInterceptors).map(i => i.scope)
 }
@@ -389,7 +389,7 @@ function activate() {
       // https://github.com/nock/nock/pull/1386
       // https://github.com/nock/nock/pull/1440
       throw Error(
-        'Making a request with empty `options` is not supported in Nock'
+        'Making a request with empty `options` is not supported in Nock',
       )
     }
 
@@ -402,10 +402,10 @@ function activate() {
 
     if (isOn() && interceptors) {
       const matches = interceptors.some(interceptor =>
-        interceptor.matchOrigin(options)
+        interceptor.matchOrigin(options),
       )
       const allowUnmocked = interceptors.some(
-        interceptor => interceptor.options.allowUnmocked
+        interceptor => interceptor.options.allowUnmocked,
       )
 
       if (!matches && allowUnmocked) {

--- a/lib/intercepted_request_router.js
+++ b/lib/intercepted_request_router.js
@@ -42,7 +42,7 @@ class InterceptedRequestRouter {
       // We use lower-case header field names throughout Nock.
       headers: common.headersFieldNamesToLowerCase(
         options.headers || {},
-        false
+        false,
       ),
     }
     this.interceptors = interceptors
@@ -89,7 +89,7 @@ class InterceptedRequestRouter {
       req.setHeader(
         // We use lower-case header field names throughout Nock.
         'authorization',
-        `Basic ${Buffer.from(options.auth).toString('base64')}`
+        `Basic ${Buffer.from(options.auth).toString('base64')}`,
       )
     }
 
@@ -297,16 +297,16 @@ class InterceptedRequestRouter {
     const requestBodyIsUtf8Representable =
       common.isUtf8Representable(requestBodyBuffer)
     const requestBodyString = requestBodyBuffer.toString(
-      requestBodyIsUtf8Representable ? 'utf8' : 'hex'
+      requestBodyIsUtf8Representable ? 'utf8' : 'hex',
     )
 
     const matchedInterceptor = interceptors.find(i =>
-      i.match(req, options, requestBodyString)
+      i.match(req, options, requestBodyString),
     )
 
     if (matchedInterceptor) {
       matchedInterceptor.scope.logger(
-        'interceptor identified, starting mocking'
+        'interceptor identified, starting mocking',
       )
 
       matchedInterceptor.markConsumed()
@@ -329,7 +329,7 @@ class InterceptedRequestRouter {
 
       // Try to find a hostname match that allows unmocked.
       const allowUnmocked = interceptors.some(
-        i => i.matchHostName(options) && i.options.allowUnmocked
+        i => i.matchHostName(options) && i.options.allowUnmocked,
       )
 
       if (allowUnmocked && req instanceof ClientRequest) {

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -39,13 +39,13 @@ module.exports = class Interceptor {
       !uri.startsWith('*')
     ) {
       throw Error(
-        `Non-wildcard URL path strings must begin with a slash (otherwise they won't match anything) (got: ${uri})`
+        `Non-wildcard URL path strings must begin with a slash (otherwise they won't match anything) (got: ${uri})`,
       )
     }
 
     if (!method) {
       throw new Error(
-        'The "method" parameter is required for an intercept call.'
+        'The "method" parameter is required for an intercept call.',
       )
     }
 
@@ -67,10 +67,10 @@ module.exports = class Interceptor {
     //  We use lower-case header field names throughout Nock.
     this.reqheaders = common.headersFieldNamesToLowerCase(
       scope.scopeOptions.reqheaders || {},
-      true
+      true,
     )
     this.badheaders = common.headersFieldsArrayToLowerCase(
-      scope.scopeOptions.badheaders || []
+      scope.scopeOptions.badheaders || [],
     )
 
     this.delayBodyInMs = 0
@@ -118,7 +118,7 @@ module.exports = class Interceptor {
         // It's not very Javascript-y to throw an error for extra args to a function, but because
         // of legacy behavior, this error was added to reduce confusion for those migrating.
         throw Error(
-          'Invalid arguments. When providing a function for the first argument, .reply does not accept other arguments.'
+          'Invalid arguments. When providing a function for the first argument, .reply does not accept other arguments.',
         )
       }
       this.statusCode = null
@@ -152,7 +152,7 @@ module.exports = class Interceptor {
     // Including all the default headers is safe for our purposes because of the specific headers we introspect.
     // A more thoughtful process is used to merge the default headers when the response headers are finally computed.
     this.headers = common.headersArrayToObject(
-      this.rawHeaders.concat(this.scope._defaultReplyHeaders)
+      this.rawHeaders.concat(this.scope._defaultReplyHeaders),
     )
 
     //  If the content is not encoded we may need to transform the response body.
@@ -236,7 +236,7 @@ module.exports = class Interceptor {
       "request header field doesn't match:",
       key,
       header,
-      reqHeader
+      reqHeader,
     )
     return false
   }
@@ -247,7 +247,7 @@ module.exports = class Interceptor {
       this.scope.logger(
         'attempting match %s, body = %s',
         stringify(options),
-        stringify(body)
+        stringify(body),
       )
     }
 
@@ -259,7 +259,7 @@ module.exports = class Interceptor {
 
     if (this.method !== method) {
       this.scope.logger(
-        `Method did not match. Request ${method} Interceptor ${this.method}`
+        `Method did not match. Request ${method} Interceptor ${this.method}`,
       )
       return false
     }
@@ -286,7 +286,7 @@ module.exports = class Interceptor {
     }
 
     const reqHeadersMatch = Object.keys(this.reqheaders).every(key =>
-      this.reqheaderMatches(options, key)
+      this.reqheaderMatches(options, key),
     )
 
     if (!reqHeadersMatch) {
@@ -299,13 +299,13 @@ module.exports = class Interceptor {
       !this.scope.scopeOptions.conditionally()
     ) {
       this.scope.logger(
-        'matching failed because Scope.conditionally() did not validate'
+        'matching failed because Scope.conditionally() did not validate',
       )
       return false
     }
 
     const badHeaders = this.badheaders.filter(
-      header => header in options.headers
+      header => header in options.headers,
     )
 
     if (badHeaders.length) {
@@ -322,7 +322,7 @@ module.exports = class Interceptor {
       const matchQueries = this.matchQuery({ search })
 
       this.scope.logger(
-        matchQueries ? 'query matching succeeded' : 'query matching failed'
+        matchQueries ? 'query matching succeeded' : 'query matching failed',
       )
 
       if (!matchQueries) {
@@ -369,7 +369,7 @@ module.exports = class Interceptor {
           "bodies don't match: \n",
           this._requestBody,
           '\n',
-          body
+          body,
         )
       }
     }

--- a/lib/playback_interceptor.js
+++ b/lib/playback_interceptor.js
@@ -29,7 +29,7 @@ function parseFullReplyResult(response, fullReplyResult) {
 
   if (fullReplyResult.length > 3) {
     throw Error(
-      'The array returned from the .reply callback contains too many values'
+      'The array returned from the .reply callback contains too many values',
     )
   }
 
@@ -257,7 +257,7 @@ function playbackInterceptor({
     }
 
     response.rawHeaders.push(
-      ...selectDefaultHeaders(response.rawHeaders, defaultHeaders)
+      ...selectDefaultHeaders(response.rawHeaders, defaultHeaders),
     )
 
     // Evaluate functional headers.

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -68,7 +68,7 @@ function generateRequestAndResponseObject({
 }) {
   const { body, isUtf8Representable } = getBodyFromChunks(
     dataChunks,
-    res.headers
+    res.headers,
   )
   options.path = req.path
 
@@ -120,7 +120,7 @@ function generateRequestAndResponse({
     const formattedPair = common.formatQueryValue(
       key,
       queryObj[key],
-      common.percentEncode
+      common.percentEncode,
     )
     encodedQueryObj[formattedPair[0]] = formattedPair[1]
   }
@@ -368,7 +368,7 @@ function record(recOptions) {
 function restore() {
   debug(
     currentRecordingId,
-    'restoring all the overridden http/https properties'
+    'restoring all the overridden http/https properties',
   )
 
   common.restoreOverriddenRequests()

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -35,7 +35,7 @@ function normalizeUrl(u) {
 
   if (!/https?:/.test(u.protocol)) {
     throw new TypeError(
-      `Protocol '${u.protocol}' not recognized. This commonly occurs when a hostname and port are included without a protocol, producing a URL that is valid but confusing, and probably not what you want.`
+      `Protocol '${u.protocol}' not recognized. This commonly occurs when a hostname and port are included without a protocol, producing a URL that is valid but confusing, and probably not what you want.`,
     )
   }
 
@@ -112,7 +112,7 @@ class Scope extends EventEmitter {
       interceptor,
       this,
       this.scopeOptions,
-      this.urlParts.hostname
+      this.urlParts.hostname,
     )
   }
 
@@ -135,7 +135,7 @@ class Scope extends EventEmitter {
       uri,
       method,
       requestBody,
-      interceptorOptions
+      interceptorOptions,
     )
 
     this.interceptors.push(ic)
@@ -182,7 +182,7 @@ class Scope extends EventEmitter {
       this.keyedInterceptors[key].some(({ interceptionCounter, optional }) => {
         const persistedAndUsed = this._persist && interceptionCounter > 0
         return !persistedAndUsed && !optional
-      })
+      }),
     )
   }
 
@@ -204,7 +204,7 @@ class Scope extends EventEmitter {
   done() {
     assert.ok(
       this.isDone(),
-      `Mocks not yet satisfied:\n${this.pendingMocks().join('\n')}`
+      `Mocks not yet satisfied:\n${this.pendingMocks().join('\n')}`,
     )
   }
 
@@ -220,7 +220,7 @@ class Scope extends EventEmitter {
           // However the code used to contain a truthiness test of `candidate`.
           // The check is being preserved for now.
           throw Error(
-            `Nock internal assertion failed: typeof candidate is ${typeof candidate}. If you encounter this error, please report it as a bug.`
+            `Nock internal assertion failed: typeof candidate is ${typeof candidate}. If you encounter this error, please report it as a bug.`,
           )
         }
         return candidate.replace(filteringArguments[0], filteringArguments[1])
@@ -234,7 +234,7 @@ class Scope extends EventEmitter {
     this.transformPathFunction = this.buildFilter.apply(this, arguments)
     if (!this.transformPathFunction) {
       throw new Error(
-        'Invalid arguments: filtering path should be a function or a regular expression'
+        'Invalid arguments: filtering path should be a function or a regular expression',
       )
     }
     return this
@@ -244,7 +244,7 @@ class Scope extends EventEmitter {
     this.transformRequestBodyFunction = this.buildFilter.apply(this, arguments)
     if (!this.transformRequestBodyFunction) {
       throw new Error(
-        'Invalid arguments: filtering request body should be a function or a regular expression'
+        'Invalid arguments: filtering request body should be a function or a regular expression',
       )
     }
     return this
@@ -326,7 +326,7 @@ function getScopeFromDefinition(nockDef) {
     } else {
       if (parseInt(options.port) !== parseInt(nockDef.port)) {
         throw new Error(
-          'Mismatched port numbers in scope and port properties of nock definition.'
+          'Mismatched port numbers in scope and port properties of nock definition.',
         )
       }
     }

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -74,7 +74,7 @@ module.exports = class Socket extends EventEmitter {
 
   getPeerCertificate() {
     return Buffer.from(
-      (Math.random() * 10000 + Date.now()).toString()
+      (Math.random() * 10000 + Date.now()).toString(),
     ).toString('base64')
   }
 

--- a/migration_guides/migrating_to_12.md
+++ b/migration_guides/migrating_to_12.md
@@ -28,6 +28,6 @@
 1.  [`enableNetConnect()`](https://github.com/nock/nock#enabling-requests) now accepts a function.
     ```js
     nock.enableNetConnect(
-      host => host.includes('amazon.com') || host.includes('github.com')
+      host => host.includes('amazon.com') || host.includes('github.com'),
     )
     ```

--- a/tests/servers/index.js
+++ b/tests/servers/index.js
@@ -47,7 +47,7 @@ async function startHttpsServer(requestListener = defaultRequestListener) {
       key: fs.readFileSync(path.resolve(__dirname, './localhost.key')),
       cert: fs.readFileSync(path.resolve(__dirname, './localhost.crt')),
     },
-    requestListener
+    requestListener,
   )
   await new Promise(resolve => server.listen(resolve))
   servers.push(server)

--- a/tests/test_allow_unmocked.js
+++ b/tests/test_allow_unmocked.js
@@ -118,7 +118,7 @@ describe('allowUnmocked option', () => {
       .reply(200, 'Match regex')
 
     const { body, statusCode } = await got(
-      'http://example.test/resources/regex'
+      'http://example.test/resources/regex',
     )
     expect(statusCode).to.equal(200)
     expect(body).to.equal('Match regex')
@@ -133,7 +133,7 @@ describe('allowUnmocked option', () => {
       .reply(200, 'Match regex')
 
     const { body, statusCode } = await got(
-      'http://localhost:3000/no/regex/here'
+      'http://localhost:3000/no/regex/here',
     )
     expect(statusCode).to.equal(200)
     expect(body).to.equal('Match regex')
@@ -190,7 +190,7 @@ describe('allowUnmocked option', () => {
     expect((await got(origin)).body).to.equal('live')
     expect((await got(`${origin}/alphalicious`)).body).to.equal('this is alpha')
     expect((await got(`${origin}/bravo-company`)).body).to.equal(
-      'bravo, bravo!'
+      'bravo, bravo!',
     )
 
     scope1.done()
@@ -243,7 +243,7 @@ describe('allowUnmocked option', () => {
   // https://github.com/nock/nock/issues/1832
   it('should only emit "finish" once even if an unmocked request is created after playback as started', async () => {
     const { origin, port } = await startHttpServer((request, response) =>
-      response.end()
+      response.end(),
     )
 
     const scope = nock(origin, { allowUnmocked: true }).post('/', 'foo').reply()

--- a/tests/test_back.js
+++ b/tests/test_back.js
@@ -39,7 +39,7 @@ function testNock(done) {
           expect(data).to.be.an.instanceOf(Buffer)
           expect(data.toString()).to.equal('Hello World!')
         })
-      }
+      },
     )
     .end()
 }
@@ -83,7 +83,7 @@ function nockBackWithFixtureLocalhost(mochaDone) {
           this.assertScopesFinished()
           nockDone()
           mochaDone()
-        }
+        },
       )
 
       request.on('error', () => expect.fail())
@@ -117,7 +117,7 @@ describe('Nock Back', () => {
 
   it('should throw an exception when a hook is not a function', () => {
     expect(() =>
-      nockBack('good_request.json', { before: 'not-a-function-innit' })
+      nockBack('good_request.json', { before: 'not-a-function-innit' }),
     ).to.throw('processing hooks must be a function')
   })
 
@@ -127,7 +127,7 @@ describe('Nock Back', () => {
         expect(nockDone).to.be.a('function')
         expect(context).to.be.an('object')
         done()
-      }
+      },
     )
   })
 
@@ -140,7 +140,7 @@ describe('Nock Back', () => {
     const fixturePath = path.join(nockBack.fixtures, fixtureName)
     nockBack(fixtureName, function (nockDone) {
       expect(() => this.assertScopesFinished()).to.throw(
-        `["GET http://www.example.test:80/"] was not used, consider removing ${fixturePath} to rerecord fixture`
+        `["GET http://www.example.test:80/"] was not used, consider removing ${fixturePath} to rerecord fixture`,
       )
       nockDone()
       done()
@@ -164,7 +164,7 @@ describe('Nock Back', () => {
 
     it(
       "shouldn't do anything when fixtures are present",
-      nockBackWithFixtureLocalhost
+      nockBackWithFixtureLocalhost,
     )
   })
 
@@ -186,7 +186,7 @@ describe('Nock Back', () => {
           response => {
             expect(response.statusCode).to.equal(217)
             done()
-          }
+          },
         )
 
         request.on('error', () => expect.fail())
@@ -224,7 +224,7 @@ describe('Nock Back', () => {
                 expect(fs.existsSync(fixtureLoc)).to.be.false()
                 done()
               })
-            }
+            },
           )
 
           request.on('error', () => expect.fail())
@@ -275,7 +275,7 @@ describe('Nock Back', () => {
               expect(response.statusCode).to.equal(217)
               expect(fs.existsSync(fixtureLoc)).to.be.true()
               done()
-            }
+            },
           )
 
           request.on('error', () => expect.fail())
@@ -299,7 +299,7 @@ describe('Nock Back', () => {
                 nockDone()
 
                 const fixtureContent = JSON.parse(
-                  fs.readFileSync(fixtureLoc).toString('utf8')
+                  fs.readFileSync(fixtureLoc).toString('utf8'),
                 )
                 expect(fixtureContent).to.have.length(1)
 
@@ -314,7 +314,7 @@ describe('Nock Back', () => {
               })
 
               response.resume()
-            }
+            },
           )
 
           request.on('error', err => expect.fail(err.message))
@@ -342,7 +342,7 @@ describe('Nock Back', () => {
               expect(response.statusCode).to.equal(217)
               expect(fs.existsSync(fixtureLoc)).to.be.true()
               done()
-            }
+            },
           )
 
           request.on('error', () => expect.fail())
@@ -357,7 +357,7 @@ describe('Nock Back', () => {
           .get('http://other.example.test', () => expect.fail())
           .on('error', err => {
             expect(err.message).to.equal(
-              'Nock: Disallowed net connect for "other.example.test:80/"'
+              'Nock: Disallowed net connect for "other.example.test:80/"',
             )
             nockDone()
             done()
@@ -398,7 +398,7 @@ describe('Nock Back', () => {
               expect(fs.existsSync(fixtureLoc)).to.be.true()
               expect(this.scopes).to.be.empty()
               done()
-            }
+            },
           )
           request.on('error', () => expect.fail())
           request.end()
@@ -425,10 +425,10 @@ describe('Nock Back', () => {
               expect(response.statusCode).to.equal(217)
               expect(fs.existsSync(fixtureLoc)).to.be.true()
               expect(fs.readFileSync(fixtureLoc, 'utf8')).to.equal(
-                'string-response'
+                'string-response',
               )
               done()
-            }
+            },
           )
           request.on('error', () => expect.fail())
           request.end()
@@ -454,7 +454,7 @@ describe('Nock Back', () => {
                   nockDone()
 
                   const fixtureContent = JSON.parse(
-                    fs.readFileSync(fixtureLoc).toString('utf8')
+                    fs.readFileSync(fixtureLoc).toString('utf8'),
                   )
 
                   expect(fixtureContent).to.have.length(1)
@@ -463,13 +463,13 @@ describe('Nock Back', () => {
                   done()
                 })
                 response.resume()
-              }
+              },
             )
 
             request.on('error', () => expect.fail())
             request.end()
           })
-        }
+        },
       )
     })
 
@@ -496,7 +496,7 @@ describe('Nock Back', () => {
       nockBack.setMode('update')
       fs.copyFileSync(
         path.resolve(fixturePath, 'wrong_uri.json'),
-        path.resolve(fixturePath, 'temp_wrong_uri.json')
+        path.resolve(fixturePath, 'temp_wrong_uri.json'),
       )
     })
 
@@ -521,7 +521,7 @@ describe('Nock Back', () => {
               expect(response.statusCode).to.equal(217)
               expect(fs.existsSync(fixtureLoc)).to.be.true()
               done()
-            }
+            },
           )
 
           request.on('error', () => expect.fail())
@@ -545,7 +545,7 @@ describe('Nock Back', () => {
                 nockDone()
 
                 const fixtureContent = JSON.parse(
-                  fs.readFileSync(fixtureLoc).toString('utf8')
+                  fs.readFileSync(fixtureLoc).toString('utf8'),
                 )
                 expect(fixtureContent).to.have.length(1)
 
@@ -560,7 +560,7 @@ describe('Nock Back', () => {
               })
 
               response.resume()
-            }
+            },
           )
 
           request.on('error', err => expect.fail(err.message))
@@ -588,7 +588,7 @@ describe('Nock Back', () => {
               expect(response.statusCode).to.equal(217)
               expect(fs.existsSync(fixtureLoc)).to.be.true()
               done()
-            }
+            },
           )
 
           request.on('error', () => expect.fail())
@@ -610,10 +610,10 @@ describe('Nock Back', () => {
               nockDone()
               expect(response.statusCode).to.equal(217)
               expect(
-                fs.existsSync(`${fixturePath}/temp_wrong_uri.json`)
+                fs.existsSync(`${fixturePath}/temp_wrong_uri.json`),
               ).to.be.true()
               done()
-            }
+            },
           )
 
           request.on('error', () => expect.fail())
@@ -625,7 +625,7 @@ describe('Nock Back', () => {
     it("shouldn't load recorded tests", done => {
       fs.copyFileSync(
         path.resolve(fixturePath, 'good_request.json'),
-        path.resolve(fixturePath, 'temp_good_request.json')
+        path.resolve(fixturePath, 'temp_good_request.json'),
       )
       nockBack('temp_good_request.json', function (nockDone) {
         expect(this.scopes).to.have.lengthOf.at.least(0)
@@ -662,7 +662,7 @@ describe('Nock Back', () => {
               expect(fs.existsSync(fixtureLoc)).to.be.true()
               expect(this.scopes).to.be.empty()
               done()
-            }
+            },
           )
           request.on('error', () => expect.fail())
           request.end()
@@ -689,10 +689,10 @@ describe('Nock Back', () => {
               expect(response.statusCode).to.equal(217)
               expect(fs.existsSync(fixtureLoc)).to.be.true()
               expect(fs.readFileSync(fixtureLoc, 'utf8')).to.equal(
-                'string-response'
+                'string-response',
               )
               done()
-            }
+            },
           )
           request.on('error', () => expect.fail())
           request.end()
@@ -718,7 +718,7 @@ describe('Nock Back', () => {
                   nockDone()
 
                   const fixtureContent = JSON.parse(
-                    fs.readFileSync(fixtureLoc).toString('utf8')
+                    fs.readFileSync(fixtureLoc).toString('utf8'),
                   )
 
                   expect(fixtureContent).to.have.length(1)
@@ -727,13 +727,13 @@ describe('Nock Back', () => {
                   done()
                 })
                 response.resume()
-              }
+              },
             )
 
             request.on('error', () => expect.fail())
             request.end()
           })
-        }
+        },
       )
     })
 
@@ -761,12 +761,12 @@ describe('Nock Back', () => {
           host: 'other.example.test',
           path: '/',
         },
-        () => expect.fail('Should not come here!')
+        () => expect.fail('Should not come here!'),
       )
 
       req.on('error', err => {
         expect(err.message.trim()).to.equal(
-          'Nock: Disallowed net connect for "other.example.test:80/"'
+          'Nock: Disallowed net connect for "other.example.test:80/"',
         )
         done()
       })

--- a/tests/test_basic_auth.js
+++ b/tests/test_basic_auth.js
@@ -26,7 +26,7 @@ describe('basic auth with username and password', () => {
   it('fails when it doesnt match', async () => {
     await assertRejects(
       got('http://example.test/test'),
-      /Nock: No match for request/
+      /Nock: No match for request/,
     )
   })
 })
@@ -52,7 +52,7 @@ describe('basic auth with username only', () => {
   it('fails when it doesnt match', async () => {
     await assertRejects(
       got('http://example.test/test'),
-      /Nock: No match for request/
+      /Nock: No match for request/,
     )
   })
 })

--- a/tests/test_body_match.js
+++ b/tests/test_body_match.js
@@ -154,7 +154,7 @@ describe('`matchBody()`', () => {
     const scope = nock('http://example.test')
       .post(
         '/',
-        `--${boundary}\r\nContent-Disposition: form-data; name="field"\r\n\r\nvalue\r\n--${boundary}--\r\n`
+        `--${boundary}\r\nContent-Disposition: form-data; name="field"\r\n\r\nvalue\r\n--${boundary}--\r\n`,
       )
       .reply(200)
 

--- a/tests/test_client_request.js
+++ b/tests/test_client_request.js
@@ -85,7 +85,7 @@ describe('Direct use of `ClientRequest`', () => {
 
   it('should throw an expected error when creating with empty options', () => {
     expect(() => new http.ClientRequest()).to.throw(
-      'Creating a ClientRequest with empty `options` is not supported in Nock'
+      'Creating a ClientRequest with empty `options` is not supported in Nock',
     )
   })
 
@@ -110,7 +110,7 @@ describe('Direct use of `ClientRequest`', () => {
     nock.disableNetConnect()
     new http.ClientRequest({ port: 12345, path: '/' }).on('error', err => {
       expect(err.message).to.equal(
-        'Nock: Disallowed net connect for "localhost:12345/"'
+        'Nock: Disallowed net connect for "localhost:12345/"',
       )
       done()
     })

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -28,7 +28,7 @@ describe('Body Match', () => {
       const result = matchBody(
         {},
         'something //here is something more \n',
-        'something //here is something more \n\r'
+        'something //here is something more \n\r',
       )
       expect(result).to.equal(true)
     })
@@ -45,7 +45,7 @@ describe('Body Match', () => {
       const result = matchBody(
         { headers: { 'Content-Type': ['multipart/form-data;'] } },
         {},
-        'test'
+        'test',
       )
       expect(result).to.equal(false)
     })
@@ -54,7 +54,7 @@ describe('Body Match', () => {
       const result = matchBody(
         { headers: { 'Content-Type': 'multipart/form-data;' } },
         'something //here is something more \nHello',
-        'something //here is something more \nHello'
+        'something //here is something more \nHello',
       )
       expect(result).to.equal(true)
     })
@@ -63,7 +63,7 @@ describe('Body Match', () => {
       const result = matchBody(
         { headers: { 'Content-Type': ['multipart/form-data;'] } },
         'something //here is something more \nHello',
-        'something //here is something more \nHello'
+        'something //here is something more \nHello',
       )
       expect(result).to.equal(true)
     })
@@ -125,24 +125,24 @@ describe('`normalizeRequestOptions()`', () => {
 describe('`isUtf8Representable()`', () => {
   it("should return false for buffers that aren't utf8 representable", () => {
     expect(common.isUtf8Representable(Buffer.from('8001', 'hex'))).to.equal(
-      false
+      false,
     )
   })
 
   it('should returns true for buffers containing strings', () => {
     expect(common.isUtf8Representable(Buffer.from('8001', 'utf8'))).to.equal(
-      true
+      true,
     )
   })
 })
 
 it('`isJSONContent()`', () => {
   expect(common.isJSONContent({ 'content-type': 'application/json' })).to.equal(
-    true
+    true,
   )
 
   expect(
-    common.isJSONContent({ 'content-type': 'application/json; charset=utf-8' })
+    common.isJSONContent({ 'content-type': 'application/json; charset=utf-8' }),
   ).to.equal(true)
 
   expect(common.isJSONContent({ 'content-type': 'text/plain' })).to.equal(false)
@@ -172,10 +172,10 @@ describe('`headersFieldNamesToLowerCase()`', () => {
           HoSt: 'example.test',
           HOST: 'example.test',
         },
-        true
-      )
+        true,
+      ),
     ).to.throw(
-      'Failed to convert header keys to lower case due to field name conflict: host'
+      'Failed to convert header keys to lower case due to field name conflict: host',
     )
   })
 })
@@ -240,13 +240,13 @@ describe('`deleteHeadersField()`', () => {
 
   it('should throw for invalid headers', () => {
     expect(() => common.deleteHeadersField('foo', 'Content-Type')).to.throw(
-      'headers must be an object'
+      'headers must be an object',
     )
   })
 
   it('should throw for invalid field name', () => {
     expect(() => common.deleteHeadersField({}, /cookie/)).to.throw(
-      'field name must be a string'
+      'field name must be a string',
     )
   })
 })
@@ -298,7 +298,7 @@ describe('`overrideRequests()`', () => {
     common.overrideRequests()
     // Second call throws.
     expect(() => common.overrideRequests()).to.throw(
-      "Module's request already overridden for http protocol."
+      "Module's request already overridden for http protocol.",
     )
   })
 })
@@ -466,7 +466,7 @@ it('`headersArrayToObject()`', () => {
   })
 
   expect(() => common.headersArrayToObject(123)).to.throw(
-    'Expected a header array'
+    'Expected a header array',
   )
 })
 
@@ -518,7 +518,7 @@ describe('`dataEqual()`', () => {
   it('treats JSON path notated and nested objects as equal', () => {
     const result = common.dataEqual(
       { 'foo[bar][0]': 'baz' },
-      { foo: { bar: ['baz'] } }
+      { foo: { bar: ['baz'] } },
     )
     expect(result).to.equal(true)
   })

--- a/tests/test_define.js
+++ b/tests/test_define.js
@@ -19,7 +19,7 @@ describe('`define()`', () => {
           //  "reply" has been deprecated
           reply: '500',
         },
-      ])
+      ]),
     ).to.be.ok()
 
     await assertRejects(
@@ -27,7 +27,7 @@ describe('`define()`', () => {
       ({ response: { statusCode } }) => {
         expect(statusCode).to.equal(500)
         return true
-      }
+      },
     )
   })
 
@@ -40,7 +40,7 @@ describe('`define()`', () => {
           path: '/',
           reply: 'frodo',
         },
-      ])
+      ]),
     ).to.throw('`reply`, when present, must be a numeric string')
   })
 
@@ -56,7 +56,7 @@ describe('`define()`', () => {
           body,
           response: '�',
         },
-      ])
+      ]),
     ).to.have.lengthOf(1)
 
     const { statusCode } = await got.post('http://example.test/', { body })
@@ -77,7 +77,7 @@ describe('`define()`', () => {
           body,
           response: '�',
         },
-      ])
+      ]),
     ).to.be.ok()
 
     const { statusCode } = await got.post('http://example.test:1451/', { body })
@@ -96,9 +96,9 @@ describe('`define()`', () => {
           body: 'Hello, world!',
           response: '�',
         },
-      ])
+      ]),
     ).to.throw(
-      'Mismatched port numbers in scope and port properties of nock definition.'
+      'Mismatched port numbers in scope and port properties of nock definition.',
     )
   })
 
@@ -111,7 +111,7 @@ describe('`define()`', () => {
           body: 'Hello, world!',
           response: 'yo',
         },
-      ])
+      ]),
     ).to.throw('Method is required')
   })
 
@@ -129,7 +129,7 @@ describe('`define()`', () => {
           status: 200,
           response: exampleResponseBody,
         },
-      ])
+      ]),
     ).to.be.ok()
 
     const { statusCode, body } = await got.post('http://example.test/', {
@@ -160,7 +160,7 @@ describe('`define()`', () => {
           status: 200,
           response: exampleResponse,
         },
-      ])
+      ]),
     ).to.be.ok()
 
     const req = http.request(
@@ -183,7 +183,7 @@ describe('`define()`', () => {
           expect(response.toString('hex')).to.equal(exampleResponse)
           done()
         })
-      }
+      },
     )
 
     req.on('error', () => {
@@ -213,7 +213,7 @@ describe('`define()`', () => {
           status: 200,
           reqheaders,
         },
-      ])
+      ]),
     ).to.be.ok()
 
     // Make a request which should match the mock that was configured above.
@@ -235,7 +235,7 @@ describe('`define()`', () => {
         // Streams start in 'paused' mode and must be started.
         // See https://nodejs.org/api/stream.html#stream_class_stream_readable
         res.resume()
-      }
+      },
     )
     req.end()
   })
@@ -259,7 +259,7 @@ describe('`define()`', () => {
             'x-foo': 'bar',
           },
         },
-      ])
+      ]),
     ).to.be.ok()
 
     const req = http.request(
@@ -280,7 +280,7 @@ describe('`define()`', () => {
         // Streams start in 'paused' mode and must be started.
         // See https://nodejs.org/api/stream.html#stream_class_stream_readable
         res.resume()
-      }
+      },
     )
     req.end()
   })

--- a/tests/test_delay.js
+++ b/tests/test_delay.js
@@ -34,7 +34,7 @@ function checkDuration(start, durationMillis) {
   // TODO: find a better way to test delays while ensuring the delays aren't too long.
   expect(milliseconds).to.be.at.least(
     durationMillis - 5,
-    'delay minimum not satisfied'
+    'delay minimum not satisfied',
   )
   // .and.at.most(durationMillis + bufferMillis, 'delay upper bound exceeded')
 }
@@ -77,7 +77,7 @@ describe('`delay()`', () => {
 
   it('should throw on invalid arguments', () => {
     expect(() => interceptor.delay('one million seconds')).to.throw(
-      'Unexpected input'
+      'Unexpected input',
     )
   })
 
@@ -204,7 +204,7 @@ describe('`delayConnection()`', () => {
 
     await assertRejects(
       got('http://example.test', { timeout: 10 }),
-      err => err.code === 'ETIMEDOUT'
+      err => err.code === 'ETIMEDOUT',
     )
 
     scope.done()
@@ -294,7 +294,7 @@ describe('`delayConnection()`', () => {
 
     const { body, statusCode } = await resolvesInAtLeast(
       got('http://example.test'),
-      200
+      200,
     )
 
     expect(statusCode).to.equal(200)
@@ -310,7 +310,7 @@ describe('`delayConnection()`', () => {
 
     await resolvesInAtLeast(
       assertRejects(got('http://example.test'), /this is an error message/),
-      100
+      100,
     )
   })
 
@@ -377,7 +377,7 @@ describe('`delayConnection()`', () => {
       { agent, timeout: 5000 },
       res => {
         res.once('end', onEnd)
-      }
+      },
     )
 
     req.on('timeout', function () {

--- a/tests/test_header_matching.js
+++ b/tests/test_header_matching.js
@@ -43,7 +43,7 @@ describe('Header matching', () => {
         got('http://example.test/', {
           headers: { 'X-My-Headers': 456 },
         }),
-        /Nock: No match for request/
+        /Nock: No match for request/,
       )
     })
 
@@ -59,7 +59,7 @@ describe('Header matching', () => {
         got('http://example.test/', {
           headers: { '-My-Headers': 456 },
         }),
-        /Nock: No match for request/
+        /Nock: No match for request/,
       )
 
       expect(scope.isDone()).to.be.false()
@@ -223,7 +223,7 @@ describe('Header matching', () => {
         got('http://example.test/', {
           headers: { 'X-My-Headers': 456 },
         }),
-        /Nock: No match for request/
+        /Nock: No match for request/,
       )
     })
 
@@ -237,7 +237,7 @@ describe('Header matching', () => {
         got('http://example.test/', {
           headers: { '-My-Headers': 456 },
         }),
-        /Nock: No match for request/
+        /Nock: No match for request/,
       )
 
       expect(scope.isDone()).to.be.false()
@@ -247,7 +247,7 @@ describe('Header matching', () => {
       const username = 'testuser'
       const password = 'testpassword'
       const authString = Buffer.from(`${username}:${password}`).toString(
-        'base64'
+        'base64',
       )
       const expectedAuthHeader = `Basic ${authString}`
 
@@ -282,7 +282,7 @@ describe('Header matching', () => {
         got.post('http://example.test/', {
           headers: { 'X-App-Token': 'apptoken' },
         }),
-        /Nock: No match for request/
+        /Nock: No match for request/,
       )
     })
 
@@ -314,7 +314,7 @@ describe('Header matching', () => {
         got.post('http://example.test/', {
           headers: { 'X-My-Super-Power': 'mullet growing' },
         }),
-        /Nock: No match/
+        /Nock: No match/,
       )
 
       expect(scope.isDone()).to.be.false()
@@ -343,7 +343,7 @@ describe('Header matching', () => {
       }
 
       expect(() => nock('http://example.test', options).get('/')).to.throw(
-        'Headers must be provided as an object'
+        'Headers must be provided as an object',
       )
     })
 
@@ -377,7 +377,7 @@ describe('Header matching', () => {
         got.post('http://example.test/', {
           headers: { 'X-My-Super-Power': 'mullet growing' },
         }),
-        /Nock: No match/
+        /Nock: No match/,
       )
 
       expect(scope.isDone()).to.be.false()
@@ -518,7 +518,7 @@ describe('Header matching', () => {
         got('http://example.test/', {
           headers: { Cookie: 'cookie', Donut: 'donut' },
         }),
-        /Nock: No match for request/
+        /Nock: No match for request/,
       )
 
       expect(scope.isDone()).to.be.false()
@@ -579,7 +579,7 @@ describe('Header matching', () => {
         got('http://example.test/', {
           headers: { Host: 'some.other.domain.test' },
         }),
-        /Nock: No match for request/
+        /Nock: No match for request/,
       )
     })
   })

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -22,20 +22,20 @@ const acceptableGlobalKeys = new Set([
 describe('Intercept', () => {
   it('invalid or missing method parameter throws an exception', () => {
     expect(() => nock('https://example.test').intercept('/somepath')).to.throw(
-      'The "method" parameter is required for an intercept call.'
+      'The "method" parameter is required for an intercept call.',
     )
   })
 
   it("should throw when the path doesn't include a leading slash and there is no base path", () => {
     expect(() => nock('http://example.test').get('no-leading-slash')).to.throw(
-      "Non-wildcard URL path strings must begin with a slash (otherwise they won't match anything)"
+      "Non-wildcard URL path strings must begin with a slash (otherwise they won't match anything)",
     )
   })
 
   // https://github.com/nock/nock/issues/1730
   it('should throw when the path is empty and there is no base path', () => {
     expect(() => nock('http://example.test').get('')).to.throw(
-      "Non-wildcard URL path strings must begin with a slash (otherwise they won't match anything) (got: )"
+      "Non-wildcard URL path strings must begin with a slash (otherwise they won't match anything) (got: )",
     )
   })
 
@@ -126,7 +126,7 @@ describe('Intercept', () => {
           scope.done()
           done()
         })
-      }
+      },
     )
 
     req.end()
@@ -317,7 +317,7 @@ describe('Intercept', () => {
         // Streams start in 'paused' mode and must be started.
         // See https://nodejs.org/api/stream.html#stream_class_stream_readable
         res.resume()
-      }
+      },
     )
 
     req.end()
@@ -335,7 +335,7 @@ describe('Intercept', () => {
       () => {
         scope.done()
         done()
-      }
+      },
     )
     req.end()
   })
@@ -370,7 +370,7 @@ describe('Intercept', () => {
       },
       res => {
         expect.fail(new Error('should not come here!'))
-      }
+      },
     )
 
     req.end()
@@ -384,8 +384,8 @@ describe('Intercept', () => {
             headers: {},
           },
           null,
-          2
-        )}`
+          2,
+        )}`,
       )
       done()
     })
@@ -401,7 +401,7 @@ describe('Intercept', () => {
       },
       res => {
         expect.fail(new Error('should not come here!'))
-      }
+      },
     )
     req.on('error', err => {
       expect(err.message.trim()).to.equal(
@@ -412,8 +412,8 @@ describe('Intercept', () => {
             headers: {},
           },
           null,
-          2
-        )}`
+          2,
+        )}`,
       )
       done()
     })
@@ -431,7 +431,7 @@ describe('Intercept', () => {
       },
       res => {
         expect.fail(new Error('should not come here!'))
-      }
+      },
     )
 
     req.on('error', err => {
@@ -443,8 +443,8 @@ describe('Intercept', () => {
             headers: {},
           },
           null,
-          2
-        )}`
+          2,
+        )}`,
       )
       done()
     })
@@ -497,7 +497,7 @@ describe('Intercept', () => {
         res => {
           scope.done()
           done()
-        }
+        },
       )
       .end()
   })
@@ -512,7 +512,7 @@ describe('Intercept', () => {
       })
 
     const { statusCode } = await got(
-      'http://username:password@example.test/abc'
+      'http://username:password@example.test/abc',
     )
     expect(statusCode).to.equal(200)
 
@@ -532,7 +532,7 @@ describe('Intercept', () => {
         res => {
           scope.done()
           done()
-        }
+        },
       )
       .end()
   })
@@ -550,7 +550,7 @@ describe('Intercept', () => {
         res => {
           scope.done()
           done()
-        }
+        },
       )
       .end()
   })
@@ -571,7 +571,7 @@ describe('Intercept', () => {
         res => {
           scope.done()
           done()
-        }
+        },
       )
       .end('{"some_data":"something"}')
   })
@@ -623,7 +623,7 @@ describe('Intercept', () => {
 
     await assertRejects(
       got('http://example.test/'),
-      /Nock: No match for request/
+      /Nock: No match for request/,
     )
     expect(scope.isDone()).to.be.false()
 
@@ -842,7 +842,7 @@ describe('Intercept', () => {
       .reply(200, 'Match regex')
 
     const { statusCode, body } = await got(
-      'http://example.test/resources/regex'
+      'http://example.test/resources/regex',
     )
     expect(statusCode).to.equal(200)
     expect(body).to.equal('Match regex')
@@ -880,7 +880,7 @@ describe('Intercept', () => {
       .reply(200, 'Match PUT')
 
     const postResponse = await got.post(
-      'http://example.test/match/uri/function'
+      'http://example.test/match/uri/function',
     )
     expect(postResponse).to.include({ statusCode: 200, body: `Match POST` })
 
@@ -889,7 +889,7 @@ describe('Intercept', () => {
 
     await assertRejects(
       got.head('http://example.test/do/not/match'),
-      /Nock: No match for request/
+      /Nock: No match for request/,
     )
   })
 
@@ -902,7 +902,7 @@ describe('Intercept', () => {
 
     await assertRejects(
       got('http://example.test/hey'),
-      /Nock: No match for request/
+      /Nock: No match for request/,
     )
   })
 
@@ -927,7 +927,7 @@ describe('Intercept', () => {
             scope.done()
             done()
           })
-        }
+        },
       )
       .end('WHAA')
   })
@@ -990,14 +990,14 @@ describe('Intercept', () => {
 
   it('with filteringScope, URL path without leading slash does not throw error', done => {
     expect(() =>
-      nock('http://example.test', { filteringScope: () => {} }).get('')
+      nock('http://example.test', { filteringScope: () => {} }).get(''),
     ).not.to.throw()
     done()
   })
 
   it('no new keys were added to the global namespace', done => {
     const leaks = Object.keys(global).filter(
-      key => !acceptableGlobalKeys.has(key)
+      key => !acceptableGlobalKeys.has(key),
     )
     expect(leaks).to.deep.equal([])
     done()
@@ -1094,7 +1094,7 @@ describe('Intercept', () => {
             expect(res.statusCode).to.equal(200)
             scope.done()
             server.close(done)
-          }
+          },
         )
 
         req.on('error', error => {

--- a/tests/test_ipv6.js
+++ b/tests/test_ipv6.js
@@ -55,7 +55,7 @@ describe('IPv6', () => {
             scope.done()
             done()
           })
-        }
+        },
       )
       .end()
   })

--- a/tests/test_logging.js
+++ b/tests/test_logging.js
@@ -27,7 +27,7 @@ describe('Logging using the `debug` package', () => {
 
     // the log when an interceptor is chosen
     expect(logFn).to.have.been.calledWith(
-      sinon.match('matched base path (1 interceptor)')
+      sinon.match('matched base path (1 interceptor)'),
     )
 
     // the log of the Interceptor match
@@ -38,18 +38,18 @@ describe('Logging using the `debug` package', () => {
       // request URL.
       sinon.match('"href":"http://example.test/deep/link"'),
       // This is the JSON-stringified body.
-      `"${exampleBody}"`
+      `"${exampleBody}"`,
     )
 
     expect(logFn).to.have.been.calledWith(sinon.match('query matching skipped'))
 
     expect(logFn).to.have.been.calledWith(
       sinon.match(
-        'matching http://example.test:80/deep/link to POST http://example.test:80/deep/link: true'
-      )
+        'matching http://example.test:80/deep/link to POST http://example.test:80/deep/link: true',
+      ),
     )
     expect(logFn).to.have.been.calledWith(
-      sinon.match('interceptor identified, starting mocking')
+      sinon.match('interceptor identified, starting mocking'),
     )
   })
 })

--- a/tests/test_net_connect.js
+++ b/tests/test_net_connect.js
@@ -16,7 +16,7 @@ describe('`disableNetConnect()`', () => {
 
     await assertRejects(
       got('https://other.example.test/'),
-      /Nock: Disallowed net connect for "other.example.test:443\/"/
+      /Nock: Disallowed net connect for "other.example.test:443\/"/,
     )
   })
 
@@ -54,7 +54,7 @@ describe('`enableNetConnect()`', () => {
 
     await assertRejects(
       got('https://example.test/'),
-      /Nock: Disallowed net connect for "example.test:443\/"/
+      /Nock: Disallowed net connect for "example.test:443\/"/,
     )
   })
 
@@ -77,7 +77,7 @@ describe('`enableNetConnect()`', () => {
 
     await assertRejects(
       got('https://example.test/'),
-      /Nock: Disallowed net connect for "example.test:443\/"/
+      /Nock: Disallowed net connect for "example.test:443\/"/,
     )
   })
 
@@ -100,7 +100,7 @@ describe('`enableNetConnect()`', () => {
 
     await assertRejects(
       got('https://example.test/'),
-      /Nock: Disallowed net connect for "example.test:443\/"/
+      /Nock: Disallowed net connect for "example.test:443\/"/,
     )
   })
 

--- a/tests/test_nock_off.js
+++ b/tests/test_nock_off.js
@@ -23,7 +23,7 @@ describe('NOCK_OFF env var', () => {
       (request, response) => {
         response.writeHead(200)
         response.end(responseBody)
-      }
+      },
     )
 
     const scope = nock(origin, { allowUnmocked: true })

--- a/tests/test_persist_optionally.js
+++ b/tests/test_persist_optionally.js
@@ -36,7 +36,7 @@ describe('`optionally()`', () => {
 
     expect(() => interceptor.optionally('foo')).to.throw(
       Error,
-      'Invalid arguments: argument should be a boolean'
+      'Invalid arguments: argument should be a boolean',
     )
   })
 
@@ -203,14 +203,14 @@ describe('`persist()`', () => {
 
     await assertRejects(
       got('http://example.test/'),
-      /Nock: No match for request/
+      /Nock: No match for request/,
     )
   })
 
   it('when called with an invalid argument, throws the expected error', () => {
     expect(() => nock('http://example.test').persist('string')).to.throw(
       Error,
-      'Invalid arguments: argument should be a boolean'
+      'Invalid arguments: argument should be a boolean',
     )
   })
 })

--- a/tests/test_query.js
+++ b/tests/test_query.js
@@ -63,7 +63,7 @@ describe('`query()`', () => {
         .reply()
 
       const { statusCode } = await got(
-        'http://example.test/?num=1&bool=true&empty=&str=fou'
+        'http://example.test/?num=1&bool=true&empty=&str=fou',
       )
 
       expect(statusCode).to.equal(200)
@@ -138,11 +138,11 @@ describe('`query()`', () => {
 
       await assertRejects(
         got('http://example.test/?foo=hello%20world'),
-        /Nock: No match for request/
+        /Nock: No match for request/,
       )
 
       const { statusCode } = await got(
-        'http://example.test/?foo=hello%2520world'
+        'http://example.test/?foo=hello%2520world',
       )
       expect(statusCode).to.equal(200)
       scope.done()
@@ -175,7 +175,7 @@ describe('`query()`', () => {
 
       await assertRejects(
         got('http://example.test/?foo=baz'),
-        /Nock: No match for request/
+        /Nock: No match for request/,
       )
     })
 
@@ -184,7 +184,7 @@ describe('`query()`', () => {
 
       await assertRejects(
         got('http://example.test/?foo=bar&baz=foz'),
-        /Nock: No match for request/
+        /Nock: No match for request/,
       )
     })
 
@@ -195,7 +195,7 @@ describe('`query()`', () => {
 
       await assertRejects(
         got('http://example.test/?foobar'),
-        /Nock: No match for request/
+        /Nock: No match for request/,
       )
     })
 
@@ -212,7 +212,7 @@ describe('`query()`', () => {
 
       await assertRejects(
         got('http://example.test/?num=1str=fou'),
-        /Nock: No match for request/
+        /Nock: No match for request/,
       )
     })
 
@@ -221,7 +221,7 @@ describe('`query()`', () => {
 
       await assertRejects(
         got('http://example.test?foo[]=bar&foo[]=baz'),
-        /Nock: No match for request/
+        /Nock: No match for request/,
       )
     })
 
@@ -233,7 +233,7 @@ describe('`query()`', () => {
 
       await assertRejects(
         got('http://example.test?foo=bar%2Cbaz'),
-        /Nock: No match for request/
+        /Nock: No match for request/,
       )
     })
   })
@@ -303,7 +303,7 @@ describe('`query()`', () => {
         .reply()
 
       const { statusCode } = await got(
-        'http://example.test/?ignore=the&actual=query'
+        'http://example.test/?ignore=the&actual=query',
       )
       expect(statusCode).to.equal(200)
       scope.done()
@@ -317,7 +317,7 @@ describe('`query()`', () => {
 
       await assertRejects(
         got('http://example.test/?i=should&pass=?'),
-        /Nock: No match for request/
+        /Nock: No match for request/,
       )
     })
   })

--- a/tests/test_recorder.js
+++ b/tests/test_recorder.js
@@ -95,7 +95,7 @@ describe('Recorder', () => {
         gotRequest()
         response.writeHead(200)
         response.end()
-      }
+      },
     )
 
     nock.recorder.rec(true)
@@ -112,8 +112,8 @@ describe('Recorder', () => {
     // TODO: Use chai-string?
     expect(
       recorded[0].startsWith(
-        `\nnock('http://localhost:${port}', {"encodedQueryParams":true})\n  .post('/')`
-      )
+        `\nnock('http://localhost:${port}', {"encodedQueryParams":true})\n  .post('/')`,
+      ),
     ).to.be.true()
   })
 
@@ -176,8 +176,8 @@ describe('Recorder', () => {
       loggingFn
         .getCall(0)
         .args[0].startsWith(
-          '\n<<<<<<-- cut here -->>>>>>\n{\n  "scope": "http://localhost:'
-        )
+          '\n<<<<<<-- cut here -->>>>>>\n{\n  "scope": "http://localhost:',
+        ),
     ).to.be.true()
   })
 
@@ -422,7 +422,7 @@ describe('Recorder', () => {
             })
             done()
           })
-        }
+        },
       )
 
       req.end(requestBody)
@@ -453,7 +453,7 @@ describe('Recorder', () => {
             done()
           })
           res.resume()
-        }
+        },
       )
 
       req.end(onEnd)
@@ -498,7 +498,7 @@ describe('Recorder', () => {
             done()
           })
           res.resume()
-        }
+        },
       )
 
       req.end('foobar', onEnd)
@@ -513,7 +513,7 @@ describe('Recorder', () => {
     nock.recorder.rec()
     expect(() => nock.recorder.rec()).to.throw(
       Error,
-      'Nock recording already in progress'
+      'Nock recording already in progress',
     )
   })
 
@@ -560,7 +560,7 @@ describe('Recorder', () => {
               })
               done()
             })
-          }
+          },
         )
         .end(requestBody)
     })
@@ -599,13 +599,13 @@ describe('Recorder', () => {
                   reqheaders: {
                     host: `localhost:${port}`,
                     authorization: `Basic ${Buffer.from('foo:bar').toString(
-                      'base64'
+                      'base64',
                     )}`,
                   },
                 })
               done()
             })
-          }
+          },
         )
         .end()
     })
@@ -757,7 +757,7 @@ describe('Recorder', () => {
 
             // Confidence check: we're getting hex.
             expect(hexChunks.join('')).to.equal(
-              Buffer.from(responseBody, 'utf8').toString('hex')
+              Buffer.from(responseBody, 'utf8').toString('hex'),
             )
 
             // Assert: we're recording utf-8.
@@ -766,7 +766,7 @@ describe('Recorder', () => {
 
             done()
           })
-        }
+        },
       )
       req.end()
     })
@@ -802,7 +802,7 @@ describe('Recorder', () => {
               expect(recorded[0].reqheaders).to.be.undefined()
               done()
             })
-          }
+          },
         )
         .end()
     })
@@ -836,7 +836,7 @@ describe('Recorder', () => {
               expect(loggingFn.getCall(0).args[0]).to.be.a('string')
               done()
             })
-          }
+          },
         )
         .end()
     })
@@ -874,7 +874,7 @@ describe('Recorder', () => {
               expect(loggingFn.getCall(0).args[0]).to.be.an('object')
               done()
             })
-          }
+          },
         )
         .end()
     })
@@ -912,7 +912,7 @@ describe('Recorder', () => {
               expect(recorded[0].reqheaders['user-agent']).to.be.undefined()
               done()
             })
-          }
+          },
         )
         .end()
     })
@@ -1013,7 +1013,7 @@ describe('Recorder', () => {
               })
               done()
             })
-          }
+          },
         )
         .end(requestBody)
     })
@@ -1088,7 +1088,7 @@ describe('Recorder', () => {
                 .and.include(`.query({"param1":"1","param2":"2"})`)
               done()
             })
-          }
+          },
         )
         .end('ABCDEF')
     })
@@ -1150,7 +1150,7 @@ describe('Recorder', () => {
               })
           })
         },
-        50
+        50,
       )
 
       req.end()
@@ -1201,7 +1201,7 @@ describe('Recorder', () => {
 
         response.on('end', () => {
           expect(Buffer.concat(data).toString('hex')).to.equal(
-            transparentGifHex
+            transparentGifHex,
           )
 
           const recordedFixtures = nock.recorder.play()
@@ -1224,7 +1224,7 @@ describe('Recorder', () => {
 
               response.on('end', () => {
                 expect(Buffer.concat(data).toString('hex')).to.equal(
-                  transparentGifHex
+                  transparentGifHex,
                 )
                 done()
               })

--- a/tests/test_remove_interceptor.js
+++ b/tests/test_remove_interceptor.js
@@ -89,7 +89,7 @@ describe('`removeInterceptor()`', () => {
         nock.removeInterceptor({
           hostname: 'example.test',
           path: '/somepath',
-        })
+        }),
       ).to.be.true()
 
       const newScope = nock('http://example.test')
@@ -109,7 +109,7 @@ describe('`removeInterceptor()`', () => {
         nock.removeInterceptor({
           hostname: 'example.org',
           path: '/somepath',
-        })
+        }),
       ).to.be.false()
     })
 
@@ -126,7 +126,7 @@ describe('`removeInterceptor()`', () => {
           proto: 'https',
           hostname: 'example.test',
           path: '/somepath',
-        })
+        }),
       ).to.be.true()
 
       expect(scope.pendingMocks()).to.deep.equal([])
@@ -145,7 +145,7 @@ describe('`removeInterceptor()`', () => {
           method: 'post',
           hostname: 'example.test',
           path: '/somepath',
-        })
+        }),
       ).to.be.true()
 
       expect(scope.pendingMocks()).to.deep.equal([])
@@ -160,7 +160,7 @@ describe('`removeInterceptor()`', () => {
       expect(
         nock.removeInterceptor({
           hostname: 'example.test',
-        })
+        }),
       ).to.be.true()
 
       expect(scope.pendingMocks()).to.deep.equal([])
@@ -185,7 +185,7 @@ describe('`removeInterceptor()`', () => {
         nock.removeInterceptor({
           hostname: 'example.test',
           path: '/anotherpath',
-        })
+        }),
       ).to.be.true()
 
       expect(scope1.pendingMocks()).to.deep.equal([

--- a/tests/test_repeating.js
+++ b/tests/test_repeating.js
@@ -17,7 +17,7 @@ describe('repeating', () => {
 
     await assertRejects(
       got('http://example.test/'),
-      /Nock: No match for request/
+      /Nock: No match for request/,
     )
 
     scope.done()
@@ -37,7 +37,7 @@ describe('repeating', () => {
 
     await assertRejects(
       got('http://example.test/'),
-      /Nock: No match for request/
+      /Nock: No match for request/,
     )
 
     scope.done()
@@ -57,7 +57,7 @@ describe('repeating', () => {
 
     await assertRejects(
       got('http://example.test/'),
-      /Nock: No match for request/
+      /Nock: No match for request/,
     )
 
     scope.done()
@@ -78,7 +78,7 @@ describe('repeating', () => {
 
       await assertRejects(
         got('http://example.test/'),
-        /Nock: No match for request/
+        /Nock: No match for request/,
       )
 
       scope.done()
@@ -95,7 +95,7 @@ describe('repeating', () => {
 
       await assertRejects(
         got('http://example.test/'),
-        /Nock: No match for request/
+        /Nock: No match for request/,
       )
 
       scope.done()

--- a/tests/test_reply_body.js
+++ b/tests/test_reply_body.js
@@ -102,7 +102,7 @@ describe('`reply()` body', () => {
     }
 
     expect(() =>
-      nock('http://localhost').get('/').reply(200, unencodableObject)
+      nock('http://localhost').get('/').reply(200, unencodableObject),
     ).to.throw(Error, 'Error encoding response body into JSON')
   })
 
@@ -133,11 +133,11 @@ describe('`reply()` status code', () => {
 
     expect(() => scope.reply('200')).to.throw(
       Error,
-      'Invalid string value for status code'
+      'Invalid string value for status code',
     )
     expect(() => scope.reply(false)).to.throw(
       Error,
-      'Invalid boolean value for status code'
+      'Invalid boolean value for status code',
     )
   })
 })

--- a/tests/test_reply_function_async.js
+++ b/tests/test_reply_function_async.js
@@ -16,7 +16,7 @@ describe('asynchronous `reply()` function', () => {
       const scope = nock('http://example.test')
         .get('/')
         .reply(200, (path, requestBody, callback) =>
-          callback(null, 'Hello World!')
+          callback(null, 'Hello World!'),
         )
 
       const { body } = await got('http://example.test/', {
@@ -41,7 +41,7 @@ describe('asynchronous `reply()` function', () => {
                 responseBody,
                 { 'X-Custom-Header': 'abcdef' },
               ]),
-            1
+            1,
           )
         })
 
@@ -87,7 +87,7 @@ describe('asynchronous `reply()` function', () => {
       nock('http://example.test')
         .get('/')
         .reply(500, (path, requestBody, callback) =>
-          callback(new Error('Database failed'))
+          callback(new Error('Database failed')),
         )
 
       await assertRejects(got('http://example.test'), /Database failed/)

--- a/tests/test_reply_function_sync.js
+++ b/tests/test_reply_function_sync.js
@@ -116,7 +116,7 @@ describe('synchronous `reply()` function', () => {
             expect(statusCode).to.equal(404)
             expect(body).to.equal(exampleResponseBody)
             return true
-          }
+          },
         )
         scope.done()
       })
@@ -144,7 +144,7 @@ describe('synchronous `reply()` function', () => {
               expect(statusCode).to.equal(404)
               expect(body).to.equal('')
               return true
-            }
+            },
           )
 
           expect(replyFnCalled).to.have.been.called()
@@ -264,7 +264,7 @@ describe('synchronous `reply()` function', () => {
           expect(statusCode).to.equal(401)
           expect(body).to.equal(exampleResponse)
           return true
-        }
+        },
       )
       scope.done()
     })
@@ -306,7 +306,7 @@ describe('synchronous `reply()` function', () => {
         ])
 
       const { statusCode, body, headers, rawHeaders } = await got(
-        'http://example.test/'
+        'http://example.test/',
       )
 
       expect(statusCode).to.equal(202)
@@ -330,7 +330,7 @@ describe('synchronous `reply()` function', () => {
         ])
 
       const { statusCode, body, headers, rawHeaders } = await got(
-        'http://example.test/'
+        'http://example.test/',
       )
 
       expect(statusCode).to.equal(202)
@@ -403,7 +403,7 @@ describe('synchronous `reply()` function', () => {
       const interceptor = nock('http://example.test').get('/')
 
       expect(() =>
-        interceptor.reply(() => [200], { 'x-my-header': 'some-value' })
+        interceptor.reply(() => [200], { 'x-my-header': 'some-value' }),
       ).to.throw(Error, 'Invalid arguments')
     })
   })

--- a/tests/test_reply_headers.js
+++ b/tests/test_reply_headers.js
@@ -46,10 +46,10 @@ describe('`reply()` headers', () => {
       const scope = nock('http://example.test').get('/')
 
       expect(() =>
-        scope.reply(200, 'Hello World!', ['one', 'two', 'three'])
+        scope.reply(200, 'Hello World!', ['one', 'two', 'three']),
       ).to.throw(
         Error,
-        'Raw headers must be provided as an array with an even number of items. [fieldName, value, ...]'
+        'Raw headers must be provided as an array with an even number of items. [fieldName, value, ...]',
       )
     })
 
@@ -131,12 +131,12 @@ describe('`reply()` headers', () => {
 
       expect(() => scope.reply(200, 'Hello World!', 'foo: bar')).to.throw(
         Error,
-        'Headers must be provided as an array of raw values, a Map, or a plain Object. foo: bar'
+        'Headers must be provided as an array of raw values, a Map, or a plain Object. foo: bar',
       )
 
       expect(() => scope.reply(200, 'Hello World!', false)).to.throw(
         Error,
-        'Headers must be provided as an array of raw values, a Map, or a plain Object. false'
+        'Headers must be provided as an array of raw values, a Map, or a plain Object. false',
       )
     })
   })
@@ -308,7 +308,7 @@ describe('`reply()` headers', () => {
       expect(counter).to.equal(1)
 
       const { headers: headers2, rawHeaders: rawHeaders2 } = await got(
-        'http://example.test/'
+        'http://example.test/',
       )
       expect(headers2).to.deep.equal({ 'x-my-headers': '2' })
       expect(rawHeaders2).to.deep.equal(['X-My-Headers', '2'])
@@ -332,7 +332,7 @@ describe('`replyContentLength()`', () => {
     const { headers } = await got('http://example.test/')
 
     expect(headers['content-length']).to.equal(
-      `${JSON.stringify(response).length}`
+      `${JSON.stringify(response).length}`,
     )
     scope.done()
   })

--- a/tests/test_reply_with_file.js
+++ b/tests/test_reply_with_file.js
@@ -75,7 +75,7 @@ describe('`replyWithFile()`', () => {
       expect(() =>
         new Scope('http://example.test')
           .get('/')
-          .replyWithFile(200, textFilePath)
+          .replyWithFile(200, textFilePath),
       ).to.throw(Error, 'No fs')
     })
   })

--- a/tests/test_request_overrider.js
+++ b/tests/test_request_overrider.js
@@ -39,7 +39,7 @@ describe('Request Overrider', () => {
           expect(res).to.be.an.instanceof(http.IncomingMessage)
           scope.done()
           done()
-        }
+        },
       )
       .end()
   })
@@ -80,7 +80,7 @@ describe('Request Overrider', () => {
         // Streams start in 'paused' mode and must be started.
         // See https://nodejs.org/api/stream.html#stream_class_stream_readable
         res.resume()
-      }
+      },
     )
 
     req.write('mamma mia', null, () => {
@@ -114,7 +114,7 @@ describe('Request Overrider', () => {
         // Streams start in 'paused' mode and must be started.
         // See https://nodejs.org/api/stream.html#stream_class_stream_readable
         res.resume()
-      }
+      },
     )
 
     req.write('mamma mia', () => {
@@ -144,7 +144,7 @@ describe('Request Overrider', () => {
         // Streams start in 'paused' mode and must be started.
         // See https://nodejs.org/api/stream.html#stream_class_stream_readable
         res.resume()
-      }
+      },
     )
 
     req.write(undefined, null, reqWriteCallback)
@@ -172,7 +172,7 @@ describe('Request Overrider', () => {
         // Streams start in 'paused' mode and must be started.
         // See https://nodejs.org/api/stream.html#stream_class_stream_readable
         res.resume()
-      }
+      },
     )
 
     req.write(undefined)
@@ -204,7 +204,7 @@ describe('Request Overrider', () => {
         // Streams start in 'paused' mode and must be started.
         // See https://nodejs.org/api/stream.html#stream_class_stream_readable
         res.resume()
-      }
+      },
     )
 
     req.end('mamma mia', null, reqEndCallback)
@@ -233,7 +233,7 @@ describe('Request Overrider', () => {
         // Streams start in 'paused' mode and must be started.
         // See https://nodejs.org/api/stream.html#stream_class_stream_readable
         res.resume()
-      }
+      },
     )
 
     req.end(reqEndCallback)
@@ -257,7 +257,7 @@ describe('Request Overrider', () => {
           done()
         })
         res.resume()
-      }
+      },
     )
 
     // hex(foobar) == 666F6F626172
@@ -279,7 +279,7 @@ describe('Request Overrider', () => {
           done()
         })
         res.resume()
-      }
+      },
     )
 
     // hex(foobar) == 666F6F626172
@@ -304,7 +304,7 @@ describe('Request Overrider', () => {
           done()
         })
         res.resume()
-      }
+      },
     )
 
     req.end('foobar', reqEndCallback)
@@ -326,7 +326,7 @@ describe('Request Overrider', () => {
           done()
         })
         res.resume()
-      }
+      },
     )
 
     req.end()
@@ -374,7 +374,7 @@ describe('Request Overrider', () => {
         // Streams start in 'paused' mode and must be started.
         // See https://nodejs.org/api/stream.html#stream_class_stream_readable
         res.resume()
-      }
+      },
     )
 
     req.on('finish', onFinish)
@@ -490,7 +490,7 @@ describe('Request Overrider', () => {
         scope.done()
         expect(req.path).to.equal('/the/path/to/infinity')
         done()
-      }
+      },
     )
     req.end()
   })
@@ -545,7 +545,7 @@ describe('Request Overrider', () => {
         // Streams start in 'paused' mode and must be started.
         // See https://nodejs.org/api/stream.html#stream_class_stream_readable
         res.resume()
-      }
+      },
     )
 
     req.setNoDelay(true)
@@ -723,7 +723,7 @@ describe('Request Overrider', () => {
   it('should throw expected error when creating request with missing options', done => {
     expect(() => http.request()).to.throw(
       Error,
-      'Making a request with empty `options` is not supported in Nock'
+      'Making a request with empty `options` is not supported in Nock',
     )
     done()
   })
@@ -772,7 +772,7 @@ describe('Request Overrider', () => {
         // Streams start in 'paused' mode and must be started.
         // See https://nodejs.org/api/stream.html#stream_class_stream_readable
         res.resume()
-      }
+      },
     )
     req.end()
   })

--- a/tests/test_scope.js
+++ b/tests/test_scope.js
@@ -11,7 +11,7 @@ const got = require('./got_client')
 
 it('scope exposes interceptors', () => {
   const scopes = nock.load(
-    path.join(__dirname, 'fixtures', 'good_request.json')
+    path.join(__dirname, 'fixtures', 'good_request.json'),
   )
 
   expect(scopes).to.be.an.instanceOf(Array)
@@ -67,7 +67,7 @@ describe('`Scope#constructor`', () => {
         search: '',
         searchParams: {},
         hash: '',
-      })
+      }),
     ).to.throw()
   })
 })
@@ -168,7 +168,7 @@ describe('`filteringPath()`', function () {
   it('filteringPath with invalid argument throws expected', () => {
     expect(() => nock('http://example.test').filteringPath('abc123')).to.throw(
       Error,
-      'Invalid arguments: filtering path should be a function or a regular expression'
+      'Invalid arguments: filtering path should be a function or a regular expression',
     )
   })
 })
@@ -211,10 +211,10 @@ describe('filteringRequestBody()', () => {
 
   it('filteringRequestBody with invalid argument throws expected', () => {
     expect(() =>
-      nock('http://example.test').filteringRequestBody('abc123')
+      nock('http://example.test').filteringRequestBody('abc123'),
     ).to.throw(
       Error,
-      'Invalid arguments: filtering request body should be a function or a regular expression'
+      'Invalid arguments: filtering request body should be a function or a regular expression',
     )
   })
 })

--- a/tests/test_stream.js
+++ b/tests/test_stream.js
@@ -143,7 +143,7 @@ it('response pipe', done => {
       })
 
       res.pipe(dest)
-    }
+    },
   )
 })
 
@@ -193,7 +193,7 @@ it('response pipe without implicit end', done => {
       })
 
       res.pipe(dest, { end: false })
-    }
+    },
   )
 })
 
@@ -221,7 +221,7 @@ it('response is streams2 compatible', done => {
           expect(body).to.equal(responseText)
           done()
         })
-      }
+      },
     )
     .end()
 })
@@ -287,7 +287,7 @@ it('response readable pull stream works as expected', done => {
           done()
         }
       })
-    }
+    },
   )
 
   req.end()
@@ -316,6 +316,6 @@ it('error events on reply streams proxy to the response', done => {
       replyBody.end(() => {
         replyBody.emit('error', 'oh no!')
       })
-    }
+    },
   )
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,7 +9,7 @@ export = nock
 
 declare function nock(
   basePath: string | RegExp | Url | URL,
-  options?: nock.Options
+  options?: nock.Options,
 ): nock.Scope
 
 declare namespace nock {
@@ -22,7 +22,7 @@ declare namespace nock {
   function removeInterceptor(interceptor: Interceptor | ReqOptions): boolean
   function disableNetConnect(): void
   function enableNetConnect(
-    matcher?: string | RegExp | ((host: string) => boolean)
+    matcher?: string | RegExp | ((host: string) => boolean),
   ): void
   function load(path: string): Scope[]
   function loadDefs(path: string): Definition[]
@@ -37,7 +37,7 @@ declare namespace nock {
   type InterceptFunction = (
     uri: string | RegExp | { (uri: string): boolean },
     requestBody?: RequestBodyMatcher,
-    interceptorOptions?: Options
+    interceptorOptions?: Options,
   ) => Interceptor
 
   // Essentially valid, decoded JSON with the addition of possible RegExp. TS doesn't currently have
@@ -76,7 +76,7 @@ declare namespace nock {
   type ReplyHeaderFunction = (
     req: ClientRequest,
     res: IncomingMessage,
-    body: string | Buffer
+    body: string | Buffer,
   ) => string | string[]
   type ReplyHeaderValue = string | string[] | ReplyHeaderFunction
   type ReplyHeaders =
@@ -110,7 +110,7 @@ declare namespace nock {
       uri: string | RegExp | { (uri: string): boolean },
       method: string,
       requestBody?: RequestBodyMatcher,
-      options?: Options
+      options?: Options,
     ) => Interceptor
 
     defaultReplyHeaders(headers: ReplyHeaders): this
@@ -137,7 +137,7 @@ declare namespace nock {
         | string
         | DataMatcherMap
         | URLSearchParams
-        | { (parsedObj: ParsedUrlQuery): boolean }
+        | { (parsedObj: ParsedUrlQuery): boolean },
     ): this
 
     // tslint (as of 5.16) is under the impression that the callback types can be unified,
@@ -151,16 +151,16 @@ declare namespace nock {
         body: Body,
         callback: (
           err: NodeJS.ErrnoException | null,
-          result: ReplyFnResult
-        ) => void
-      ) => void
+          result: ReplyFnResult,
+        ) => void,
+      ) => void,
     ): Scope
     reply(
       replyFn: (
         this: ReplyFnContext,
         uri: string,
-        body: Body
-      ) => ReplyFnResult | Promise<ReplyFnResult>
+        body: Body,
+      ) => ReplyFnResult | Promise<ReplyFnResult>,
     ): Scope
     reply(
       statusCode: StatusCode,
@@ -168,18 +168,21 @@ declare namespace nock {
         this: ReplyFnContext,
         uri: string,
         body: Body,
-        callback: (err: NodeJS.ErrnoException | null, result: ReplyBody) => void
+        callback: (
+          err: NodeJS.ErrnoException | null,
+          result: ReplyBody,
+        ) => void,
       ) => void,
-      headers?: ReplyHeaders
+      headers?: ReplyHeaders,
     ): Scope
     reply(
       statusCode: StatusCode,
       replyBodyFn: (
         this: ReplyFnContext,
         uri: string,
-        body: Body
+        body: Body,
       ) => ReplyBody | Promise<ReplyBody>,
-      headers?: ReplyHeaders
+      headers?: ReplyHeaders,
     ): Scope
     reply(responseCode?: StatusCode, body?: Body, headers?: ReplyHeaders): Scope
     /* tslint:enable:unified-signatures */
@@ -188,7 +191,7 @@ declare namespace nock {
     replyWithFile(
       statusCode: StatusCode,
       fileName: string,
-      headers?: ReplyHeaders
+      headers?: ReplyHeaders,
     ): Scope
 
     matchHeader(name: string, value: RequestHeaderMatcher): this
@@ -251,9 +254,12 @@ declare namespace nock {
     (
       fixtureName: string,
       options: BackOptions,
-      nockedFn: (nockDone: () => void) => void
+      nockedFn: (nockDone: () => void) => void,
     ): void
-    (fixtureName: string, options?: BackOptions): Promise<{
+    (
+      fixtureName: string,
+      options?: BackOptions,
+    ): Promise<{
       nockDone: () => void
       context: BackContext
     }>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,7 +8,7 @@ import { Url, URLSearchParams } from 'url'
 export = nock
 
 declare function nock(
-  basePath: string | RegExp | Url,
+  basePath: string | RegExp | Url | URL,
   options?: nock.Options
 ): nock.Scope
 

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -160,10 +160,9 @@ nock('http://example.test').get('/users/1').reply(200, {
 })
 
 // Using URL as input
-// Not supported yet
-// scope = nock(new URL('https://example.test/'))
-//   .get('/resource')
-//   .reply(200, 'url matched')
+scope = nock(new URL('https://example.test/'))
+  .get('/resource')
+  .reply(200, 'url matched')
 
 // specifying URL from url.parse output
 scope = nock(url.parse('https://example.test/'))

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -285,7 +285,7 @@ nock('http://example.test')
     new URLSearchParams([
       ['foo', 'one'],
       ['foo', 'two'],
-    ])
+    ]),
   )
   .reply()
 


### PR DESCRIPTION
Supported since 13.3.0 (#2437).