### PR TITLE
fix(ClientRequest): requests with 'Expect: 100-continue' pass through

### DIFF
--- a/lib/interceptors/builtin.js
+++ b/lib/interceptors/builtin.js
@@ -24,6 +24,10 @@ function activate() {
     controller.errorWith(error)
   })
   interceptor.on('request', async function ({ request, controller }) {
+    if (request.headers.get('expect') === '100-continue') {
+      // We currently does not support mocked 100-continue response, so let it pass through for now.
+      return
+    }
     const rawRequest = getRawRequest(request)
 
     // If this is GET request with body, we need to read the body from the socket because Fetch API doesn't support this.

--- a/tests/got/test_intercept.js
+++ b/tests/got/test_intercept.js
@@ -9,6 +9,7 @@ const nock = require('../..')
 const got = require('./got_client')
 const { text } = require('node:stream/consumers')
 const { getDecompressedGetBody } = require('../../lib/utils/node')
+const { startHttpServer } = require('../servers')
 
 const acceptableGlobalKeys = new Set([
   ...Object.keys(global),
@@ -923,7 +924,7 @@ describe('Intercept', () => {
           headers: {},
         },
         res => {
-          res.on('data', () => {})
+          res.on('data', () => { })
           res.once('end', () => {
             scope.done()
             done()
@@ -953,7 +954,7 @@ describe('Intercept', () => {
     https
       .request({ hostname: 'example.test' }, res => {
         expect(res.statusCode).to.equal(200)
-        res.on('data', () => {})
+        res.on('data', () => { })
         res.on('end', () => {
           scope1.done()
           done()
@@ -991,7 +992,7 @@ describe('Intercept', () => {
 
   it('with filteringScope, URL path without leading slash does not throw error', done => {
     expect(() =>
-      nock('http://example.test', { filteringScope: () => {} }).get(''),
+      nock('http://example.test', { filteringScope: () => { } }).get(''),
     ).not.to.throw()
     done()
   })
@@ -1109,5 +1110,33 @@ describe('Intercept', () => {
         expect.fail(error)
         done()
       })
+  })
+
+
+  // We don't support yet in mocked 100-continue requests, so currently we just make sure it pass through.
+  it('Request with `Expect: 100-continue` pass through', async () => {
+    const { origin } = await startHttpServer((request, response) => {
+      request.pipe(response)
+    })
+    const exampleRequestBody = 'this is the full request body'
+    const continueListener = sinon.spy()
+
+    const req = http.request(origin, {
+      method: 'POST',
+      headers: { Expect: '100-continue' },
+    })
+
+    req.on('continue', () => {
+      continueListener()
+      req.end(exampleRequestBody)
+    })
+
+    const { resolve, promise } = Promise.withResolvers()
+    req.on('response', res => {
+      expect(res.statusCode).to.equal(200)
+      resolve()
+    })
+
+    await promise
   })
 })


### PR DESCRIPTION
should fix https://github.com/nock/nock/issues/2876

Currently, we do not support mocking 100-continue requests (hopefully, we will have this feature [soon](https://github.com/mswjs/interceptors/pull/599)). However, since it is not very common, we will at least unblock users by passing through all 100-continue requests.