### PR TITLE
fix(typescript): `filteringBodyRequest`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -118,7 +118,9 @@ declare namespace nock {
     filteringPath(regex: RegExp, replace: string): this
     filteringPath(fn: (path: string) => string): this
     filteringRequestBody(regex: RegExp, replace: string): this
-    filteringRequestBody(fn: (body: string) => string): this
+    filteringRequestBody(
+      fn: (body: string, recordedBody: string) => string,
+    ): this
 
     persist(flag?: boolean): this
     replyContentLength(): this


### PR DESCRIPTION
The ambient type in `index.d.ts` does not match the actual call signature of the [filteringRequestBody](https://github.com/nock/nock/blob/main/lib/interceptor.js#L363)

This fixes it.

