### PR TITLE
fix: support literal query string

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -510,7 +510,7 @@ module.exports = class Interceptor {
       strFormattingFn = common.percentDecode
     }
 
-    if (queries instanceof URLSearchParams) {
+    if (queries instanceof URLSearchParams || typeof queries === 'string') {
       // Normalize the data into the shape that is matched against.
       // Duplicate keys are handled by combining the values into an array.
       queries = querystring.parse(queries.toString())

--- a/tests/got/test_query.js
+++ b/tests/got/test_query.js
@@ -19,6 +19,20 @@ describe('query params in path', () => {
 })
 
 describe('`query()`', () => {
+  describe('when called with a string', () => {
+    it('matches a url encoded query string of the same name=value', async () => {
+      const scope = nock('http://example.test')
+        .get('/')
+        .query('foo%5Bbar%5D%3Dhello%20world%21')
+        .reply()
+
+      const { statusCode } = await got('http://example.test/?foo%5Bbar%5D%3Dhello%20world%21')
+
+      expect(statusCode).to.equal(200)
+      scope.done()
+    })
+  })
+
   describe('when called with an object', () => {
     it('matches a query string of the same name=value', async () => {
       const scope = nock('http://example.test')
@@ -256,8 +270,8 @@ describe('`query()`', () => {
       const interceptor = nock('http://example.test').get('/')
 
       expect(() => {
-        interceptor.query('foo=bar')
-      }).to.throw(Error, 'Argument Error: foo=bar')
+        interceptor.query(1)
+      }).to.throw(Error, 'Argument Error: 1')
     })
   })
 

--- a/tests/got/test_query.js
+++ b/tests/got/test_query.js
@@ -26,7 +26,9 @@ describe('`query()`', () => {
         .query('foo%5Bbar%5D%3Dhello%20world%21')
         .reply()
 
-      const { statusCode } = await got('http://example.test/?foo%5Bbar%5D%3Dhello%20world%21')
+      const { statusCode } = await got(
+        'http://example.test/?foo%5Bbar%5D%3Dhello%20world%21',
+      )
 
       expect(statusCode).to.equal(200)
       scope.done()


### PR DESCRIPTION
closes https://github.com/nock/nock/issues/2342

@gr2m I'm a bit puzzled here. In the example, it seems like we support this, but we have (an old) test that specifically forbids string as an argument.

Anyway, I think we should support string.