### PR TITLE
feat: add `Scope#clone()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1066,6 +1066,17 @@ if (!nock.isActive()) {
 }
 ```
 
+### .clone()
+
+You can clone a scope by calling `.clone()` on it:
+
+```js
+const scope = nock('http://example.test')
+
+const getScope = scope.get('/').reply(200)
+const postScope = scope.clone().post('/').reply(200)
+```
+
 ## Restoring
 
 You can restore the HTTP interceptor to the normal unmocked behaviour by calling:

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -286,6 +286,10 @@ class Scope extends EventEmitter {
     this.date = d || new Date()
     return this
   }
+
+  clone() {
+    return new Scope(this.basePath, this.scopeOptions)
+  }
 }
 
 function loadDefs(path) {

--- a/tests/got/test_scope.js
+++ b/tests/got/test_scope.js
@@ -217,4 +217,27 @@ describe('filteringRequestBody()', () => {
       'Invalid arguments: filtering request body should be a function or a regular expression',
     )
   })
+
+  describe('`Scope#clone()`', async () => {
+    it('creates a new Scope with the same basePath and scope options', () => {
+      const scope = nock('http://example.test', { encodedQueryParams: true })
+      const clonedScope = scope.clone()
+
+      expect(clonedScope.basePath).to.equal(scope.basePath)
+      expect(clonedScope.scopeOptions).to.deep.equal(scope.scopeOptions)
+    })
+
+    it('creates a new Scope that works independently', async () => {
+      const scope = nock('http://example.test')
+
+      const getScope = scope.get('/').reply(200)
+      const postScope = scope.clone().post('/').reply(200)
+
+      await got('http://example.test/')
+      expect(getScope.isDone()).to.be.true()
+
+      await got.post('http://example.test/')
+      expect(postScope.isDone()).to.be.true()
+    })
+  })
 })


### PR DESCRIPTION
add `Scope#clone()` method to create a new Scope with the same basePath and scope options