### PR TITLE
Fix invalid `if` condition in `OverriddenClientRequest` when `interceptors` is made empty

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -283,7 +283,7 @@ function overrideClientRequest() {
     //  Filter the interceptors per request options.
     const interceptors = interceptorsFor(options)
 
-    if (isOn() && interceptors) {
+    if (isOn() && interceptors && interceptors.length > 0) {
       debug('using', interceptors.length, 'interceptors')
 
       //  Use filtered interceptors to intercept requests.


### PR DESCRIPTION
I experienced invalid behaviour when recordings were made, with some later removed using `removeInterceptors`.

When this happens, the filtered interceptors are an empty array, which in javascript this is considered truthy.

This causes the interceptor to still trigger a "No match for request" error.