### PR TITLE
feat: native fetch mocking

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -72,6 +72,7 @@ jobs:
         node-version:
           - 18
           - 20
+          - 21
         os:
           - macos-latest
           - ubuntu-latest

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           cache: 'npm'
       - name: Install dependencies
         run: npm ci --ignore-scripts --no-audit --no-progress --prefer-offline
@@ -87,11 +87,8 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 10
-          - 12
-          - 14
-          - 16
           - 18
+          - 20
         os:
           - macos-latest
           - ubuntu-latest

--- a/lib/common.js
+++ b/lib/common.js
@@ -736,10 +736,10 @@ const expand = input => {
 }
 
 /**
- * @param {Request} request 
+ * @param {Request} request
  */
 function convertFetchRequestToOptions(request) {
-  const url = new URL(request.url);
+  const url = new URL(request.url)
   const options = {
     ...urlToOptions(url),
     method: request.method,
@@ -747,8 +747,8 @@ function convertFetchRequestToOptions(request) {
     port: url.port || (url.protocol === 'https:' ? 443 : 80),
     path: url.pathname + url.search,
     proto: url.protocol.slice(0, -1),
-    headers: Object.fromEntries(request.headers.entries())
-  };
+    headers: Object.fromEntries(request.headers.entries()),
+  }
 
   // By default, Node adds a host header, but for maximum backward compatibility, we are now removing it.
   // However, we need to consider leaving the header and fixing the tests.
@@ -757,7 +757,7 @@ function convertFetchRequestToOptions(request) {
     options.headers = restHeaders
   }
 
-  return options;
+  return options
 }
 
 module.exports = {

--- a/lib/common.js
+++ b/lib/common.js
@@ -735,6 +735,31 @@ const expand = input => {
   return result
 }
 
+/**
+ * @param {Request} request 
+ */
+function convertFetchRequestToOptions(request) {
+  const url = new URL(request.url);
+  const options = {
+    ...urlToOptions(url),
+    method: request.method,
+    host: url.hostname,
+    port: url.port || (url.protocol === 'https:' ? 443 : 80),
+    path: url.pathname + url.search,
+    proto: url.protocol.slice(0, -1),
+    headers: Object.fromEntries(request.headers.entries())
+  };
+
+  // By default, Node adds a host header, but for maximum backward compatibility, we are now removing it.
+  // However, we need to consider leaving the header and fixing the tests.
+  if (options.headers.host === options.host) {
+    const { host, ...restHeaders } = options.headers
+    options.headers = restHeaders
+  }
+
+  return options;
+}
+
 module.exports = {
   contentEncoding,
   dataEqual,
@@ -765,4 +790,5 @@ module.exports = {
   setInterval,
   setTimeout,
   stringifyRequest,
+  convertFetchRequestToClientRequest: convertFetchRequestToOptions,
 }

--- a/lib/common.js
+++ b/lib/common.js
@@ -750,13 +750,6 @@ function convertFetchRequestToOptions(request) {
     headers: Object.fromEntries(request.headers.entries()),
   }
 
-  // By default, Node adds a host header, but for maximum backward compatibility, we are now removing it.
-  // However, we need to consider leaving the header and fixing the tests.
-  if (options.headers.host === options.host) {
-    const { host, ...restHeaders } = options.headers
-    options.headers = restHeaders
-  }
-
   return options
 }
 

--- a/lib/create_response.js
+++ b/lib/create_response.js
@@ -1,0 +1,44 @@
+const { headersArrayToObject } = require('./common')
+
+/**
+ * Creates a Fetch API `Response` instance from the given
+ * `http.IncomingMessage` instance.
+ * Inspired by: https://github.com/mswjs/interceptors/blob/04152ed914f8041272b6e92ed374216b8177e1b2/src/interceptors/ClientRequest/utils/createResponse.ts#L8
+ * TODO: maybe MSW can export this? so no duplicate code
+ */
+
+/**
+ * Response status codes for responses that cannot have body.
+ * @see https://fetch.spec.whatwg.org/#statuses
+ */
+const responseStatusCodesWithoutBody = [204, 205, 304]
+
+/**
+ * @param {IncomingMessage} message 
+ */
+function createResponse(message) {
+  const responseBodyOrNull = responseStatusCodesWithoutBody.includes(
+    message.statusCode || 200
+  )
+    ? null
+    : new ReadableStream({
+      start(controller) {
+        message.on('data', (chunk) => controller.enqueue(chunk))
+        message.on('end', () => controller.close())
+
+        /**
+         * @todo Should also listen to the "error" on the message
+         * and forward it to the controller. Otherwise the stream
+         * will pend indefinitely.
+         */
+      },
+    })
+
+  return new Response(responseBodyOrNull, {
+    status: message.statusCode,
+    statusText: message.statusMessage,
+    headers: headersArrayToObject(message.rawHeaders),
+  })
+}
+
+module.exports = { createResponse }

--- a/lib/create_response.js
+++ b/lib/create_response.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { headersArrayToObject } = require('./common')
 
 /**
@@ -13,25 +15,25 @@ const { headersArrayToObject } = require('./common')
 const responseStatusCodesWithoutBody = [204, 205, 304]
 
 /**
- * @param {IncomingMessage} message 
+ * @param {IncomingMessage} message
  */
 function createResponse(message) {
   const responseBodyOrNull = responseStatusCodesWithoutBody.includes(
-    message.statusCode || 200
+    message.statusCode || 200,
   )
     ? null
     : new ReadableStream({
-      start(controller) {
-        message.on('data', (chunk) => controller.enqueue(chunk))
-        message.on('end', () => controller.close())
+        start(controller) {
+          message.on('data', chunk => controller.enqueue(chunk))
+          message.on('end', () => controller.close())
 
-        /**
-         * @todo Should also listen to the "error" on the message
-         * and forward it to the controller. Otherwise the stream
-         * will pend indefinitely.
-         */
-      },
-    })
+          /**
+           * @todo Should also listen to the "error" on the message
+           * and forward it to the controller. Otherwise the stream
+           * will pend indefinitely.
+           */
+        },
+      })
 
   return new Response(responseBodyOrNull, {
     status: message.statusCode,

--- a/lib/create_response.js
+++ b/lib/create_response.js
@@ -19,7 +19,7 @@ const responseStatusCodesWithoutBody = [204, 205, 304]
  */
 function createResponse(message) {
   const responseBodyOrNull = responseStatusCodesWithoutBody.includes(
-    message.statusCode || 200,
+    message.statusCode,
   )
     ? null
     : new ReadableStream({

--- a/lib/create_response.js
+++ b/lib/create_response.js
@@ -4,7 +4,6 @@ const { headersArrayToObject } = require('./common')
  * Creates a Fetch API `Response` instance from the given
  * `http.IncomingMessage` instance.
  * Inspired by: https://github.com/mswjs/interceptors/blob/04152ed914f8041272b6e92ed374216b8177e1b2/src/interceptors/ClientRequest/utils/createResponse.ts#L8
- * TODO: maybe MSW can export this? so no duplicate code
  */
 
 /**

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -437,27 +437,25 @@ function activate() {
     }
   })
 
-  if (global.fetch) {
-    const originalFetch = global.fetch
-    global.fetch = async (input, init = undefined) => {
-      const request = new Request(input, init)
-      const options = common.convertFetchRequestToClientRequest(request)
-      options.isFetchRequest = true
-      const body = await request.arrayBuffer()
-      const clientRequest = new http.ClientRequest(options)
+  const originalFetch = global.fetch
+  global.fetch = async (input, init = undefined) => {
+    const request = new Request(input, init)
+    const options = common.convertFetchRequestToClientRequest(request)
+    options.isFetchRequest = true
+    const body = await request.arrayBuffer()
+    const clientRequest = new http.ClientRequest(options)
 
-      // If mock found
-      if (clientRequest.interceptors) {
-        return new Promise((resolve, reject) => {
-          clientRequest.on('response', response => {
-            resolve(createResponse(response))
-          })
-          clientRequest.on('error', reject)
-          clientRequest.end(body)
+    // If mock found
+    if (clientRequest.interceptors) {
+      return new Promise((resolve, reject) => {
+        clientRequest.on('response', response => {
+          resolve(createResponse(response))
         })
-      } else {
-        return originalFetch(input, init)
-      }
+        clientRequest.on('error', reject)
+        clientRequest.end(body)
+      })
+    } else {
+      return originalFetch(input, init)
     }
   }
 

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -303,7 +303,9 @@ function overrideClientRequest() {
 
       //  Fallback to original ClientRequest if nock is off or the net connection is enabled.
       if (isOff() || isEnabledForNetConnect(options)) {
-        originalClientRequest.apply(this, arguments)
+        if (options.isFetchRequest === undefined) {
+          originalClientRequest.apply(this, arguments)
+        }
       } else {
         common.setImmediate(
           function () {
@@ -435,13 +437,12 @@ function activate() {
     }
   })
 
-  overrideClientRequest()
-
   if (global.fetch) {
     const originalFetch = global.fetch
     global.fetch = async (input, init = undefined) => {
       const request = new Request(input, init)
       const options = common.convertFetchRequestToClientRequest(request)
+      options.isFetchRequest = true
       const body = await request.arrayBuffer()
       const clientRequest = new http.ClientRequest(options)
 
@@ -459,6 +460,8 @@ function activate() {
       }
     }
   }
+
+  overrideClientRequest()
 }
 
 module.exports = {

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -10,6 +10,7 @@ const { inherits } = require('util')
 const http = require('http')
 const debug = require('debug')('nock.intercept')
 const globalEmitter = require('./global_emitter')
+const { createResponse } = require('./create_response')
 
 /**
  * @name NetConnectNotAllowedError
@@ -435,6 +436,29 @@ function activate() {
   })
 
   overrideClientRequest()
+
+  if (global.fetch) {
+    const originalFetch = global.fetch
+    global.fetch = async (input, init = undefined) => {
+      const request = new Request(input, init)
+      const options = common.convertFetchRequestToClientRequest(request)
+      const body = await request.arrayBuffer()
+      const clientRequest = new http.ClientRequest(options)
+
+      // If mock found
+      if (clientRequest.interceptors) {
+        return new Promise((resolve, reject) => {
+          clientRequest.on('response', response => {
+            resolve(createResponse(response))
+          })
+          clientRequest.on('error', reject)
+          clientRequest.end(body)
+        })
+      } else {
+        return originalFetch(input, init)
+      }
+    }
+  }
 }
 
 module.exports = {

--- a/tests/test_fetch.js
+++ b/tests/test_fetch.js
@@ -1,0 +1,74 @@
+'use strict'
+
+const { expect } = require('chai')
+const nock = require('..')
+const assertRejects = require('assert-rejects')
+const { startHttpServer } = require('./servers')
+
+describe('Native Fetch', () => {
+  it('input is string', async () => {
+    const scope = nock('http://example.test').get('/').reply()
+
+    const { status } = await fetch('http://example.test/')
+    expect(status).to.equal(200)
+    scope.done()
+  })
+
+  it('input is URL', async () => {
+    const scope = nock('http://example.test').get('/').reply()
+
+    const { status } = await fetch(new URL('http://example.test/'))
+    expect(status).to.equal(200)
+    scope.done()
+  })
+
+  it('input is Request object', async () => {
+    const scope = nock('http://example.test').get('/').reply()
+
+    const { status } = await fetch(new Request('http://example.test/'))
+    expect(status).to.equal(200)
+    scope.done()
+  })
+
+
+  it('filter by body', async () => {
+    const scope = nock('http://example.test').post('/', { test: 'fetch' }).reply()
+
+    const { status } = await fetch('http://example.test/', {
+      method: 'POST',
+      body: JSON.stringify({ test: 'fetch' })
+    })
+    expect(status).to.equal(200)
+    scope.done()
+  })
+
+  it('filter by request body', async () => {
+    const scope = nock('http://example.test').post('/', { test: 'fetch' }).reply()
+
+    const { status } = await fetch(new Request('http://example.test/', {
+      method: 'POST',
+      body: JSON.stringify({ test: 'fetch' }),
+    }))
+    expect(status).to.equal(200)
+    scope.done()
+  })
+
+  it('no match', async () => {
+    nock('http://example.test').get('/').reply()
+
+    await assertRejects(
+      fetch('http://example.test/wrong-path'),
+      /Nock: No match for request/,
+    )
+  });
+
+  it('forward request if no mock', async () => {
+    const { origin } = await startHttpServer((request, response) => {
+      response.write('live')
+      response.end()
+    })
+
+    const { status } = await fetch(origin)
+    expect(status).to.equal(200)
+  });
+})

--- a/tests/test_fetch.js
+++ b/tests/test_fetch.js
@@ -77,5 +77,19 @@ if (global.fetch) {
       const { status } = await fetch(origin)
       expect(status).to.equal(200)
     })
+
+    it('should work with empty response', async () => {
+      nock('http://example.test').get('/').reply(204)
+
+      const { status } = await fetch('http://example.test')
+      expect(status).to.equal(204)
+    })
+
+    it('should work https', async () => {
+      nock('https://example.test').get('/').reply()
+
+      const { status } = await fetch('https://example.test')
+      expect(status).to.equal(200)
+    })
   })
 }

--- a/tests/test_fetch.js
+++ b/tests/test_fetch.js
@@ -5,70 +5,77 @@ const nock = require('..')
 const assertRejects = require('assert-rejects')
 const { startHttpServer } = require('./servers')
 
-describe('Native Fetch', () => {
-  it('input is string', async () => {
-    const scope = nock('http://example.test').get('/').reply()
+if (global.fetch) {
+  describe('Native Fetch', () => {
+    it('input is string', async () => {
+      const scope = nock('http://example.test').get('/').reply()
 
-    const { status } = await fetch('http://example.test/')
-    expect(status).to.equal(200)
-    scope.done()
-  })
-
-  it('input is URL', async () => {
-    const scope = nock('http://example.test').get('/').reply()
-
-    const { status } = await fetch(new URL('http://example.test/'))
-    expect(status).to.equal(200)
-    scope.done()
-  })
-
-  it('input is Request object', async () => {
-    const scope = nock('http://example.test').get('/').reply()
-
-    const { status } = await fetch(new Request('http://example.test/'))
-    expect(status).to.equal(200)
-    scope.done()
-  })
-
-
-  it('filter by body', async () => {
-    const scope = nock('http://example.test').post('/', { test: 'fetch' }).reply()
-
-    const { status } = await fetch('http://example.test/', {
-      method: 'POST',
-      body: JSON.stringify({ test: 'fetch' })
-    })
-    expect(status).to.equal(200)
-    scope.done()
-  })
-
-  it('filter by request body', async () => {
-    const scope = nock('http://example.test').post('/', { test: 'fetch' }).reply()
-
-    const { status } = await fetch(new Request('http://example.test/', {
-      method: 'POST',
-      body: JSON.stringify({ test: 'fetch' }),
-    }))
-    expect(status).to.equal(200)
-    scope.done()
-  })
-
-  it('no match', async () => {
-    nock('http://example.test').get('/').reply()
-
-    await assertRejects(
-      fetch('http://example.test/wrong-path'),
-      /Nock: No match for request/,
-    )
-  });
-
-  it('forward request if no mock', async () => {
-    const { origin } = await startHttpServer((request, response) => {
-      response.write('live')
-      response.end()
+      const { status } = await fetch('http://example.test/')
+      expect(status).to.equal(200)
+      scope.done()
     })
 
-    const { status } = await fetch(origin)
-    expect(status).to.equal(200)
-  });
-})
+    it('input is URL', async () => {
+      const scope = nock('http://example.test').get('/').reply()
+
+      const { status } = await fetch(new URL('http://example.test/'))
+      expect(status).to.equal(200)
+      scope.done()
+    })
+
+    it('input is Request object', async () => {
+      const scope = nock('http://example.test').get('/').reply()
+
+      const { status } = await fetch(new Request('http://example.test/'))
+      expect(status).to.equal(200)
+      scope.done()
+    })
+
+    it('filter by body', async () => {
+      const scope = nock('http://example.test')
+        .post('/', { test: 'fetch' })
+        .reply()
+
+      const { status } = await fetch('http://example.test/', {
+        method: 'POST',
+        body: JSON.stringify({ test: 'fetch' }),
+      })
+      expect(status).to.equal(200)
+      scope.done()
+    })
+
+    it('filter by request body', async () => {
+      const scope = nock('http://example.test')
+        .post('/', { test: 'fetch' })
+        .reply()
+
+      const { status } = await fetch(
+        new Request('http://example.test/', {
+          method: 'POST',
+          body: JSON.stringify({ test: 'fetch' }),
+        }),
+      )
+      expect(status).to.equal(200)
+      scope.done()
+    })
+
+    it('no match', async () => {
+      nock('http://example.test').get('/').reply()
+
+      await assertRejects(
+        fetch('http://example.test/wrong-path'),
+        /Nock: No match for request/,
+      )
+    })
+
+    it('forward request if no mock', async () => {
+      const { origin } = await startHttpServer((request, response) => {
+        response.write('live')
+        response.end()
+      })
+
+      const { status } = await fetch(origin)
+      expect(status).to.equal(200)
+    })
+  })
+}

--- a/tests/test_fetch.js
+++ b/tests/test_fetch.js
@@ -5,91 +5,89 @@ const nock = require('..')
 const assertRejects = require('assert-rejects')
 const { startHttpServer } = require('./servers')
 
-if (global.fetch) {
-  describe('Native Fetch', () => {
-    it('input is string', async () => {
-      const scope = nock('http://example.test').get('/').reply()
+describe('Native Fetch', () => {
+  it('input is string', async () => {
+    const scope = nock('http://example.test').get('/').reply()
 
-      const { status } = await fetch('http://example.test/')
-      expect(status).to.equal(200)
-      scope.done()
+    const { status } = await fetch('http://example.test/')
+    expect(status).to.equal(200)
+    scope.done()
+  })
+
+  it('input is URL', async () => {
+    const scope = nock('http://example.test').get('/').reply()
+
+    const { status } = await fetch(new URL('http://example.test/'))
+    expect(status).to.equal(200)
+    scope.done()
+  })
+
+  it('input is Request object', async () => {
+    const scope = nock('http://example.test').get('/').reply()
+
+    const { status } = await fetch(new Request('http://example.test/'))
+    expect(status).to.equal(200)
+    scope.done()
+  })
+
+  it('filter by body', async () => {
+    const scope = nock('http://example.test')
+      .post('/', { test: 'fetch' })
+      .reply()
+
+    const { status } = await fetch('http://example.test/', {
+      method: 'POST',
+      body: JSON.stringify({ test: 'fetch' }),
     })
+    expect(status).to.equal(200)
+    scope.done()
+  })
 
-    it('input is URL', async () => {
-      const scope = nock('http://example.test').get('/').reply()
+  it('filter by request body', async () => {
+    const scope = nock('http://example.test')
+      .post('/', { test: 'fetch' })
+      .reply()
 
-      const { status } = await fetch(new URL('http://example.test/'))
-      expect(status).to.equal(200)
-      scope.done()
-    })
-
-    it('input is Request object', async () => {
-      const scope = nock('http://example.test').get('/').reply()
-
-      const { status } = await fetch(new Request('http://example.test/'))
-      expect(status).to.equal(200)
-      scope.done()
-    })
-
-    it('filter by body', async () => {
-      const scope = nock('http://example.test')
-        .post('/', { test: 'fetch' })
-        .reply()
-
-      const { status } = await fetch('http://example.test/', {
+    const { status } = await fetch(
+      new Request('http://example.test/', {
         method: 'POST',
         body: JSON.stringify({ test: 'fetch' }),
-      })
-      expect(status).to.equal(200)
-      scope.done()
-    })
-
-    it('filter by request body', async () => {
-      const scope = nock('http://example.test')
-        .post('/', { test: 'fetch' })
-        .reply()
-
-      const { status } = await fetch(
-        new Request('http://example.test/', {
-          method: 'POST',
-          body: JSON.stringify({ test: 'fetch' }),
-        }),
-      )
-      expect(status).to.equal(200)
-      scope.done()
-    })
-
-    it('no match', async () => {
-      nock('http://example.test').get('/').reply()
-
-      await assertRejects(
-        fetch('http://example.test/wrong-path'),
-        /Nock: No match for request/,
-      )
-    })
-
-    it('forward request if no mock', async () => {
-      const { origin } = await startHttpServer((request, response) => {
-        response.write('live')
-        response.end()
-      })
-
-      const { status } = await fetch(origin)
-      expect(status).to.equal(200)
-    })
-
-    it('should work with empty response', async () => {
-      nock('http://example.test').get('/').reply(204)
-
-      const { status } = await fetch('http://example.test')
-      expect(status).to.equal(204)
-    })
-
-    it('should work https', async () => {
-      nock('https://example.test').get('/').reply()
-
-      const { status } = await fetch('https://example.test')
-      expect(status).to.equal(200)
-    })
+      }),
+    )
+    expect(status).to.equal(200)
+    scope.done()
   })
-}
+
+  it('no match', async () => {
+    nock('http://example.test').get('/').reply()
+
+    await assertRejects(
+      fetch('http://example.test/wrong-path'),
+      /Nock: No match for request/,
+    )
+  })
+
+  it('forward request if no mock', async () => {
+    const { origin } = await startHttpServer((request, response) => {
+      response.write('live')
+      response.end()
+    })
+
+    const { status } = await fetch(origin)
+    expect(status).to.equal(200)
+  })
+
+  it('should work with empty response', async () => {
+    nock('http://example.test').get('/').reply(204)
+
+    const { status } = await fetch('http://example.test')
+    expect(status).to.equal(204)
+  })
+
+  it('should work https', async () => {
+    nock('https://example.test').get('/').reply()
+
+    const { status } = await fetch('https://example.test')
+    expect(status).to.equal(200)
+  })
+})


### PR DESCRIPTION
BREAKING CHANGE: drop support for Node < 18

Fetch support.

1. Solves the urgent need for fetch support.
2. Although I think it's working as expected, I believe we should consider this as experimental until we see it working properly.
3. Recording is not supported, yet(?). Workaround can be found [here](https://github.com/nock/nock/issues/2397#issuecomment-1924424258).
4. I believe that we should keep working on switching the 'backend' to use 'mswjs/interceptors'., [here is why](https://github.com/nock/nock/pull/2517#:~:text=edited-,Why%3F,-Decompose%20interception%20and).

@gr2m WDYT?
CC @kettanaito