### PR TITLE
ci(test): use a single `test` job that we can require, independent of test matrix

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -63,9 +63,26 @@ jobs:
       - name: Lint
         run: |
           npm run lint:ts
-  test:
-    name: Test
+
+  # verify against ranges defined as supported in engines.node
+  test_matrix:
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 10
+          - 12
+          - 14
+          - 16
+          - 18
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -83,16 +100,18 @@ jobs:
       - name: Test jest
         run: npm run test:jest
         if: matrix.node-version >= 14
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version:
-          - 10
-          - 12
-          - 14
-          - 16
-          - 18
-        os:
-          - macos-latest
-          - ubuntu-latest
-          - windows-latest
+
+  # separate job to set as required in branch protection,
+  # as the build names above change each time Node versions change
+  test:
+    runs-on: ubuntu-latest
+    needs:
+      - test_matrix
+    if: ${{ !cancelled() }}
+    steps:
+      - name: All matrix versions passed
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Some matrix version failed
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1


### PR DESCRIPTION
in preparation of #2580 @mikicho