### PR TITLE
fix: fetch support compressed responses

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -2,7 +2,7 @@ env:
   node: true
 
 parserOptions:
-  ecmaVersion: 9
+  ecmaVersion: 2020
   # Override eslint-config-standard, which incorrectly sets this to "module",
   # though that setting is only for ES6 modules, not CommonJS modules.
   sourceType: 'script'

--- a/lib/create_response.js
+++ b/lib/create_response.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const zlib = require('node:zlib')
 const { headersArrayToObject } = require('./common')
 const { STATUS_CODES } = require('http')
 
@@ -16,7 +17,7 @@ const { STATUS_CODES } = require('http')
 const responseStatusCodesWithoutBody = [204, 205, 304]
 
 /**
- * @param {IncomingMessage} message
+ * @param {import('node:http').IncomingMessage} message
  */
 function createResponse(message) {
   const responseBodyOrNull = responseStatusCodesWithoutBody.includes(
@@ -25,7 +26,21 @@ function createResponse(message) {
     ? null
     : new ReadableStream({
         start(controller) {
-          message.on('data', chunk => controller.enqueue(chunk))
+          message.on('data', chunk => {
+            if (
+              ['x-gzip', 'gzip'].includes(message.headers['content-encoding'])
+            ) {
+              // https://github.com/nodejs/node/blob/0161ad0baf87a0009101ce00b22b874ad6fc5d88/deps/undici/src/lib/fetch/index.js#L2178
+              controller.enqueue(
+                zlib.gunzipSync(chunk, {
+                  flush: zlib.constants.Z_SYNC_FLUSH,
+                  finishFlush: zlib.constants.Z_SYNC_FLUSH,
+                }),
+              )
+            } else {
+              controller.enqueue(chunk)
+            }
+          })
           message.on('end', () => controller.close())
 
           /**

--- a/lib/create_response.js
+++ b/lib/create_response.js
@@ -65,10 +65,7 @@ function createResponse(message) {
                 }
               },
               error => {
-                error
-                /* istanbul ignore next - hard to test */
-                ? controller.error(error)
-                : controller.close()
+                error ? controller.error(error) : controller.close()
               },
             )
           })

--- a/lib/create_response.js
+++ b/lib/create_response.js
@@ -3,7 +3,7 @@
 const zlib = require('node:zlib')
 const { headersArrayToObject } = require('./common')
 const { STATUS_CODES } = require('http')
-const { pipeline, Readable, Writable } = require('node:stream')
+const { pipeline, Readable } = require('node:stream')
 
 /**
  * Creates a Fetch API `Response` instance from the given

--- a/lib/create_response.js
+++ b/lib/create_response.js
@@ -64,9 +64,12 @@ function createResponse(message) {
                   yield controller.enqueue(chunk)
                 }
               },
-              e => {
-                if (e) throw e
-                controller.close()
+              error => {
+                if (error) {
+                  controller.error(error)
+                } else {
+                  controller.close()
+                }
               },
             )
           })

--- a/lib/create_response.js
+++ b/lib/create_response.js
@@ -65,11 +65,10 @@ function createResponse(message) {
                 }
               },
               error => {
-                if (error) {
-                  controller.error(error)
-                } else {
-                  controller.close()
-                }
+                error
+                /* istanbul ignore next - hard to test */
+                ? controller.error(error)
+                : controller.close()
               },
             )
           })

--- a/lib/create_response.js
+++ b/lib/create_response.js
@@ -3,6 +3,7 @@
 const zlib = require('node:zlib')
 const { headersArrayToObject } = require('./common')
 const { STATUS_CODES } = require('http')
+const { pipeline, Readable, Writable } = require('node:stream')
 
 /**
  * Creates a Fetch API `Response` instance from the given
@@ -20,29 +21,55 @@ const responseStatusCodesWithoutBody = [204, 205, 304]
  * @param {import('node:http').IncomingMessage} message
  */
 function createResponse(message) {
-  const isGzipped = ['x-gzip', 'gzip'].includes(
-    message.headers['content-encoding'],
-  )
+  // https://github.com/Uzlopak/undici/blob/main/lib/fetch/index.js#L2031
+  const decoders = []
+  const codings =
+    message.headers['content-encoding']
+      ?.toLowerCase()
+      .split(',')
+      .map(x => x.trim())
+      .reverse() || []
+  for (const coding of codings) {
+    if (coding === 'gzip' || coding === 'x-gzip') {
+      decoders.push(
+        zlib.createGunzip({
+          flush: zlib.constants.Z_SYNC_FLUSH,
+          finishFlush: zlib.constants.Z_SYNC_FLUSH,
+        }),
+      )
+    } else if (coding === 'deflate') {
+      decoders.push(zlib.createInflate())
+    } else if (coding === 'br') {
+      decoders.push(zlib.createBrotliDecompress())
+    } else {
+      decoders.length = 0
+      break
+    }
+  }
+
+  const chunks = []
   const responseBodyOrNull = responseStatusCodesWithoutBody.includes(
     message.statusCode,
   )
     ? null
     : new ReadableStream({
         start(controller) {
-          message.on('data', chunk => {
-            if (isGzipped) {
-              // https://github.com/nodejs/node/blob/0161ad0baf87a0009101ce00b22b874ad6fc5d88/deps/undici/src/lib/fetch/index.js#L2178
-              controller.enqueue(
-                zlib.gunzipSync(chunk, {
-                  flush: zlib.constants.Z_SYNC_FLUSH,
-                  finishFlush: zlib.constants.Z_SYNC_FLUSH,
-                }),
-              )
-            } else {
-              controller.enqueue(chunk)
-            }
+          message.on('data', chunk => chunks.push(chunk))
+          message.on('end', () => {
+            pipeline(
+              Readable.from(chunks),
+              ...decoders,
+              async function* (source) {
+                for await (const chunk of source) {
+                  yield controller.enqueue(chunk)
+                }
+              },
+              e => {
+                if (e) throw e
+                controller.close()
+              },
+            )
           })
-          message.on('end', () => controller.close())
 
           /**
            * @todo Should also listen to the "error" on the message

--- a/lib/create_response.js
+++ b/lib/create_response.js
@@ -20,6 +20,9 @@ const responseStatusCodesWithoutBody = [204, 205, 304]
  * @param {import('node:http').IncomingMessage} message
  */
 function createResponse(message) {
+  const isGzipped = ['x-gzip', 'gzip'].includes(
+    message.headers['content-encoding'],
+  )
   const responseBodyOrNull = responseStatusCodesWithoutBody.includes(
     message.statusCode,
   )
@@ -27,9 +30,7 @@ function createResponse(message) {
     : new ReadableStream({
         start(controller) {
           message.on('data', chunk => {
-            if (
-              ['x-gzip', 'gzip'].includes(message.headers['content-encoding'])
-            ) {
+            if (isGzipped) {
               // https://github.com/nodejs/node/blob/0161ad0baf87a0009101ce00b22b874ad6fc5d88/deps/undici/src/lib/fetch/index.js#L2178
               controller.enqueue(
                 zlib.gunzipSync(chunk, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "typescript": "^5.0.4"
       },
       "engines": {
-        "node": ">= 10.13"
+        "node": ">= 18"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/nock/nock/issues"
   },
   "engines": {
-    "node": ">= 10.13"
+    "node": ">= 18"
   },
   "main": "./index.js",
   "types": "types",

--- a/tests/test_fetch.js
+++ b/tests/test_fetch.js
@@ -111,21 +111,77 @@ describe('Native Fetch', () => {
     scope.done()
   })
 
-  it('should accept gzipped content', async () => {
-    const message = 'Lorem ipsum dolor sit amet'
-    const compressed = zlib.gzipSync(message)
+  describe('content-encoding', () => {
+    it('should accept gzipped content', async () => {
+      const message = 'Lorem ipsum dolor sit amet'
+      const compressed = zlib.gzipSync(message)
 
-    const scope = nock('http://example.test')
-      .get('/foo')
-      .reply(200, compressed, {
-        'X-Transfer-Length': String(compressed.length),
-        'Content-Length': undefined,
-        'Content-Encoding': 'gzip',
-      })
-    const response = await fetch('http://example.test/foo')
+      const scope = nock('http://example.test')
+        .get('/foo')
+        .reply(200, compressed, {
+          'X-Transfer-Length': String(compressed.length),
+          'Content-Length': undefined,
+          'Content-Encoding': 'gzip',
+        })
+      const response = await fetch('http://example.test/foo')
 
-    expect(response.status).to.equal(200)
-    expect(await response.text()).to.equal(message)
-    scope.done()
+      expect(response.status).to.equal(200)
+      expect(await response.text()).to.equal(message)
+      scope.done()
+    })
+
+    it('should accept deflated content', async () => {
+      const message = 'Lorem ipsum dolor sit amet'
+      const compressed = zlib.deflateSync(message)
+
+      const scope = nock('http://example.test')
+        .get('/foo')
+        .reply(200, compressed, {
+          'X-Transfer-Length': String(compressed.length),
+          'Content-Length': undefined,
+          'Content-Encoding': 'deflate',
+        })
+      const response = await fetch('http://example.test/foo')
+
+      expect(response.status).to.equal(200)
+      expect(await response.text()).to.equal(message)
+      scope.done()
+    })
+
+    it('should accept brotli content', async () => {
+      const message = 'Lorem ipsum dolor sit amet'
+      const compressed = zlib.brotliCompressSync(message)
+
+      const scope = nock('http://example.test')
+        .get('/foo')
+        .reply(200, compressed, {
+          'X-Transfer-Length': String(compressed.length),
+          'Content-Length': undefined,
+          'Content-Encoding': 'br',
+        })
+      const response = await fetch('http://example.test/foo')
+
+      expect(response.status).to.equal(200)
+      expect(await response.text()).to.equal(message)
+      scope.done()
+    })
+
+    it('should accept gzip and broti content', async () => {
+      const message = 'Lorem ipsum dolor sit amet'
+      const compressed = zlib.brotliCompressSync(zlib.gzipSync(message))
+
+      const scope = nock('http://example.test')
+        .get('/foo')
+        .reply(200, compressed, {
+          'X-Transfer-Length': String(compressed.length),
+          'Content-Length': undefined,
+          'Content-Encoding': 'gzip, br',
+        })
+      const response = await fetch('http://example.test/foo')
+
+      expect(response.status).to.equal(200)
+      expect(await response.text()).to.equal(message)
+      scope.done()
+    })
   })
 })

--- a/tests/test_fetch.js
+++ b/tests/test_fetch.js
@@ -212,6 +212,7 @@ describe('Native Fetch', () => {
       const response = await fetch('http://example.test/foo')
       await response.text().catch(e => {
         expect(e.message).to.contain('unexpected end of file')
+        scope.done()
       })
     })
   })

--- a/tests/test_fetch.js
+++ b/tests/test_fetch.js
@@ -183,5 +183,21 @@ describe('Native Fetch', () => {
       expect(await response.text()).to.equal(message)
       scope.done()
     })
+
+    it('should pass through the result if a not supported encoding was used', async () => {
+      const message = 'Lorem ipsum dolor sit amet'
+      const compressed = Buffer.from(message)
+      const scope = nock('http://example.test')
+        .get('/foo')
+        .reply(200, compressed, {
+          'X-Transfer-Length': String(compressed.length),
+          'Content-Length': undefined,
+          'Content-Encoding': 'invalid',
+        })
+      const response = await fetch('http://example.test/foo')
+      expect(response.status).to.equal(200)
+      expect(await response.text()).to.equal(message)
+      scope.done()
+    })
   })
 })

--- a/tests/test_fetch.js
+++ b/tests/test_fetch.js
@@ -199,5 +199,20 @@ describe('Native Fetch', () => {
       expect(await response.text()).to.equal(message)
       scope.done()
     })
+
+    it('should throw error if wrong encoding is used', async () => {
+      const message = 'Lorem ipsum dolor sit amet'
+      const scope = nock('http://example.test')
+        .get('/foo')
+        .reply(200, message, {
+          'X-Transfer-Length': String(message.length),
+          'Content-Length': undefined,
+          'Content-Encoding': 'br',
+        })
+      const response = await fetch('http://example.test/foo')
+      await response.text().catch(e => {
+        expect(e.message).to.contain('unexpected end of file')
+      })
+    })
   })
 })

--- a/tests/test_fetch.js
+++ b/tests/test_fetch.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const zlib = require('zlib')
 const { expect } = require('chai')
 const nock = require('..')
 const assertRejects = require('assert-rejects')
@@ -97,5 +98,34 @@ describe('Native Fetch', () => {
     const { status, statusText } = await fetch('https://example.test')
     expect(status).to.equal(404)
     expect(statusText).to.equal('Not Found')
+  })
+
+  it('should return mocked response', async () => {
+    const message = 'Lorem ipsum dolor sit amet'
+    const scope = nock('http://example.test').get('/foo').reply(200, message)
+
+    const response = await fetch('http://example.test/foo')
+
+    expect(response.status).to.equal(200)
+    expect(await response.text()).to.equal(message)
+    scope.done()
+  })
+
+  it('should accept gzipped content', async () => {
+    const message = 'Lorem ipsum dolor sit amet'
+    const compressed = zlib.gzipSync(message)
+
+    const scope = nock('http://example.test')
+      .get('/foo')
+      .reply(200, compressed, {
+        'X-Transfer-Length': String(compressed.length),
+        'Content-Length': undefined,
+        'Content-Encoding': 'gzip',
+      })
+    const response = await fetch('http://example.test/foo')
+
+    expect(response.status).to.equal(200)
+    expect(await response.text()).to.equal(message)
+    scope.done()
   })
 })


### PR DESCRIPTION
fixes https://github.com/nock/nock/issues/2397#issuecomment-1961177318

This is a pretty naive solution that doesn't support more decoders easily (or multiple decoders at all), but I'm not expecting it in streams and such. 
Improvements are welcome. 