### PR TITLE
types, test: Use Error objects instead of plain objects with replyWithError()

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,13 +462,14 @@ nock('http://www.google.com')
   .replyWithError('something awful happened')
 ```
 
-JSON error responses are allowed too:
+Error objects are allowed too:
 
 ```js
-nock('http://www.google.com').get('/cat-poems').replyWithError({
-  message: 'something awful happened',
-  code: 'AWFUL_ERROR',
-})
+nock('http://www.google.com')
+  .get('/cat-poems')
+  .replyWithError(
+    Object.assign(new Error('Connection refused'), { code: 'ECONNREFUSED' })
+  )
 ```
 
 > Note: This will emit an `error` event on the `request` object, not the reply.

--- a/tests/test_reply_with_error.js
+++ b/tests/test_reply_with_error.js
@@ -31,10 +31,14 @@ describe('`replyWithError()`', () => {
   })
 
   // TODO: https://github.com/mswjs/interceptors/issues/625
-  it.skip('allows json response', done => {
+  it.skip('allows an Error response', done => {
     const scope = nock('http://example.test')
       .post('/echo')
-      .replyWithError({ message: 'Service not found', code: 'test' })
+      .replyWithError(
+        Object.assign(new Error('Connection refused'), {
+          code: 'ECONNREFUSED',
+        }),
+      )
 
     const req = http.request({
       host: 'example.test',
@@ -45,8 +49,8 @@ describe('`replyWithError()`', () => {
 
     req.on('error', e => {
       expect(e).to.deep.equal({
-        message: 'Service not found',
-        code: 'test',
+        message: 'Connection refused',
+        code: 'ECONNREFUSED',
       })
       scope.done()
       done()

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -370,7 +370,9 @@ nock('http://example.test')
 
 nock('http://example.test')
   .get('/cat-poems')
-  .replyWithError({ message: 'something awful happened', code: 'AWFUL_ERROR' })
+  .replyWithError(
+    Object.assign(new Error('Connection refused'), { code: 'ECONNREFUSED' }),
+  )
 
 nock('http://example.test')
   .get('/cat-poems')


### PR DESCRIPTION
Includes #2899
