### PR TITLE
`ReplyHeaders` type fixed

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -77,12 +77,12 @@ declare namespace nock {
     req: ClientRequest,
     res: IncomingMessage,
     body: string | Buffer,
-  ) => string | string[]
-  type ReplyHeaderValue = string | string[] | ReplyHeaderFunction
+  ) => string
+  type ReplyHeaderValue = string | ReplyHeaderFunction
   type ReplyHeaders =
     | Record<string, ReplyHeaderValue>
     | Map<string, ReplyHeaderValue>
-    | ReplyHeaderValue[]
+    | string[]
 
   type StatusCode = number
   type ReplyFnResult =

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -422,12 +422,6 @@ scope = nock('http://example.test').get('/').reply(200, 'Hello World!', {
 
 scope = nock('http://example.test')
   .get('/')
-  .reply(200, 'Hello World!', {
-    'X-My-Headers': ['My Header value 1', 'My Header value 2'],
-  })
-
-scope = nock('http://example.test')
-  .get('/')
   .reply(200, 'Hello World!', new Map([['X-Header-One', 'foo']]))
 
 scope = nock('http://example.test')


### PR DESCRIPTION
Following type fixes does this PR include:
* `string[]` removed from `ReplyHeaderValue` and `ReplyHeaderFunction`. The resulting `IncomingMessage.rawHeaders` value would else be invalid. See example below.
* `ReplyHeaderFunction[]` replaced with just `string[]`. This actually leads to an runtime error when running nock.

See following examples

```
import http from 'node:http';
import nock from 'nock';

nock('http://github.com')
  .get('/nock/nock')
  .reply(200, 'Hello from GitHub!', {
    'X-My-Headers': ['My Header value 1', 'My Header value 2'],
  });

const req = http.request('http://github.com/nock/nock', (res) => {
  console.log(res.rawHeaders);
});

req.end();
```

Output:

```
[ 'X-My-Headers', [ 'My Header value 1', 'My Header value 2' ] ]
```

Which is an invalid `rawHeaders` value. The node docs define a `string[]`: https://nodejs.org/docs/latest/api/http.html#messagerawheaders

```
import http from 'node:http';
import nock from 'nock';

nock('http://github.com')
  .get('/nock/nock')
  .reply(200, 'Hello from GitHub!', [() => 'Test1', () => 'Test2']);

const req = http.request('http://github.com/nock/nock', (res) => {
  console.log(res.rawHeaders);
});

req.end();
```

This results in an exception:

```
TypeError: name.toLowerCase is not a function
    at addHeaderLine (/node_modules/nock/lib/common.js:339:20)
    at /node_modules/nock/lib/common.js:280:5
    at forEachHeader (/node_modules/nock/lib/common.js:396:5)
    at Object.headersArrayToObject (/node_modules/nock/lib/common.js:279:3)
    at Interceptor.reply (/node_modules/nock/lib/interceptor.js:154:27)
    at file:///playground/dist/main.js:5:6
    at ModuleJob.run (node:internal/modules/esm/module_job:218:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:329:24)
    at async loadESM (node:internal/process/esm_loader:28:7)
    at async handleMainPromise (node:internal/modules/run_main:113:12)
```