### PR TITLE
feat(nockBack): `substitutions` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,7 +686,7 @@ To repeat this response for as long as nock is active, use [.persist()](#persist
 
 ### Delay the response
 
-Nock can simulate response latency to allow you to test timeouts, race conditions, an other timing related scenarios.  
+Nock can simulate response latency to allow you to test timeouts, race conditions, an other timing related scenarios.
 You are able to specify the number of milliseconds that your reply should be delayed.
 
 ```js
@@ -696,8 +696,8 @@ nock('http://my.server.com')
   .reply(200, '<html></html>')
 ```
 
-`delay(1000)` is an alias for `delayConnection(1000).delayBody(0)`  
-`delay({ head: 1000, body: 2000 })` is an alias for `delayConnection(1000).delayBody(2000)`  
+`delay(1000)` is an alias for `delayConnection(1000).delayBody(0)`
+`delay({ head: 1000, body: 2000 })` is an alias for `delayConnection(1000).delayBody(2000)`
 Both of which are covered in detail below.
 
 #### Delay the connection
@@ -715,7 +715,7 @@ nock('http://my.server.com')
 req = http.request('http://my.server.com', { timeout: 1000 })
 ```
 
-Nock emits timeout events almost immediately by comparing the requested connection delay to the timeout parameter passed to `http.request()` or `http.ClientRequest#setTimeout()`.  
+Nock emits timeout events almost immediately by comparing the requested connection delay to the timeout parameter passed to `http.request()` or `http.ClientRequest#setTimeout()`.
 This allows you to test timeouts without using fake timers or slowing down your tests.
 If the client chooses to _not_ take an action (e.g. abort the request), the request and response will continue on as normal, after real clock time has passed.
 
@@ -725,12 +725,12 @@ Following the `'finish'` event being emitted by `ClientRequest`, Nock will wait 
 At this point, any connection delay value is compared against any request timeout setting and a [`'timeout'`](https://nodejs.org/api/http.html#http_event_timeout) is emitted when appropriate from the socket and the request objects.
 A Node timeout timer is then registered with any connection delay value to delay real time before checking again if the request has been aborted and the [`'response'`](http://nodejs.org/api/http.html#http_event_response) is emitted by the request.
 
-A similar method, `.socketDelay()` was removed in version 13. It was thought that having two methods so subtlety similar was confusing.  
+A similar method, `.socketDelay()` was removed in version 13. It was thought that having two methods so subtlety similar was confusing.
 The discussion can be found at https://github.com/nock/nock/pull/1974.
 
 #### Delay the response body
 
-You are able to specify the number of milliseconds that the response body should be delayed.  
+You are able to specify the number of milliseconds that the response body should be delayed.
 This is the time between the headers being received and the body starting to be received.
 
 ```js
@@ -1514,6 +1514,18 @@ To set the mode call `nockBack.setMode(mode)` or run the tests with the `NOCK_BA
 
 - lockdown: use recorded nocks, disables all http calls even when not nocked, doesn't record
 
+### Hiding Secrets from NockBack
+
+Nockback will happily record secrets that appear in URL parameters or HTTP request bodies. To prevent this you can use simple substitution to dynamically replace these values whenever the fixture is written or read from disk. To do this, use the `substitutions` options on Nock.
+
+```js
+context { nockDone } = nockBack('exampleFixture.json', { substitutions: { A_SECRET: "the-value-of-your-secret" }})
+```
+
+In the recorded cassette where ever `the-value-of-your-secret` would appear `{{ A_SECRET }}` will appear instead.
+
+This feature should only be used for strings that are unlikely to occur naturally - as this works with simple string substitution.
+
 ### Verifying recorded fixtures
 
 Although you can certainly open the recorded JSON fixtures to manually verify requests recorded by nockBack - it's sometimes useful to put those expectations in your tests.
@@ -1634,7 +1646,7 @@ const config = {
 
 ### Memory issues with Jest
 
-Memory issues can be avoided by calling [`nock.restore()`](#restoring) after each test suite.  
+Memory issues can be avoided by calling [`nock.restore()`](#restoring) after each test suite.
 One of the core principles of [Jest](https://jestjs.io/) is that it runs tests in isolation.
 It does this by manipulating the modules cache of Node in a way that conflicts with how Nock monkey patches the builtin `http` and `https` modules.
 [Related issue with more details](https://github.com/nock/nock/issues/1817).

--- a/lib/back.js
+++ b/lib/back.js
@@ -170,6 +170,7 @@ const record = {
       if (options.substitutions) {
         Object.entries(options.substitutions).forEach(pair => {
           const [key, value] = pair
+          debug(`substituting ${value} with ${key}`)
           outputs = outputs.replace(new RegExp(value, 'g'), `{{ ${key} }}`)
         })
       }
@@ -216,6 +217,15 @@ const update = {
 
     outputs =
       typeof outputs === 'string' ? outputs : JSON.stringify(outputs, null, 4)
+
+    if (options.substitutions) {
+      Object.entries(options.substitutions).forEach(pair => {
+        const [key, value] = pair
+        debug(`substituting ${value} with ${key}`)
+        outputs = outputs.replace(new RegExp(value, 'g'), `{{ ${key} }}`)
+      })
+    }
+
     debug('recorder outputs:', outputs)
 
     fs.mkdirSync(path.dirname(fixture), { recursive: true })

--- a/lib/back.js
+++ b/lib/back.js
@@ -26,21 +26,22 @@ try {
 /**
  * nock the current function with the fixture given
  *
- * @param {string}   fixtureName  - the name of the fixture, e.x. 'foo.json'
- * @param {object}   options      - [optional] extra options for nock with, e.x. `{ assert: true }`
- * @param {function} nockedFn     - [optional] callback function to be executed with the given fixture being loaded;
- *                                  if defined the function will be called with context `{ scopes: loaded_nocks || [] }`
- *                                  set as `this` and `nockDone` callback function as first and only parameter;
- *                                  if not defined a promise resolving to `{nockDone, context}` where `context` is
- *                                  aforementioned `{ scopes: loaded_nocks || [] }`
+ * @param {string}   fixtureName   - the name of the fixture, e.x. 'foo.json'
+ * @param {object}   options       - [optional] extra options for nock with, e.x. `{ assert: true }`
+ * @param {function} nockedFn      - [optional] callback function to be executed with the given fixture being loaded;
+ *                                   if defined the function will be called with context `{ scopes: loaded_nocks || [] }`
+ *                                   set as `this` and `nockDone` callback function as first and only parameter;
+ *                                   if not defined a promise resolving to `{nockDone, context}` where `context` is
+ *                                   aforementioned `{ scopes: loaded_nocks || [] }`
  *
  * List of options:
  *
- * @param {function} before       - a preprocessing function, gets called before nock.define
- * @param {function} after        - a postprocessing function, gets called after nock.define
- * @param {function} afterRecord  - a postprocessing function, gets called after recording. Is passed the array
- *                                  of scopes recorded and should return the array scopes to save to the fixture
- * @param {function} recorder     - custom options to pass to the recorder
+ * @param {object}   substitutions - a list of key/value pairs to use as substitutions in a templated fixture
+ * @param {function} before        - a preprocessing function, gets called before nock.define
+ * @param {function} after         - a postprocessing function, gets called after nock.define
+ * @param {function} afterRecord   - a postprocessing function, gets called after recording. Is passed the array
+ *                                   of scopes recorded and should return the array scopes to save to the fixture
+ * @param {function} recorder      - custom options to pass to the recorder
  *
  */
 function Back(fixtureName, options, nockedFn) {
@@ -165,6 +166,14 @@ const record = {
 
       outputs =
         typeof outputs === 'string' ? outputs : JSON.stringify(outputs, null, 4)
+
+      if (options.substitutions) {
+        Object.entries(options.substitutions).forEach(pair => {
+          const [key, value] = pair
+          outputs = outputs.replace(new RegExp(value, 'g'), `{{ ${key} }}`)
+        })
+      }
+
       debug('recorder outputs:', outputs)
 
       fs.mkdirSync(path.dirname(fixture), { recursive: true })
@@ -258,7 +267,7 @@ function load(fixture, options) {
   }
 
   if (fixture && fixtureExists(fixture)) {
-    let scopes = loadDefs(fixture)
+    let scopes = loadDefs(fixture, options.substitutions)
     applyHook(scopes, options.before)
 
     scopes = define(scopes)

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -10,6 +10,7 @@ const assert = require('assert')
 const url = require('url')
 const { EventEmitter } = require('events')
 const Interceptor = require('./interceptor')
+const Mustache = require('mustache')
 
 const { URL, Url: LegacyUrl } = url
 let fs
@@ -292,17 +293,18 @@ class Scope extends EventEmitter {
   }
 }
 
-function loadDefs(path) {
+function loadDefs(path, view = {}) {
   if (!fs) {
     throw new Error('No fs')
   }
 
   const contents = fs.readFileSync(path)
-  return JSON.parse(contents)
+  const rendered = Mustache.render(contents.toString(), view)
+  return JSON.parse(rendered)
 }
 
-function load(path) {
-  return define(loadDefs(path))
+function load(path, view = {}) {
+  return define(loadDefs(path, view))
 }
 
 function getStatusFromDefinition(nockDef) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@mswjs/interceptors": "^0.34.3",
         "json-stringify-safe": "^5.0.1",
+        "mustache": "^4.2.0",
         "propagate": "^2.0.0"
       },
       "devDependencies": {
@@ -8840,6 +8841,14 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.1",
@@ -21754,6 +21763,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="
     },
     "nanoid": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@mswjs/interceptors": "^0.34.3",
     "json-stringify-safe": "^5.0.1",
+    "mustache": "^4.2.0",
     "propagate": "^2.0.0"
   },
   "devDependencies": {

--- a/tests/fixtures/test-template-substitution-fixture.json
+++ b/tests/fixtures/test-template-substitution-fixture.json
@@ -1,0 +1,21 @@
+[
+  {
+    "scope": "http://example.test:80",
+    "method": "GET",
+    "path": "/?secret={{ SECRET }}",
+    "body": "",
+    "status": 217,
+    "response": "server served a response",
+    "rawHeaders": [
+      "Date",
+      "Fri, 17 Nov 2023 03:19:12 GMT",
+      "Connection",
+      "keep-alive",
+      "Keep-Alive",
+      "timeout=5",
+      "Transfer-Encoding",
+      "chunked"
+    ],
+    "responseIsBinary": false
+  }
+]

--- a/tests/test_back.js
+++ b/tests/test_back.js
@@ -115,6 +115,26 @@ describe('Nock Back', () => {
     })
   })
 
+  it('should allow template substitutions in recorded fixtures', done => {
+    const mySecretApiKey = 'blah-blah'
+
+    nockBack(
+      'test-template-substitution-fixture.json',
+      {
+        substitutions: { SECRET: mySecretApiKey },
+        after: scope => {
+          expect(scope.interceptors[0].uri).to.eql('/?secret=blah-blah')
+        },
+      },
+      function (nockDone) {
+        http.get('http://example.test/?secret=blah-blah', () => {
+          nockDone()
+          done()
+        })
+      },
+    )
+  })
+
   it('should throw an exception when a hook is not a function', () => {
     expect(() =>
       nockBack('good_request.json', { before: 'not-a-function-innit' }),
@@ -289,7 +309,6 @@ describe('Nock Back', () => {
             },
             response => {
               nockDone()
-
               expect(response.statusCode).to.equal(217)
               expect(fs.existsSync(fixtureLoc)).to.be.true()
               done()
@@ -300,6 +319,44 @@ describe('Nock Back', () => {
           request.end()
         })
       })
+    })
+
+    it('should record template keys into fixtures rather than secrets', done => {
+      expect(fs.existsSync(fixtureLoc)).to.be.false()
+
+      const mySecretApiKey = 'sooper-secret'
+
+      nockBack(
+        fixture,
+        {
+          substitutions: { SECRET: mySecretApiKey },
+        },
+        function (nockDone) {
+          startHttpServer(requestListener).then(server => {
+            const request = http.request(
+              {
+                host: 'localhost',
+                path: '/?secret=sooper-secret',
+                port: server.address().port,
+              },
+              response => {
+                response.once('end', () => {
+                  nockDone()
+                  const fixtureContent = fs.readFileSync(fixtureLoc, 'utf8')
+                  expect(response.statusCode).to.equal(217)
+                  expect(fixtureContent).to.contain('{{ SECRET }}')
+                  done()
+                })
+
+                response.resume()
+              },
+            )
+
+            request.on('error', () => expect.fail())
+            request.end()
+          })
+        },
+      )
     })
 
     it('should record the expected data', done => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -287,6 +287,7 @@ declare namespace nock {
   }
 
   interface BackOptions {
+    substitutions?: { [key: string]: string }
     before?: (def: Definition) => void
     after?: (scope: Scope) => void
     afterRecord?: (defs: Definition[]) => Definition[]


### PR DESCRIPTION
VCR has a feature called [Filter Sensitive Data](https://benoittgt.github.io/vcr/#/configuration/filter_sensitive_data) - which is super handy if you're recording HTTP interactions, since data like API keys, passwords etc can show up in the fixtures, particularly if that data is passed via something other than a Request Header.

This implements a similar feature in Nock Back - the only place where it's really a problem.

Requested in #2230