### PR TITLE
ci: add node 20 in ci

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -75,6 +75,7 @@ jobs:
           - 14
           - 16
           - 18
+          - 20
         os:
           - macos-latest
           - ubuntu-latest


### PR DESCRIPTION
In the package.json engines field it is specified that `"node": ">= 10.13"` which means version 20 is included 😄