### PR TITLE
Update readme examples for removeInterceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1308,6 +1308,8 @@ Examples:
 nock.removeInterceptor({
   hostname: 'localhost',
   path: '/mockedResource',
+  // method defaults to `GET`
+  // proto defaullts to `http`
 })
 ```
 


### PR DESCRIPTION
Examples for `removeInterceptor` can be read ambiguously, as if not defining params makes them work for all types of those params, when the code is written to instead default. https://github.com/nock/nock/blob/26fb02550dbd303f51da39655400cbe5b037d8d3/lib/intercept.js#L224