### PR TITLE
fix(recorder): response body accessed multiple times in parallel requests

### DIFF
--- a/.nycrc.yml
+++ b/.nycrc.yml
@@ -1,8 +1,8 @@
 all: true
 check-coverage: true
 
-branches: 94.26
-lines: 96.72
+branches: 94.25
+lines: 96.7
 
 include:
   - lib

--- a/.nycrc.yml
+++ b/.nycrc.yml
@@ -2,7 +2,7 @@ all: true
 check-coverage: true
 
 branches: 94.25
-lines: 96.7
+lines: 96.69
 
 include:
   - lib

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -224,31 +224,37 @@ function record(recOptions) {
   //  We override the requests so that we can save information on them before executing.
   clientRequestInterceptor.apply()
   fetchRequestInterceptor.apply()
-  clientRequestInterceptor.on('response', async function ({ request, response }) {
-    await recordResponse(request, response)
-  })
-  fetchRequestInterceptor.on('response', async function ({ request, response }) {
-    // fetch decompresses the body automatically, so we need to recompress it
-    const codings =
-      response.headers
-        .get('content-encoding')
-        ?.toLowerCase()
-        .split(',')
-        .map(c => c.trim()) || []
+  clientRequestInterceptor.on(
+    'response',
+    async function ({ request, response }) {
+      await recordResponse(request, response)
+    },
+  )
+  fetchRequestInterceptor.on(
+    'response',
+    async function ({ request, response }) {
+      // fetch decompresses the body automatically, so we need to recompress it
+      const codings =
+        response.headers
+          .get('content-encoding')
+          ?.toLowerCase()
+          .split(',')
+          .map(c => c.trim()) || []
 
-    let body = await response.arrayBuffer()
-    for (const coding of codings) {
-      if (coding === 'gzip') {
-        body = gzipSync(body)
-      } else if (coding === 'deflate') {
-        body = deflateSync(body)
-      } else if (coding === 'br') {
-        body = brotliCompressSync(body)
+      let body = await response.arrayBuffer()
+      for (const coding of codings) {
+        if (coding === 'gzip') {
+          body = gzipSync(body)
+        } else if (coding === 'deflate') {
+          body = deflateSync(body)
+        } else if (coding === 'br') {
+          body = brotliCompressSync(body)
+        }
       }
-    }
 
-    await recordResponse(request, new Response(body, response))
-  })
+      await recordResponse(request, new Response(body, response))
+    },
+  )
 
   async function recordResponse(mswRequest, mswResponse) {
     const request = mswRequest.clone()

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -225,134 +225,100 @@ function record(recOptions) {
   //  We override the requests so that we can save information on them before executing.
   clientRequestInterceptor.apply()
   fetchRequestInterceptor.apply()
-  clientRequestInterceptor.on('request', async function ({ request }) {
-    await recordRequest(request)
+  clientRequestInterceptor.on('response', async function ({ request, response }) {
+    await recordResponse(request, response)
   })
-  fetchRequestInterceptor.on('request', async function ({ request }) {
-    await recordRequest(request)
+  fetchRequestInterceptor.on('response', async function ({ request, response }) {
+    // fetch decompresses the body automatically, so we need to recompress it
+    const codings =
+      response.headers
+        .get('content-encoding')
+        ?.toLowerCase()
+        .split(',')
+        .map(c => c.trim()) || []
+
+    let body = await response.arrayBuffer()
+    for (const coding of codings) {
+      if (coding === 'gzip') {
+        body = gzipSync(body)
+      } else if (coding === 'deflate') {
+        body = deflateSync(body)
+      } else if (coding === 'br') {
+        body = brotliCompressSync(body)
+      }
+    }
+
+    await recordResponse(request, new Response(body, response))
   })
 
-  async function recordRequest(mswRequest) {
+  async function recordResponse(mswRequest, mswResponse) {
     const request = mswRequest.clone()
+    const response = mswResponse.clone()
     const { options } = common.normalizeClientRequestArgs(request.url)
     options.method = request.method
     const proto = options.protocol.slice(0, -1)
-
-    // Node 0.11 https.request calls http.request -- don't want to record things
-    // twice.
-    /* istanbul ignore if */
-    if (options._recording) {
-      return
+    if (proto === 'https') {
+      options.proto = 'https'
     }
-    options._recording = true
+    debug(thisRecordingId, proto, 'intercepted request ended')
 
-    const req = new EventEmitter()
-    req.on('response', function () {
-      debug(thisRecordingId, 'intercepting', proto, 'request to record')
+    let reqheaders
+    // Ignore request headers completely unless it was explicitly enabled by the user (see README)
+    if (enableReqHeadersRecording) {
+      // We never record user-agent headers as they are worse than useless -
+      // they actually make testing more difficult without providing any benefit (see README)
+      reqheaders = Object.fromEntries(request.headers.entries())
+      common.deleteHeadersField(reqheaders, 'user-agent')
+    }
 
-      clientRequestInterceptor.once('response', async function ({ response }) {
-        await recordResponse(response)
-      })
-      fetchRequestInterceptor.once('response', async function ({ response }) {
-        // fetch decompresses the body automatically, so we need to recompress it
-        const codings =
-          response.headers
-            .get('content-encoding')
-            ?.toLowerCase()
-            .split(',')
-            .map(c => c.trim()) || []
+    const headers = Object.fromEntries(response.headers.entries())
+    const res = {
+      statusCode: response.status,
+      headers,
+      rawHeaders: headers,
+    }
 
-        let body = await response.arrayBuffer()
-        for (const coding of codings) {
-          if (coding === 'gzip') {
-            body = gzipSync(body)
-          } else if (coding === 'deflate') {
-            body = deflateSync(body)
-          } else if (coding === 'br') {
-            body = brotliCompressSync(body)
-          }
-        }
-
-        await recordResponse(new Response(body, response))
-      })
-
-      // Intercept "res.once('end', ...)"-like event
-      async function recordResponse(mswResponse) {
-        const response = mswResponse.clone()
-        debug(thisRecordingId, proto, 'intercepted request ended')
-
-        let reqheaders
-        // Ignore request headers completely unless it was explicitly enabled by the user (see README)
-        if (enableReqHeadersRecording) {
-          // We never record user-agent headers as they are worse than useless -
-          // they actually make testing more difficult without providing any benefit (see README)
-          reqheaders = Object.fromEntries(request.headers.entries())
-          common.deleteHeadersField(reqheaders, 'user-agent')
-        }
-
-        const headers = Object.fromEntries(response.headers.entries())
-        const res = {
-          statusCode: response.status,
-          headers,
-          rawHeaders: headers,
-        }
-
-        const generateFn = outputObjects
-          ? generateRequestAndResponseObject
-          : generateRequestAndResponse
-        let out = generateFn({
-          req: options,
-          bodyChunks: [Buffer.from(await request.arrayBuffer())],
-          options,
-          res,
-          dataChunks: [Buffer.from(await response.arrayBuffer())],
-          reqheaders,
-        })
-
-        debug('out:', out)
-
-        //  Check that the request was made during the current recording.
-        //  If it hasn't then skip it. There is no other simple way to handle
-        //  this as it depends on the timing of requests and responses. Throwing
-        //  will make some recordings/unit tests fail randomly depending on how
-        //  fast/slow the response arrived.
-        //  If you are seeing this error then you need to make sure that all
-        //  the requests made during a single recording session finish before
-        //  ending the same recording session.
-        if (thisRecordingId !== currentRecordingId) {
-          debug('skipping recording of an out-of-order request', out)
-          return
-        }
-
-        outputs.push(out)
-
-        if (!dontPrint) {
-          if (useSeparator) {
-            if (typeof out !== 'string') {
-              out = JSON.stringify(out, null, 2)
-            }
-            logging(SEPARATOR + out + SEPARATOR)
-          } else {
-            logging(out)
-          }
-        }
-      }
-
-      debug('finished setting up intercepting')
-
-      // We override both the http and the https modules; when we are
-      // serializing the request, we need to know which was called.
-      // By stuffing the state, we can make sure that nock records
-      // the intended protocol.
-      if (proto === 'https') {
-        options.proto = 'https'
-      }
+    const generateFn = outputObjects
+      ? generateRequestAndResponseObject
+      : generateRequestAndResponse
+    let out = generateFn({
+      req: options,
+      bodyChunks: [Buffer.from(await request.arrayBuffer())],
+      options,
+      res,
+      dataChunks: [Buffer.from(await response.arrayBuffer())],
+      reqheaders,
     })
 
-    // This is a massive change, we are trying to change minimum code, so we emit end event here
-    // because mswjs take care for these events
-    // TODO: refactor the recorder, we no longer need all the listeners and can just record the request we get from MSW
-    req.emit('response')
+    debug('out:', out)
+
+    //  Check that the request was made during the current recording.
+    //  If it hasn't then skip it. There is no other simple way to handle
+    //  this as it depends on the timing of requests and responses. Throwing
+    //  will make some recordings/unit tests fail randomly depending on how
+    //  fast/slow the response arrived.
+    //  If you are seeing this error then you need to make sure that all
+    //  the requests made during a single recording session finish before
+    //  ending the same recording session.
+    if (thisRecordingId !== currentRecordingId) {
+      debug('skipping recording of an out-of-order request', out)
+      return
+    }
+
+    outputs.push(out)
+
+    if (!dontPrint) {
+      if (useSeparator) {
+        if (typeof out !== 'string') {
+          out = JSON.stringify(out, null, 2)
+        }
+        logging(SEPARATOR + out + SEPARATOR)
+      } else {
+        logging(out)
+      }
+    }
+
+    debug('finished setting up intercepting')
   }
 }
 

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -6,7 +6,6 @@ const { inspect } = require('util')
 
 const common = require('./common')
 const { restoreOverriddenClientRequest } = require('./intercept')
-const { EventEmitter } = require('stream')
 const { gzipSync, brotliCompressSync, deflateSync } = require('zlib')
 const {
   default: nodeInterceptors,

--- a/tests/got/test_recorder.js
+++ b/tests/got/test_recorder.js
@@ -126,20 +126,15 @@ describe('Recorder', () => {
     nock.recorder.clear()
     expect(nock.recorder.play()).to.be.empty()
 
-    const { origin } = await servers.startHttpServer(
-      (request, response) => {
-        gotRequest()
-        response.writeHead(200)
-        response.end()
-      },
-    )
+    const { origin } = await servers.startHttpServer((request, response) => {
+      gotRequest()
+      response.writeHead(200)
+      response.end()
+    })
 
     nock.recorder.rec(true)
 
-    await Promise.all([
-      got.post(origin),
-      got.post(origin),
-    ])
+    await Promise.all([got.post(origin), got.post(origin)])
 
     expect(gotRequest).to.have.been.calledTwice()
 

--- a/tests/got/test_recorder.js
+++ b/tests/got/test_recorder.js
@@ -126,7 +126,7 @@ describe('Recorder', () => {
     nock.recorder.clear()
     expect(nock.recorder.play()).to.be.empty()
 
-    const { origin, port } = await servers.startHttpServer(
+    const { origin } = await servers.startHttpServer(
       (request, response) => {
         gotRequest()
         response.writeHead(200)


### PR DESCRIPTION
closes #2836 
### Root cause
We unintentionally created a listener for each request instead of a single listener for all requests. As a result, `mswjs/interceptors` invoked the same listener multiple times with the same `response` object. Then, we attempted to read its body twice and encountered the error. 

### Solution

We use `listener.on` instead of `listener.once`. Also, I removed the unnecessary `request` listener.
Regarding the coverage, this is a small difference, and I plan to fix it back to 100% in my `cleanup` branch