### PR TITLE
Fix: GitHub workflow script injection

### DIFF
--- a/.github/workflows/fix-formatting.yaml
+++ b/.github/workflows/fix-formatting.yaml
@@ -8,6 +8,9 @@ name: Fix formatting
 permissions:
   contents: read
 
+env:
+  HEAD_REF: ${{ github.head_ref }}
+
 jobs:
   fixFormatting:
     permissions:
@@ -33,4 +36,4 @@ jobs:
           git config user.name "github-actions"
           git add .
           git commit -m "style: format files with Prettier" | true # ignore error if there are no changes to commit
-          git push origin HEAD:${{ github.head_ref }}
+          git push origin HEAD:$HEAD_REF


### PR DESCRIPTION
Hi! Joyce here from Google's Open Source Security Team ([GOSST](https://opensource.googleblog.com/2023/04/googles-open-source-security-upstream-team-one-year-later.html)).  I've found a small fix to prevent script injection attacks in your GitHub workflows, PTL.

### Changes

- parse `github.head_ref` into an environment variable before use (to prevent script injection).

You can see further explanation about this kind of threat in this blogpost [Keeping your GitHub Actions and workflows secure Part 2: Untrusted input](https://securitylab.github.com/resources/github-actions-untrusted-input/).

Let me know if you have any questions!