### PR TITLE
fix: for some reason you need to require both http and https

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -70,7 +70,13 @@ function overrideRequests(newRequest) {
     debug('- overriding request for', proto)
 
     const moduleName = proto // 1 to 1 match of protocol and module is fortunate :)
-    const module = require(proto)
+    // TODO: figure out why you need to require both modules instead of doing the following:
+    // const module = require(proto)
+    // https://github.com/nock/nock/pull/2572
+    const module = {
+      http: require('http'),
+      https: require('https'),
+    }[moduleName]
     const overriddenRequest = module.request
     const overriddenGet = module.get
 


### PR DESCRIPTION
My CI broke because of a change in https://github.com/nock/nock/pull/2572
Some other people later mentioned this issue, but no one has yet found the root cause
Honestly I am curious but don't have the time to dig into it at this moment...