### PR TITLE
make interceptors if statements explicitly check for undefined

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -283,7 +283,7 @@ function overrideClientRequest() {
     //  Filter the interceptors per request options.
     const interceptors = interceptorsFor(options)
 
-    if (isOn() && interceptors) {
+    if (isOn() && interceptors !== undefined) {
       debug('using', interceptors.length, 'interceptors')
 
       //  Use filtered interceptors to intercept requests.
@@ -387,7 +387,7 @@ function activate() {
       options.proto = options.protocol.slice(0, -1)
       options.method = request.method
       const interceptors = interceptorsFor(options)
-      if (isOn() && interceptors) {
+      if (isOn() && interceptors !== undefined) {
         const matches = interceptors.some(interceptor =>
           interceptor.matchOrigin(options),
         )


### PR DESCRIPTION
If the understandings in #2859 are incorrect, this PR makes it clear that the intention of the code here is not to check if there are any interceptors, but instead if the function returned undefined.