### PR TITLE
feat: add `context.query()` to nock back

### DIFF
--- a/lib/back.js
+++ b/lib/back.js
@@ -240,6 +240,23 @@ function load(fixture, options) {
     assertScopesFinished: function () {
       assertScopes(this.scopes, fixture)
     },
+    query: function () {
+      const nested = this.scopes.map(scope =>
+        scope.interceptors.map(interceptor => ({
+          method: interceptor.method,
+          uri: interceptor.uri,
+          basePath: interceptor.basePath,
+          path: interceptor.path,
+          queries: interceptor.queries,
+          counter: interceptor.counter,
+          body: interceptor.body,
+          statusCode: interceptor.statusCode,
+          optional: interceptor.optional,
+        })),
+      )
+
+      return [].concat.apply([], nested)
+    },
   }
 
   if (fixture && fixtureExists(fixture)) {

--- a/tests/test_back.js
+++ b/tests/test_back.js
@@ -147,6 +147,24 @@ describe('Nock Back', () => {
     })
   })
 
+  it('`query` returns all of the interceptors recorded to the cassette', done => {
+    nockBack('good_request.json').then(({ nockDone, context }) => {
+      const interceptor = context.query()
+      nockDone()
+      expect(interceptor.length).to.equal(1)
+      expect(interceptor[0].method).to.equal('GET')
+      expect(interceptor[0].uri).to.equal('/')
+      expect(interceptor[0].basePath).to.equal('http://www.example.test:80')
+      expect(interceptor[0].path).to.equal('/')
+      expect(interceptor[0].queries).to.be.null()
+      expect(interceptor[0].counter).to.equal(1)
+      expect(interceptor[0]).to.have.property('body')
+      expect(interceptor[0].statusCode).to.equal(200)
+      expect(interceptor[0].optional).to.equal(false)
+      done()
+    })
+  })
+
   describe('wild mode', () => {
     beforeEach(() => {
       nockBack.setMode('wild')

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -267,10 +267,23 @@ declare namespace nock {
     }>
   }
 
+  interface InterceptorSurface {
+    method: string
+    uri: string
+    basePath: string
+    path: string
+    queries?: string
+    counter: number
+    body: string
+    statusCode: number
+    optional: boolean
+  }
+
   interface BackContext {
     isLoaded: boolean
     scopes: Scope[]
     assertScopesFinished(): void
+    query: InterceptorSurface[]
   }
 
   interface BackOptions {


### PR DESCRIPTION
When TDDing using Nock Back you're kind of in a Chicken-and-Egg situation.  You want to be able to verify the external calls you need to make - but you don't know the exact nature of those external calls.   This lets you list the interceptors created in a given fixture to make sure all the ones that you expect are there.

By itself, this functions as a negative expectation - like I can verify that certain calls do NOT happen in the fixture.  When paired with `assertScopesFinished` this can be used to verify the complete set of calls in the fixture.  For instance I have a fairly complex HTTP interactor that synchronizes a local data store with a remote one.  I know how many calls this takes - and I know that if the scopes in the fixture complete then my interaction worked.

But if I need to re-record my interaction, I need to go over to the fixture and check it manually.  This lets me make assertions about what is _in_ the fixture - so that I can re-record them and verify that they still do what I expect.

Example Code Simplified and Anonymized to the Point Of Inaccuracy:

```typescript
it('#synchronize - synchronize with the external API', async (localState) => {
  const { nockDone, context } = await back('http-interaction.json')
  
  const syncronizer = new Synchronizer(localState); 
  
  sycnronizer.syncronize();
  
  nockDone();
  
  context.assertScopesFinished();
  
  expect(context.query()).toEqual(
    expect.arrayContaining([
       expect.objectContaining({
           method: "POST",
           path: "/create/thing"
       }),
       expect.objectContaining({
          method: "POST",
          path: "create/thing"
      })
    ])
  );
})

```