### PR TITLE
test: improve node16 check in test

### DIFF
--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -476,11 +476,10 @@ it('`percentEncode()` encodes extra reserved characters', () => {
 describe('`normalizeClientRequestArgs()`', () => {
   it('should throw for invalid URL', () => {
     // See https://github.com/nodejs/node/pull/38614 release in node v16.2.0
-    const [major, minor, patch] = process.versions.node.split('.').map(parseInt)
+    const [major, minor] = process.versions.node.split('.').map(Number)
     const useNewErrorText =
       major > 16 ||
-      (major === 16 && minor > 2) ||
-      (major === 16 && minor === 2 && patch > 0)
+      (major === 16 && minor > 1)
     const errorText = useNewErrorText ? 'Invalid URL' : 'example.test'
 
     // no schema

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -477,9 +477,7 @@ describe('`normalizeClientRequestArgs()`', () => {
   it('should throw for invalid URL', () => {
     // See https://github.com/nodejs/node/pull/38614 release in node v16.2.0
     const [major, minor] = process.versions.node.split('.').map(Number)
-    const useNewErrorText =
-      major > 16 ||
-      (major === 16 && minor > 1)
+    const useNewErrorText = major > 16 || (major === 16 && minor > 1)
     const errorText = useNewErrorText ? 'Invalid URL' : 'example.test'
 
     // no schema


### PR DESCRIPTION
I checked it now properly.

For some reason parseInt transformed the minor and patch to NaN.

There is no node 16.2.1, so we dont need to check the patch version. 

16.2.0 was still using the old error text. 16.3.0 was using the new error text.