### PR TITLE
Fix matching URL with mix of array-like and string value

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -496,7 +496,7 @@ function isStream(obj) {
 function normalizeClientRequestArgs(input, options, cb) {
   if (typeof input === 'string') {
     input = urlToOptions(new url.URL(input))
-  } else if (input instanceof url.URL) {
+  } else if (input instanceof url.URL  || input.constructor.name === 'URL') {
     input = urlToOptions(input)
   } else {
     cb = options
@@ -690,7 +690,7 @@ const expand = input => {
     return input
   }
 
-  const keys = Object.keys(input)
+  const keys = Object.keys(input).toSorted((a, b) => b.length - a.length)
 
   const result = {}
   let resultPtr = result
@@ -717,7 +717,11 @@ const expand = input => {
         if (Array.isArray(resultPtr)) {
           resultPtr[+part] = input[originalPath]
         } else {
-          resultPtr[part] = input[originalPath]
+          if(resultPtr[part] instanceof Object) {
+            resultPtr[part].__string_value = input[originalPath];
+          } else {
+            resultPtr[part] = input[originalPath]
+          }
         }
       } else {
         if (resultPtr[part] === undefined || resultPtr[part] === null) {

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -659,7 +659,7 @@ describe('`expand()`', () => {
     expect(expand({ 'a[0]': 4, 'a[1]': 5 })).deep.equal({ a: [4, 5] })
   })
 
-  it('array-like meshed with string', () => {
+  it('array-like mixed with string value', () => {
     // Handles cases with URL with query params that overlap array-like with normal values.
     // For example, used by Apple Music API: "include=record-labels,artists&include[music-videos]=artists"
     // https://github.com/nock/nock/issues/2541


### PR DESCRIPTION
Fixes issue described in https://github.com/nock/nock/issues/2541
Also, fixes issue for Nock working with ClickHouse Client JS, as it uses non-standard URL but still URL-like library. 

