### PR TITLE
fix: memory leaks due to timer references outliving the timers

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -519,7 +519,6 @@ function deepEqual(expected, actual) {
 }
 
 const timeouts = []
-const intervals = []
 const immediates = []
 
 const wrapTimer =
@@ -531,7 +530,6 @@ const wrapTimer =
   }
 
 const setTimeout = wrapTimer(timers.setTimeout, timeouts)
-const setInterval = wrapTimer(timers.setInterval, intervals)
 const setImmediate = wrapTimer(timers.setImmediate, immediates)
 
 function clearTimer(clear, ids) {
@@ -543,7 +541,6 @@ function clearTimer(clear, ids) {
 function removeAllTimers() {
   debug('remove all timers')
   clearTimer(clearTimeout, timeouts)
-  clearTimer(clearInterval, intervals)
   clearTimer(clearImmediate, immediates)
 }
 
@@ -711,7 +708,6 @@ module.exports = {
   percentEncode,
   removeAllTimers,
   setImmediate,
-  setInterval,
   setTimeout,
   stringifyRequest,
   convertFetchRequestToClientRequest,

--- a/lib/common.js
+++ b/lib/common.js
@@ -518,14 +518,22 @@ function deepEqual(expected, actual) {
   return expected === actual
 }
 
-const timeouts = []
-const immediates = []
+const timeouts = new Set()
+const immediates = new Set()
 
 const wrapTimer =
   (timer, ids) =>
-  (...args) => {
-    const id = timer(...args)
-    ids.push(id)
+  (callback, ...timerArgs) => {
+    const cb = (...callbackArgs) => {
+      try {
+        // eslint-disable-next-line n/no-callback-literal
+        callback(...callbackArgs)
+      } finally {
+        ids.delete(id)
+      }
+    }
+    const id = timer(cb, ...timerArgs)
+    ids.add(id)
     return id
   }
 
@@ -533,9 +541,8 @@ const setTimeout = wrapTimer(timers.setTimeout, timeouts)
 const setImmediate = wrapTimer(timers.setImmediate, immediates)
 
 function clearTimer(clear, ids) {
-  while (ids.length) {
-    clear(ids.shift())
-  }
+  ids.forEach(clear)
+  ids.clear()
 }
 
 function removeAllTimers() {

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -522,17 +522,14 @@ describe('`dataEqual()`', () => {
 
 it('testing timers are deleted correctly', done => {
   const timeoutSpy = sinon.spy()
-  const intervalSpy = sinon.spy()
   const immediateSpy = sinon.spy()
 
   common.setTimeout(timeoutSpy, 0)
-  common.setInterval(intervalSpy, 0)
   common.setImmediate(immediateSpy)
   common.removeAllTimers()
 
   setImmediate(() => {
     expect(timeoutSpy).to.not.have.been.called()
-    expect(intervalSpy).to.not.have.been.called()
     expect(immediateSpy).to.not.have.been.called()
     done()
   })


### PR DESCRIPTION
This fixes the memory leaks described in #2771 by first removing the unused `setInterval` spy, and then augmenting the `setTimer` and `setImmediate` spies to delete the strong references after the respective callback has been executed. Since the code base does not use any `clearTimeout` / `clearImmediate` calls, intercepting those for deletion from the Set is not required.

Closes #2771.