### PR TITLE
fix: address timeout issue with mocked timers

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -22,6 +22,10 @@ overrides:
       mocha: true
     rules:
       mocha/no-exclusive-tests: 'error'
+  - files:
+      - 'tests_jest/**/*.js'
+    globals:
+      jest: true
 
 rules:
   # TODO These are included in standard and should be cleaned up and turned on.

--- a/README.md
+++ b/README.md
@@ -1618,8 +1618,8 @@ It does this by manipulating the modules cache of Node in a way that conflicts w
 
 ### Jest
 
-To use Nock in conjunction with Jest fake timers, make sure you're using the "async" functions when advacing the timers,
-such as `jest.advanceTimersByTime()` or `jest.runAllTimers()`.
+To use Nock in conjunction with Jest fake timers, make sure you're using the "async" functions when advancing the timers,
+such as `jest.advanceTimersByTimeAsync()` or `jest.runAllTimersAsync()`.
 Otherwise, the timers will not be advanced correctly and you'll experience a timeout in your tests.
 
 ```js
@@ -1647,6 +1647,13 @@ test('should mock a request with fake timers', async () => {
   jest.useRealTimers() // Restore real timers after the test
   scope.done()
 })
+```
+
+In case you don't need testing delays, you can instruct jest to advance the timers automatically using the
+`advanceTimers` option
+
+```js
+jest.useFakeTimers({ advanceTimers: true })
 ```
 
 ### Sinon
@@ -1678,6 +1685,13 @@ it('should us sinon timers', async () => {
   clock.restore()
   scope.done()
 })
+```
+
+Same applies for sinon, if you don't need testing delays, you can instruct sinon to advance the timers automatically
+using the `shouldAdvanceTimers` option
+
+```js
+clock = sinon.useFakeTimers({ shouldAdvanceTimers: true })
 ```
 
 ## Debugging

--- a/README.md
+++ b/README.md
@@ -1623,10 +1623,9 @@ such as `jest.advanceTimersByTime()` or `jest.runAllTimers()`.
 Otherwise, the timers will not be advanced correctly and you'll experience a timeout in your tests.
 
 ```js
-
 test('should mock a request with fake timers', async () => {
   jest.useFakeTimers()
-  
+
   const scope = nock('https://example.com')
     .get('/path')
     .delay(1000)
@@ -1636,10 +1635,10 @@ test('should mock a request with fake timers', async () => {
   const promise = got('https://example.com/path')
 
   // Fast-forward time
-  jest.advanceTimersByTimeAsync(1000)
-  
+  await jest.advanceTimersByTimeAsync(1000)
+
   // Or advance all timers
-  jest.runAllTimersAsync()
+  await jest.runAllTimersAsync()
 
   // Wait for the request to complete
   const response = await promise
@@ -1680,7 +1679,6 @@ it('should us sinon timers', async () => {
   scope.done()
 })
 ```
-
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -1688,10 +1688,10 @@ it('should us sinon timers', async () => {
 ```
 
 Same applies for `sinon`, if you don't need testing delays, you can instruct `sinon` to advance the timers automatically
-using the `shouldAdvanceTimer` option
+using the `shouldAdvanceTime` option
 
 ```js
-clock = sinon.useFakeTimers({ shouldAdvanceTimer: true })
+clock = sinon.useFakeTimers({ shouldAdvanceTime: true })
 ```
 
 ## Debugging

--- a/README.md
+++ b/README.md
@@ -1618,9 +1618,9 @@ It does this by manipulating the modules cache of Node in a way that conflicts w
 
 ### Jest
 
-To use Nock in conjunction with Jest fake timers, make sure you're using the "async" functions when advancing the timers,
-such as `jest.advanceTimersByTimeAsync()` or `jest.runAllTimersAsync()`.
-Otherwise, the timers will not be advanced correctly and you'll experience a timeout in your tests.
+To use `nock` in conjunction with `jest` fake timers, make sure you're using the "async" functions when advancing the
+timers, such as `jest.advanceTimersByTimeAsync()` or `jest.runAllTimersAsync()`. Otherwise, the timers will not be
+advanced correctly and you'll experience a timeout in your tests.
 
 ```js
 test('should mock a request with fake timers', async () => {
@@ -1632,7 +1632,7 @@ test('should mock a request with fake timers', async () => {
     .reply(200, 'response')
 
   // Simulate a request
-  const promise = got('https://example.com/path')
+  const request = got('https://example.com/path')
 
   // Fast-forward time
   await jest.advanceTimersByTimeAsync(1000)
@@ -1641,7 +1641,7 @@ test('should mock a request with fake timers', async () => {
   await jest.runAllTimersAsync()
 
   // Wait for the request to complete
-  const response = await promise
+  const response = await request
 
   expect(response.body).toBe('response')
   jest.useRealTimers() // Restore real timers after the test
@@ -1649,7 +1649,7 @@ test('should mock a request with fake timers', async () => {
 })
 ```
 
-In case you don't need testing delays, you can instruct jest to advance the timers automatically using the
+In case you don't need testing delays, you can instruct `jest` to advance the timers automatically using the
 `advanceTimers` option
 
 ```js
@@ -1658,7 +1658,7 @@ jest.useFakeTimers({ advanceTimers: true })
 
 ### Sinon
 
-In a similar way to Jest, if you are using Sinon fake timers, you should use the `clock.tickAsync()` or
+In a similar way to `jest`, if you are using `sinon` fake timers, you should use the `clock.tickAsync()` or
 `clock.runAllAsync()` methods to advance the timers correctly.
 
 ```js
@@ -1670,7 +1670,7 @@ it('should us sinon timers', async () => {
     .reply(200, 'response')
 
   // Simulate a request
-  const promise = got('https://example.com/path')
+  const request = got('https://example.com/path')
 
   // Fast-forward time
   await clock.tickAsync(1000)
@@ -1679,7 +1679,7 @@ it('should us sinon timers', async () => {
   await clock.runAllAsync()
 
   // Wait for the request to complete
-  const response = await promise
+  const response = await request
 
   expect(response.body).toBe('response')
   clock.restore()
@@ -1687,11 +1687,11 @@ it('should us sinon timers', async () => {
 })
 ```
 
-Same applies for sinon, if you don't need testing delays, you can instruct sinon to advance the timers automatically
-using the `shouldAdvanceTimers` option
+Same applies for `sinon`, if you don't need testing delays, you can instruct `sinon` to advance the timers automatically
+using the `shouldAdvanceTimer` option
 
 ```js
-clock = sinon.useFakeTimers({ shouldAdvanceTimers: true })
+clock = sinon.useFakeTimers({ shouldAdvanceTimer: true })
 ```
 
 ## Debugging

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { common: debug } = require('./debug')
-const timers = require('timers')
 const url = require('url')
 const util = require('util')
 const http = require('http')
@@ -521,24 +520,36 @@ function deepEqual(expected, actual) {
 const timeouts = new Set()
 const immediates = new Set()
 
-const wrapTimer =
-  (timer, ids) =>
-  (callback, ...timerArgs) => {
-    const cb = (...callbackArgs) => {
-      try {
-        // eslint-disable-next-line n/no-callback-literal
-        callback(...callbackArgs)
-      } finally {
-        ids.delete(id)
-      }
+const _setImmediate = (callback, ...timerArgs) => {
+  const cb = (...callbackArgs) => {
+    try {
+      // eslint-disable-next-line n/no-callback-literal
+      callback(...callbackArgs)
+    } finally {
+      immediates.delete(id)
     }
-    const id = timer(cb, ...timerArgs)
-    ids.add(id)
-    return id
   }
 
-const setTimeout = wrapTimer(timers.setTimeout, timeouts)
-const setImmediate = wrapTimer(timers.setImmediate, immediates)
+  const id = setImmediate(cb, 0, ...timerArgs)
+
+  immediates.add(id)
+  return id
+}
+
+const _setTimeout = (callback, ...timerArgs) => {
+  const cb = (...callbackArgs) => {
+    try {
+      // eslint-disable-next-line n/no-callback-literal
+      callback(...callbackArgs)
+    } finally {
+      timeouts.delete(id)
+    }
+  }
+
+  const id = setTimeout(cb, ...timerArgs)
+  timeouts.add(id)
+  return id
+}
 
 function clearTimer(clear, ids) {
   ids.forEach(clear)
@@ -714,8 +725,8 @@ module.exports = {
   percentDecode,
   percentEncode,
   removeAllTimers,
-  setImmediate,
-  setTimeout,
+  setImmediate: _setImmediate,
+  setTimeout: _setTimeout,
   stringifyRequest,
   convertFetchRequestToClientRequest,
 }

--- a/lib/common.js
+++ b/lib/common.js
@@ -4,7 +4,6 @@ const { common: debug } = require('./debug')
 const url = require('url')
 const util = require('util')
 const http = require('http')
-const timers = require('timers')
 
 /**
  * Normalizes the request options so that it always has `host` property.
@@ -531,7 +530,7 @@ const _setImmediate = (callback, ...timerArgs) => {
     }
   }
 
-  const id = timers.setImmediate(cb, 0, ...timerArgs)
+  const id = setImmediate(cb, 0, ...timerArgs)
 
   immediates.add(id)
   return id
@@ -547,7 +546,7 @@ const _setTimeout = (callback, ...timerArgs) => {
     }
   }
 
-  const id = timers.setTimeout(cb, ...timerArgs)
+  const id = setTimeout(cb, ...timerArgs)
   timeouts.add(id)
   return id
 }

--- a/lib/common.js
+++ b/lib/common.js
@@ -4,6 +4,7 @@ const { common: debug } = require('./debug')
 const url = require('url')
 const util = require('util')
 const http = require('http')
+const timers = require('timers')
 
 /**
  * Normalizes the request options so that it always has `host` property.
@@ -530,7 +531,7 @@ const _setImmediate = (callback, ...timerArgs) => {
     }
   }
 
-  const id = setImmediate(cb, 0, ...timerArgs)
+  const id = timers.setImmediate(cb, 0, ...timerArgs)
 
   immediates.add(id)
   return id
@@ -546,7 +547,7 @@ const _setTimeout = (callback, ...timerArgs) => {
     }
   }
 
-  const id = setTimeout(cb, ...timerArgs)
+  const id = timers.setTimeout(cb, ...timerArgs)
   timeouts.add(id)
   return id
 }

--- a/tests/got/test_fake_timer.js
+++ b/tests/got/test_fake_timer.js
@@ -11,9 +11,9 @@ it('should still return successfully when fake timer is enabled', async () => {
 
   const promise = got('http://example.test')
 
-  await clock.runAllAsync(); // Run all fake timers to ensure all scheduled tasks are executed
+  await clock.runAllAsync() // Run all fake timers to ensure all scheduled tasks are executed
 
-  await promise;
+  await promise
 
   clock.uninstall()
   scope.done()

--- a/tests/got/test_fake_timer.js
+++ b/tests/got/test_fake_timer.js
@@ -9,7 +9,11 @@ it('should still return successfully when fake timer is enabled', async () => {
   const clock = fakeTimers.install()
   const scope = nock('http://example.test').get('/').reply()
 
-  await got('http://example.test')
+  const promise = got('http://example.test')
+
+  await clock.runAllAsync(); // Run all fake timers to ensure all scheduled tasks are executed
+
+  await promise;
 
   clock.uninstall()
   scope.done()

--- a/tests/got/test_reply_headers.js
+++ b/tests/got/test_reply_headers.js
@@ -427,7 +427,7 @@ describe('`replyDate()`', () => {
       const scope = nock('http://example.test').replyDate().get('/').reply()
 
       const req = got('http://example.test/')
-      clock.tick()
+      await clock.runAllAsync()
       const { headers } = await req
       const date = new Date()
       expect(headers).to.include({ date: date.toUTCString() })

--- a/tests/test_fake_timers.js
+++ b/tests/test_fake_timers.js
@@ -10,7 +10,7 @@ describe('test fake timers (sinon)', () => {
   let scope
   let clock
 
-  describe('sinon', () => {
+  describe('using timers to test delays', () => {
     beforeEach(() => {
       clock = sinon.useFakeTimers()
 

--- a/tests/test_fake_timers.js
+++ b/tests/test_fake_timers.js
@@ -1,0 +1,77 @@
+'use strict'
+
+const sinon = require('sinon')
+const { expect } = require('chai')
+const nock = require('..')
+
+describe('test fake timers (sinon)', () => {
+  const url = 'https://api.example.com'
+
+  describe('sinon', () => {
+    let scope
+    let clock
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers()
+
+      scope = nock(url)
+        .get('/api/v1/resource')
+        .times(3)
+        .reply(
+          429,
+          { message: 'Too many requests' },
+          { 'content-type': 'application/json' },
+        )
+        .get('/api/v1/resource')
+        .reply(
+          200,
+          { message: 'Success' },
+          { 'content-type': 'application/json' },
+        )
+    })
+
+    afterEach(() => {
+      clock.restore()
+      nock.cleanAll()
+    })
+
+    it('should use fake timers', async () => {
+      const fetch = createRetryFetch({ retries: 3, delay: 100 })
+
+      const p = fetch(new URL('/api/v1/resource', url))
+
+      await clock.tickAsync(100) // first request
+      await clock.tickAsync(100) // first retry
+      await clock.tickAsync(100) // second retry
+      await clock.tickAsync(100) // third retry
+
+      const response = await p.then(response => response.json())
+
+      expect(response).to.be.deep.equal({ message: 'Success' })
+
+      scope.done()
+    })
+  })
+})
+
+function createRetryFetch(options = {}) {
+  const { retries = 3, delay = 100 } = options
+
+  return async function fetchWithRetry(url, fetchOptions = {}) {
+    let currentAttempt = 0
+
+    while (currentAttempt <= retries) {
+      const response = await fetch(url, fetchOptions)
+
+      if (!response.ok) {
+        await new Promise(resolve => setTimeout(resolve, delay))
+        currentAttempt++
+        continue
+      }
+
+      return response // Success or non-retryable error
+    }
+
+    throw new Error('Fetch request failed after multiple retries.')
+  }
+}

--- a/tests/test_fake_timers.js
+++ b/tests/test_fake_timers.js
@@ -33,19 +33,20 @@ describe('test fake timers (sinon)', () => {
     afterEach(() => {
       clock.restore()
       nock.cleanAll()
+      nock.restore()
     })
 
     it('should use fake timers', async () => {
       const fetch = createRetryFetch({ retries: 3, delay: 100 })
 
-      const p = fetch(new URL('/api/v1/resource', url))
+      const promise = fetch(new URL('/api/v1/resource', url))
 
       await clock.tickAsync(100) // first request
       await clock.tickAsync(100) // first retry
       await clock.tickAsync(100) // second retry
       await clock.tickAsync(100) // third retry
 
-      const response = await p.then(response => response.json())
+      const response = await promise.then(response => response.json())
 
       expect(response).to.be.deep.equal({ message: 'Success' })
 

--- a/tests_jest/test_fake_timers.spec.js
+++ b/tests_jest/test_fake_timers.spec.js
@@ -1,6 +1,12 @@
 'use strict'
 
-const { describe, it, beforeEach, afterEach, afterAll } = require('@jest/globals')
+const {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  afterAll,
+} = require('@jest/globals')
 const { expect } = require('chai')
 const nock = require('..')
 
@@ -8,7 +14,7 @@ describe('test fake timers (jest)', () => {
   const url = 'https://api.example.com'
 
   afterAll(() => {
-    nock.restore();
+    nock.restore()
   })
 
   describe('using timers to test delays', () => {
@@ -48,8 +54,7 @@ describe('test fake timers (jest)', () => {
       await jest.runAllTimersAsync() // second retry
       await jest.runAllTimersAsync() // third retry
 
-      const response = await request.then(async response => response.json());
-
+      const response = await request.then(async response => response.json())
 
       expect(response).to.be.deep.equal({ message: 'Success' })
 

--- a/tests_jest/test_fake_timers.spec.js
+++ b/tests_jest/test_fake_timers.spec.js
@@ -1,0 +1,75 @@
+'use strict'
+
+const { expect } = require('chai')
+const nock = require('..')
+
+describe('test fake timers (jest)', () => {
+  const url = 'https://api.example.com'
+
+  describe('jest', () => {
+    let scope
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+
+      scope = nock(url)
+        .get('/api/v1/resource')
+        .delay(1000)
+        .reply(
+          429,
+          { message: 'Too many requests' },
+          { 'content-type': 'application/json' },
+        )
+        .get('/api/v1/resource')
+        .reply(
+          200,
+          { message: 'Success' },
+          { 'content-type': 'application/json' },
+        )
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+      nock.cleanAll()
+    })
+
+    it('should use fake timers', async () => {
+      const fetch = createRetryFetch({ retries: 3, delay: 100 })
+
+      const request = fetch(new URL('/api/v1/resource', url))
+
+      await jest.runAllTimersAsync() // first request
+      await jest.runAllTimersAsync() // first retry
+      await jest.runAllTimersAsync() // second retry
+      await jest.runAllTimersAsync() // third retry
+
+      const response = await request.then(response => response.json())
+
+      expect(response).to.be.deep.equal({ message: 'Success' })
+
+      scope.done()
+    })
+  })
+})
+
+function createRetryFetch(options = {}) {
+  const { retries = 3, delay = 100 } = options
+
+  return async function fetchWithRetry(url, fetchOptions = {}) {
+    let currentAttempt = 0
+
+    while (currentAttempt <= retries) {
+      const response = await fetch(url, fetchOptions)
+
+      if (!response.ok) {
+        await new Promise(resolve => setTimeout(resolve, delay))
+        currentAttempt++
+        continue
+      }
+
+      return response // Success or non-retryable error
+    }
+
+    throw new Error('Fetch request failed after multiple retries.')
+  }
+}

--- a/tests_jest/test_fake_timers.spec.js
+++ b/tests_jest/test_fake_timers.spec.js
@@ -1,10 +1,15 @@
 'use strict'
 
+const { describe, it, beforeEach, afterEach, afterAll } = require('@jest/globals')
 const { expect } = require('chai')
 const nock = require('..')
 
 describe('test fake timers (jest)', () => {
   const url = 'https://api.example.com'
+
+  afterAll(() => {
+    nock.restore();
+  })
 
   describe('using timers to test delays', () => {
     let scope
@@ -29,9 +34,8 @@ describe('test fake timers (jest)', () => {
     })
 
     afterEach(() => {
-      jest.useRealTimers()
       nock.cleanAll()
-      nock.restore()
+      jest.useRealTimers()
     })
 
     it('correctly trigger the timers', async () => {
@@ -44,7 +48,8 @@ describe('test fake timers (jest)', () => {
       await jest.runAllTimersAsync() // second retry
       await jest.runAllTimersAsync() // third retry
 
-      const response = await request.then(response => response.json())
+      const response = await request.then(async response => response.json());
+
 
       expect(response).to.be.deep.equal({ message: 'Success' })
 
@@ -68,9 +73,8 @@ describe('test fake timers (jest)', () => {
     })
 
     afterEach(() => {
-      jest.useRealTimers()
       nock.cleanAll()
-      nock.restore()
+      jest.useRealTimers()
     })
 
     it('should use fake timers', async () => {

--- a/tests_jest/test_fake_timers.spec.js
+++ b/tests_jest/test_fake_timers.spec.js
@@ -10,7 +10,7 @@ describe('test fake timers (jest)', () => {
     let scope
 
     beforeEach(() => {
-      jest.useFakeTimers();
+      jest.useFakeTimers()
 
       scope = nock(url)
         .get('/api/v1/resource')
@@ -31,6 +31,7 @@ describe('test fake timers (jest)', () => {
     afterEach(() => {
       jest.useRealTimers()
       nock.cleanAll()
+      nock.restore()
     })
 
     it('should use fake timers', async () => {


### PR DESCRIPTION
Make it work with `sinon` and `jest` fake timers. Fixes #2200

Importing `timers` instead of using the global ones would still not work for `jest`