### PR TITLE
docs: remove discarded build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # Nock
 
 [![npm](https://img.shields.io/npm/v/nock.svg)][npmjs]
-[![Build Status](https://travis-ci.org/nock/nock.svg)][build]
 ![Coverage Status](http://img.shields.io/badge/coverage-100%25-brightgreen.svg)
 [![Backers on Open Collective](https://opencollective.com/nock/backers/badge.svg)](#backers)
 [![Sponsors on Open Collective](https://opencollective.com/nock/sponsors/badge.svg)](#sponsors)
 
 [npmjs]: https://www.npmjs.com/package/nock
-[build]: https://travis-ci.org/nock/nock
 
 > **Notice**
 >


### PR DESCRIPTION
travis is dropped by
https://github.com/nock/nock/pull/1882