### PR TITLE
fix(types): return type of BackOptions.afterRecord

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -289,7 +289,7 @@ declare namespace nock {
   interface BackOptions {
     before?: (def: Definition) => void
     after?: (scope: Scope) => void
-    afterRecord?: (defs: Definition[]) => Definition[]
+    afterRecord?: (defs: Definition[]) => Definition[] | string
     recorder?: RecorderOptions
   }
 }


### PR DESCRIPTION
This PR fixes a TypeScript discrepancy where the docs (and source code) say nock back's `afterRecord` function may also return a `string`, but the typings only allow for `Definition[]`.
