### PR TITLE
fetch support delay

### DIFF
--- a/lib/create_response.js
+++ b/lib/create_response.js
@@ -19,8 +19,9 @@ const responseStatusCodesWithoutBody = [204, 205, 304]
 
 /**
  * @param {import('node:http').IncomingMessage} message
+ * @param {AbortSignal} signal
  */
-function createResponse(message) {
+function createResponse(message, signal) {
   // https://github.com/Uzlopak/undici/blob/main/lib/fetch/index.js#L2031
   const decoders = []
   const codings =
@@ -54,6 +55,10 @@ function createResponse(message) {
     ? null
     : new ReadableStream({
         start(controller) {
+          signal.addEventListener('abort', () => {
+            message.removeAllListeners()
+            controller.error(signal.reason)
+          })
           message.on('data', chunk => chunks.push(chunk))
           message.on('end', () => {
             pipeline(

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -240,6 +240,7 @@ function removeInterceptor(options) {
 let originalClientRequest
 //  Variable where we keep the fetch we have overridden
 let originalFetch
+let originalAbortTimeout
 
 function ErroringClientRequest(error) {
   http.OutgoingMessage.call(this)
@@ -343,6 +344,8 @@ function restoreOverriddenClientRequest() {
 
     global.fetch = originalFetch
     originalFetch = undefined
+    AbortSignal.timeout = originalAbortTimeout
+    originalAbortTimeout = undefined
 
     debug('- ClientRequest restored')
   }
@@ -443,18 +446,35 @@ function activate() {
   })
 
   originalFetch = global.fetch
+  originalAbortTimeout = AbortSignal.timeout
+  AbortSignal.timeout = function nockAbortTimeout(delay) {
+    const signal = originalAbortTimeout(delay)
+    signal.__nock_delay = delay
+    return signal
+  }
   global.fetch = async (input, init = undefined) => {
     const request = new Request(input, init)
+    if (request.signal.aborted) return Promise.reject(request.signal.reason)
+
     const options = common.convertFetchRequestToClientRequest(request)
     options.isFetchRequest = true
+    options.timeout = init?.signal?.__nock_delay
     const body = await request.arrayBuffer()
     const clientRequest = new http.ClientRequest(options)
 
     // If mock found
     if (clientRequest.interceptors) {
       return new Promise((resolve, reject) => {
+        clientRequest.on('timeout', () => {
+          reject(
+            new DOMException(
+              'The operation was aborted due to timeout',
+              'TimeoutError',
+            ),
+          )
+        })
         clientRequest.on('response', response => {
-          resolve(createResponse(response))
+          resolve(createResponse(response, request.signal))
         })
         clientRequest.on('error', reject)
         clientRequest.end(body)

--- a/tests/test_fetch.js
+++ b/tests/test_fetch.js
@@ -111,6 +111,19 @@ describe('Native Fetch', () => {
     scope.done()
   })
 
+  it('should throw when signal is already aborted', async () => {
+    nock('http://example.test').get('/').reply(200)
+
+    const signal = AbortSignal.abort('reason')
+    try {
+      await fetch('http://example.test', { signal })
+      expect.fail()
+    } catch (e) {
+      expect(signal.aborted).to.true()
+      expect(e).to.equal('reason')
+    }
+  })
+
   describe('content-encoding', () => {
     it('should accept gzipped content', async () => {
       const message = 'Lorem ipsum dolor sit amet'

--- a/tests/test_fetch.js
+++ b/tests/test_fetch.js
@@ -242,6 +242,22 @@ describe('Native Fetch', () => {
       }
     })
 
+    it('should delay the connection', async () => {
+      nock('http://example.test').get('/').delayBody(50).reply(200)
+
+      const start = Date.now()
+
+      const response = await fetch('http://example.test')
+
+      expect(response.status).to.equal(200)
+      // wait for body stream to complete
+      await response.text()
+      expect(Date.now() - start).to.be.at.least(
+        50,
+        'delay minimum not satisfied',
+      )
+    })
+
     it('should delay the response body', async () => {
       nock('http://example.test').get('/').delayBody(50).reply(200)
 


### PR DESCRIPTION
* I had to patch the `AbortSignal.timeout` to get the delay for throwing the 'timeout' error without actually waiting for it.
* I'm wondering if it's worth it... `signal` is very general, and my current solution is for a very specific use case (`AbortSignal.timeout` function only), I'm not certain if it belongs in Nock.
* Currently, I reject the promise on the `timeout` event, which means the `signal` isn't really aborted. Is there an easy way to update the [`kAborted` to true and `kReason`](https://github.com/nodejs/node/blob/d78a565713d565dfb386c39ef65c73e93e03a1d3/lib/internal/abort_controller.js#L370)? We may override the `signal` with an aborted signal, but I'm afraid it would be fragile:
```js
clientRequest.on('timeout', () => {
  init.signal = AbortSignal.abort(new DOMException('The operation was aborted due to timeout', 'TimeoutError'))
  reject(init.signal.reason)
})
```

@gr2m @Uzlopak WDYT?