### PR TITLE
ci: exclude nodejs 10, 12 and 14 tests running on macos

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -80,7 +80,13 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
-
+        exclude: 
+          - node-version: 10
+            os: macos-latest
+          - node-version: 12
+            os: macos-latest
+          - node-version: 14
+            os: macos-latest
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5
 

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -80,7 +80,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
-        exclude: 
+        exclude:
           - node-version: 10
             os: macos-latest
           - node-version: 12


### PR DESCRIPTION
macos latest is using arm64 (M1!) and node 10, 12 and 14 were not compiled for that. 

So we exclude these cases from the test matrix...