### PR TITLE
feat: add no match reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1354,10 +1354,14 @@ You can also listen for no match events like this:
 ```js
 nock.emitter.on('no match', (req, interceptorResults) => {
   console.log('Request did not match any interceptors:', req.url)
-  
+
   if (interceptorResults && interceptorResults.length > 0) {
     interceptorResults.forEach(({ interceptor, reasons }) => {
-      console.log('Interceptor:', interceptor.method, interceptor.basePath + interceptor.path)
+      console.log(
+        'Interceptor:',
+        interceptor.method,
+        interceptor.basePath + interceptor.path,
+      )
       console.log('Reasons:', reasons)
     })
   }
@@ -1365,14 +1369,17 @@ nock.emitter.on('no match', (req, interceptorResults) => {
 ```
 
 The callback receives two parameters:
+
 - `req` - The request object that didn't match
 - `interceptorResults` - An array of objects containing detailed information about each interceptor that was tested
 
 Each interceptor result object contains:
+
 - `interceptor` - The interceptor that was tested against the request
 - `reasons` - An array of strings describing why the request didn't match this interceptor
 
 Common mismatch reasons include:
+
 - **Method mismatch**: `"Method mismatch: expected GET, got POST"`
 - **Path mismatch**: `"Path mismatch: expected /api/users, got /api/posts"`
 - **Header mismatch**: `"Header mismatch: expected authorization to match Bearer token, got null"`

--- a/README.md
+++ b/README.md
@@ -1371,12 +1371,11 @@ nock.emitter.on('no match', (req, interceptorResults) => {
 The callback receives two parameters:
 
 - `req` - The request object that didn't match
-- `interceptorResults` - An array of objects containing detailed information about each interceptor that was tested
-
-Each interceptor result object contains:
-
-- `interceptor` - The interceptor that was tested against the request
-- `reasons` - An array of strings describing why the request didn't match this interceptor
+- `interceptorResults` - An array of objects containing detailed information about each interceptor that was tested.
+  Each object contains:
+  - `interceptor` - The interceptor that was tested against the request
+  - `reasons` - An array of strings describing why the request didn't match this interceptor
+    > ⚠️ **Experimental**: The structure and format of the detailed mismatch information may change in future versions as we gather user feedback and refine the API. The feature itself is stable and ready for use and we're seeking community input on the API design before marking it stable.
 
 Common mismatch reasons include:
 

--- a/README.md
+++ b/README.md
@@ -1352,8 +1352,32 @@ A scope emits the following events:
 You can also listen for no match events like this:
 
 ```js
-nock.emitter.on('no match', req => {})
+nock.emitter.on('no match', (req, interceptorResults) => {
+  console.log('Request did not match any interceptors:', req.url)
+  
+  if (interceptorResults && interceptorResults.length > 0) {
+    interceptorResults.forEach(({ interceptor, reasons }) => {
+      console.log('Interceptor:', interceptor.method, interceptor.basePath + interceptor.path)
+      console.log('Reasons:', reasons)
+    })
+  }
+})
 ```
+
+The callback receives two parameters:
+- `req` - The request object that didn't match
+- `interceptorResults` - An array of objects containing detailed information about each interceptor that was tested
+
+Each interceptor result object contains:
+- `interceptor` - The interceptor that was tested against the request
+- `reasons` - An array of strings describing why the request didn't match this interceptor
+
+Common mismatch reasons include:
+- **Method mismatch**: `"Method mismatch: expected GET, got POST"`
+- **Path mismatch**: `"Path mismatch: expected /api/users, got /api/posts"`
+- **Header mismatch**: `"Header mismatch: expected authorization to match Bearer token, got null"`
+- **Body mismatch**: `"Body mismatch: expected "expected body", got actual body"`
+- **Query mismatch**: `"query matching failed"`
 
 ## Nock Back
 

--- a/lib/handle-request.js
+++ b/lib/handle-request.js
@@ -34,9 +34,16 @@ async function handleRequest(request) {
         requestBodyIsUtf8Representable ? 'utf8' : 'hex',
       )
 
-      const matchedInterceptor = interceptors.find(i =>
-        i.match(request, requestBodyString),
-      )
+      const matchResults = []
+      const matchedInterceptor = interceptors.find(i => {
+        const reasons = i.match(request, requestBodyString)
+        if (reasons.length > 0) {
+          matchResults.push({ interceptor: i, reasons })
+          return false
+        } else {
+          return true
+        }
+      })
 
       if (matchedInterceptor) {
         matchedInterceptor.scope.logger(
@@ -54,7 +61,7 @@ async function handleRequest(request) {
 
         return response
       } else {
-        globalEmitter.emit('no match', request)
+        globalEmitter.emit('no match', request, matchResults.sort((a, b) => a.reasons.length - b.reasons.length))
 
         // Try to find a hostname match that allows unmocked.
         const allowUnmocked = interceptors.some(

--- a/lib/handle-request.js
+++ b/lib/handle-request.js
@@ -61,7 +61,11 @@ async function handleRequest(request) {
 
         return response
       } else {
-        globalEmitter.emit('no match', request, matchResults.sort((a, b) => a.reasons.length - b.reasons.length))
+        globalEmitter.emit(
+          'no match',
+          request,
+          matchResults.sort((a, b) => a.reasons.length - b.reasons.length),
+        )
 
         // Try to find a hostname match that allows unmocked.
         const allowUnmocked = interceptors.some(

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -254,7 +254,10 @@ module.exports = class Interceptor {
       }
     }
 
-    for (const header of [...this.scope.matchHeaders, ...this.interceptorMatchHeaders]) {
+    for (const header of [
+      ...this.scope.matchHeaders,
+      ...this.interceptorMatchHeaders,
+    ]) {
       if (!requestMatchesFilter(header)) {
         const msg = `Header mismatch: expected ${header.name} to match ${header.value}, got ${request.headers.get(header.name)}`
         this.scope.logger(msg)
@@ -324,14 +327,12 @@ module.exports = class Interceptor {
       matchKey = common.normalizeOrigin(url)
     }
 
-
     if (!common.matchStringOrRegexp(matchKey, this.basePath)) {
       const msg = `Base path mismatch: expected ${this.basePath}, got ${matchKey}`
       this.scope.logger(msg)
       mismatches.push(msg)
     }
 
-    
     if (typeof this.uri === 'function') {
       if (!this.uri.call(this, path)) {
         const msg = `Path function mismatch: expected function to return true for ${path}`
@@ -349,7 +350,6 @@ module.exports = class Interceptor {
         body = this.scope.transformRequestBodyFunction(body, this._requestBody)
       }
 
-      
       if (!matchBody(request, this._requestBody, body)) {
         const msg = `Body mismatch: expected ${stringify(this._requestBody)}, got ${body}`
         this.scope.logger(msg)

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -224,21 +224,21 @@ module.exports = class Interceptor {
   /**
    * @param {Request} request
    * @param {string} body - string or hex
+   * @returns {string[]}
    */
   match(request, body) {
     const url = new URL(request.url)
     // TODO: fix request log to string
     this.scope.logger('attempting match %j, body = %j', request, body)
 
+    const mismatches = []
     let path = url.pathname + url.search
-    let matches
     let matchKey
 
     if (this.method !== request.method) {
-      this.scope.logger(
-        `Method did not match. Request ${request.method} Interceptor ${this.method}`,
-      )
-      return false
+      const msg = `Method mismatch: expected ${this.method}, got ${request.method}`
+      this.scope.logger(msg)
+      mismatches.push(msg)
     }
 
     if (this.scope.transformPathFunction) {
@@ -254,12 +254,12 @@ module.exports = class Interceptor {
       }
     }
 
-    if (
-      !this.scope.matchHeaders.every(requestMatchesFilter) ||
-      !this.interceptorMatchHeaders.every(requestMatchesFilter)
-    ) {
-      this.scope.logger("headers don't match")
-      return false
+    for (const header of [...this.scope.matchHeaders, ...this.interceptorMatchHeaders]) {
+      if (!requestMatchesFilter(header)) {
+        const msg = `Header mismatch: expected ${header.name} to match ${header.value}, got ${request.headers.get(header.name)}`
+        this.scope.logger(msg)
+        mismatches.push(msg)
+      }
     }
 
     const reqHeadersMatch = Object.keys(this.reqheaders).every(key =>
@@ -271,18 +271,18 @@ module.exports = class Interceptor {
     )
 
     if (!reqHeadersMatch) {
-      this.scope.logger("headers don't match")
-      return false
+      const msg = "Request headers don't match"
+      this.scope.logger(msg)
+      mismatches.push(msg)
     }
 
     if (
       this.scope.scopeOptions.conditionally &&
       !this.scope.scopeOptions.conditionally()
     ) {
-      this.scope.logger(
-        'matching failed because Scope.conditionally() did not validate',
-      )
-      return false
+      const msg = 'conditionally() did not validate'
+      this.scope.logger(msg)
+      mismatches.push(msg)
     }
 
     const badHeaders = this.badheaders.filter(header =>
@@ -290,8 +290,9 @@ module.exports = class Interceptor {
     )
 
     if (badHeaders.length) {
-      this.scope.logger('request contains bad headers', ...badHeaders)
-      return false
+      const msg = `Request contains bad headers: ${badHeaders.join(', ')}`
+      this.scope.logger(msg)
+      mismatches.push(msg)
     }
 
     // Match query strings when using query()
@@ -302,12 +303,10 @@ module.exports = class Interceptor {
       const [pathname, search] = path.split('?')
       const matchQueries = this.matchQuery({ search })
 
-      this.scope.logger(
-        matchQueries ? 'query matching succeeded' : 'query matching failed',
-      )
-
       if (!matchQueries) {
-        return false
+        const msg = 'query matching failed'
+        this.scope.logger(msg)
+        mismatches.push(msg)
       }
 
       // If the query string was explicitly checked then subsequent checks against
@@ -325,37 +324,40 @@ module.exports = class Interceptor {
       matchKey = common.normalizeOrigin(url)
     }
 
-    if (typeof this.uri === 'function') {
-      matches =
-        common.matchStringOrRegexp(matchKey, this.basePath) &&
-        // This is a false positive, as `uri` is not bound to `this`.
 
-        this.uri.call(this, path)
-    } else {
-      matches =
-        common.matchStringOrRegexp(matchKey, this.basePath) &&
-        common.matchStringOrRegexp(path, this.path)
+    if (!common.matchStringOrRegexp(matchKey, this.basePath)) {
+      const msg = `Base path mismatch: expected ${this.basePath}, got ${matchKey}`
+      this.scope.logger(msg)
+      mismatches.push(msg)
     }
 
-    this.scope.logger(`matching ${matchKey}${path} to ${this._key}: ${matches}`)
+    
+    if (typeof this.uri === 'function') {
+      if (!this.uri.call(this, path)) {
+        const msg = `Path function mismatch: expected function to return true for ${path}`
+        this.scope.logger(msg)
+        mismatches.push(msg)
+      }
+    } else if (!common.matchStringOrRegexp(path, this.path)) {
+      const msg = `Path mismatch: expected ${this.path}, got ${path}`
+      this.scope.logger(msg)
+      mismatches.push(msg)
+    }
 
-    if (matches && this._requestBody !== undefined) {
+    if (this._requestBody !== undefined) {
       if (this.scope.transformRequestBodyFunction) {
         body = this.scope.transformRequestBodyFunction(body, this._requestBody)
       }
 
-      matches = matchBody(request, this._requestBody, body)
-      if (!matches) {
-        this.scope.logger(
-          "bodies don't match: \n",
-          this._requestBody,
-          '\n',
-          body,
-        )
+      
+      if (!matchBody(request, this._requestBody, body)) {
+        const msg = `Body mismatch: expected ${stringify(this._requestBody)}, got ${body}`
+        this.scope.logger(msg)
+        mismatches.push(msg)
       }
     }
 
-    return matches
+    return mismatches
   }
 
   /**

--- a/tests/got/test_events.js
+++ b/tests/got/test_events.js
@@ -98,7 +98,9 @@ describe('no match event', () => {
         expect(new URL(req.url).pathname).to.equal('/definitelymaybe')
         expect(mismatches).to.have.lengthOf(1)
         expect(mismatches[0].interceptor).to.equal(interceptor)
-        expect(mismatches[0].reasons).to.deep.equal(['Path mismatch: expected /, got /definitelymaybe'])
+        expect(mismatches[0].reasons).to.deep.equal([
+          'Path mismatch: expected /, got /definitelymaybe',
+        ])
         done()
       })
 
@@ -106,14 +108,16 @@ describe('no match event', () => {
     })
 
     it('emits no match because of path function mismatch', done => {
-      const pathFunction = (path) => path.includes('expected')
+      const pathFunction = path => path.includes('expected')
       const interceptor = nock('http://example.test').get(pathFunction)
       interceptor.reply(200)
 
       nock.emitter.on('no match', (req, mismatches) => {
         expect(mismatches).to.have.lengthOf(1)
         expect(mismatches[0].interceptor).to.equal(interceptor)
-        expect(mismatches[0].reasons).to.deep.equal(['Path function mismatch: expected function to return true for /something'])
+        expect(mismatches[0].reasons).to.deep.equal([
+          'Path function mismatch: expected function to return true for /something',
+        ])
         done()
       })
 
@@ -127,34 +131,37 @@ describe('no match event', () => {
       nock.emitter.on('no match', (req, mismatches) => {
         expect(mismatches).to.have.lengthOf(1)
         expect(mismatches[0].interceptor).to.equal(interceptor)
-        expect(mismatches[0].reasons).to.deep.equal(['Method mismatch: expected GET, got POST'])
+        expect(mismatches[0].reasons).to.deep.equal([
+          'Method mismatch: expected GET, got POST',
+        ])
         done()
       })
 
       const postReq = http.request({
         hostname: 'example.test',
         path: '/',
-        method: 'POST'
+        method: 'POST',
       })
       postReq.end()
     })
 
     it('emits no match because of body mismatch', done => {
-      const interceptor = nock('http://example.test')
-        .post('/', 'expected body')
+      const interceptor = nock('http://example.test').post('/', 'expected body')
       interceptor.reply(200)
 
       nock.emitter.on('no match', (req, mismatches) => {
         expect(mismatches).to.have.lengthOf(1)
         expect(mismatches[0].interceptor).to.equal(interceptor)
-        expect(mismatches[0].reasons).to.deep.equal(['Body mismatch: expected "expected body", got actual body'])
+        expect(mismatches[0].reasons).to.deep.equal([
+          'Body mismatch: expected "expected body", got actual body',
+        ])
         done()
       })
 
       const postReq = http.request({
         hostname: 'example.test',
         path: '/',
-        method: 'POST'
+        method: 'POST',
       })
       postReq.on('error', ignore)
       postReq.write('actual body')
@@ -189,7 +196,7 @@ describe('no match event', () => {
         expect(mismatches[0].interceptor).to.equal(interceptor)
         expect(mismatches[0].reasons).to.deep.equal([
           'Header mismatch: expected x-scope to match test-scope, got null',
-          'Header mismatch: expected x-interceptor to match test-interceptor, got null'
+          'Header mismatch: expected x-interceptor to match test-interceptor, got null',
         ])
         done()
       })
@@ -200,8 +207,8 @@ describe('no match event', () => {
     it('emits no match because of request headers mismatch', done => {
       const scope = nock('http://example.test', {
         reqheaders: {
-          'x-required': 'value'
-        }
+          'x-required': 'value',
+        },
       })
       const interceptor = scope.get('/')
       interceptor.reply(200)
@@ -209,7 +216,9 @@ describe('no match event', () => {
       nock.emitter.on('no match', (req, mismatches) => {
         expect(mismatches).to.have.lengthOf(1)
         expect(mismatches[0].interceptor).to.equal(interceptor)
-        expect(mismatches[0].reasons).to.deep.equal(["Request headers don't match"])
+        expect(mismatches[0].reasons).to.deep.equal([
+          "Request headers don't match",
+        ])
         done()
       })
 
@@ -218,7 +227,7 @@ describe('no match event', () => {
 
     it('emits no match because of bad headers', done => {
       const scope = nock('http://example.test', {
-        badheaders: ['x-forbidden']
+        badheaders: ['x-forbidden'],
       })
       const interceptor = scope.get('/')
       interceptor.reply(200)
@@ -226,7 +235,9 @@ describe('no match event', () => {
       nock.emitter.on('no match', (req, mismatches) => {
         expect(mismatches).to.have.lengthOf(1)
         expect(mismatches[0].interceptor).to.equal(interceptor)
-        expect(mismatches[0].reasons).to.deep.equal(['Request contains bad headers: x-forbidden'])
+        expect(mismatches[0].reasons).to.deep.equal([
+          'Request contains bad headers: x-forbidden',
+        ])
         done()
       })
 
@@ -235,8 +246,8 @@ describe('no match event', () => {
         path: '/',
         method: 'GET',
         headers: {
-          'x-forbidden': 'should not be here'
-        }
+          'x-forbidden': 'should not be here',
+        },
       })
       req.on('error', ignore)
       req.end()
@@ -244,7 +255,7 @@ describe('no match event', () => {
 
     it('emits no match because conditionally() failed', done => {
       const scope = nock('http://example.test', {
-        conditionally: () => false
+        conditionally: () => false,
       })
       const interceptor = scope.get('/')
       interceptor.reply(200)
@@ -252,13 +263,15 @@ describe('no match event', () => {
       nock.emitter.on('no match', (req, mismatches) => {
         expect(mismatches).to.have.lengthOf(1)
         expect(mismatches[0].interceptor).to.equal(interceptor)
-        expect(mismatches[0].reasons).to.deep.equal(['conditionally() did not validate'])
+        expect(mismatches[0].reasons).to.deep.equal([
+          'conditionally() did not validate',
+        ])
         done()
       })
 
       http.get('http://example.test/').once('error', ignore)
     })
-  });
+  })
 
   it('emits no match when netConnect is disabled', done => {
     nock.disableNetConnect()
@@ -270,4 +283,4 @@ describe('no match event', () => {
 
     http.get('http://example.test').once('error', ignore)
   })
-});
+})

--- a/tests/got/test_events.js
+++ b/tests/got/test_events.js
@@ -80,32 +80,194 @@ it('emits request and replied events when response body is a stream', async () =
   expect(onReplied).to.have.been.calledOnce()
 })
 
-it('emits no match when no match and no mock', done => {
-  nock.emitter.once('no match', () => {
-    done()
+describe('no match event', () => {
+  it('emits no match when no match and no mock', done => {
+    nock.emitter.once('no match', () => {
+      done()
+    })
+
+    http.get('http://example.test/abc').once('error', ignore)
   })
 
-  http.get('http://example.test/abc').once('error', ignore)
-})
+  describe('mocked requests', () => {
+    it('emits no match because of path mismatch', done => {
+      const interceptor = nock('http://example.test').get('/')
+      interceptor.reply(418)
 
-it('emits no match when no match and mocked', done => {
-  nock('http://example.test').get('/').reply(418)
+      nock.emitter.on('no match', (req, mismatches) => {
+        expect(new URL(req.url).pathname).to.equal('/definitelymaybe')
+        expect(mismatches).to.have.lengthOf(1)
+        expect(mismatches[0].interceptor).to.equal(interceptor)
+        expect(mismatches[0].reasons).to.deep.equal(['Path mismatch: expected /, got /definitelymaybe'])
+        done()
+      })
 
-  nock.emitter.on('no match', req => {
-    expect(new URL(req.url).pathname).to.equal('/definitelymaybe')
-    done()
+      http.get('http://example.test/definitelymaybe')
+    })
+
+    it('emits no match because of path function mismatch', done => {
+      const pathFunction = (path) => path.includes('expected')
+      const interceptor = nock('http://example.test').get(pathFunction)
+      interceptor.reply(200)
+
+      nock.emitter.on('no match', (req, mismatches) => {
+        expect(mismatches).to.have.lengthOf(1)
+        expect(mismatches[0].interceptor).to.equal(interceptor)
+        expect(mismatches[0].reasons).to.deep.equal(['Path function mismatch: expected function to return true for /something'])
+        done()
+      })
+
+      http.get('http://example.test/something').once('error', ignore)
+    })
+
+    it('emits no match because of method mismatch', done => {
+      const interceptor = nock('http://example.test').get('/')
+      interceptor.reply(200)
+
+      nock.emitter.on('no match', (req, mismatches) => {
+        expect(mismatches).to.have.lengthOf(1)
+        expect(mismatches[0].interceptor).to.equal(interceptor)
+        expect(mismatches[0].reasons).to.deep.equal(['Method mismatch: expected GET, got POST'])
+        done()
+      })
+
+      const postReq = http.request({
+        hostname: 'example.test',
+        path: '/',
+        method: 'POST'
+      })
+      postReq.end()
+    })
+
+    it('emits no match because of body mismatch', done => {
+      const interceptor = nock('http://example.test')
+        .post('/', 'expected body')
+      interceptor.reply(200)
+
+      nock.emitter.on('no match', (req, mismatches) => {
+        expect(mismatches).to.have.lengthOf(1)
+        expect(mismatches[0].interceptor).to.equal(interceptor)
+        expect(mismatches[0].reasons).to.deep.equal(['Body mismatch: expected "expected body", got actual body'])
+        done()
+      })
+
+      const postReq = http.request({
+        hostname: 'example.test',
+        path: '/',
+        method: 'POST'
+      })
+      postReq.on('error', ignore)
+      postReq.write('actual body')
+      postReq.end()
+    })
+
+    it('emits no match because of query mismatch', done => {
+      const interceptor = nock('http://example.test')
+        .get('/')
+        .query({ foo: 'bar' })
+      interceptor.reply(200)
+
+      nock.emitter.on('no match', (req, mismatches) => {
+        expect(mismatches).to.have.lengthOf(1)
+        expect(mismatches[0].interceptor).to.equal(interceptor)
+        expect(mismatches[0].reasons).to.deep.equal(['query matching failed'])
+        done()
+      })
+
+      http.get('http://example.test/?foo=baz').once('error', ignore)
+    })
+
+    it('emits no match because of header mismatch', done => {
+      const interceptor = nock('http://example.test')
+        .matchHeader('x-scope', 'test-scope')
+        .get('/')
+        .matchHeader('x-interceptor', 'test-interceptor')
+      interceptor.reply(200)
+
+      nock.emitter.on('no match', (req, mismatches) => {
+        expect(mismatches).to.have.lengthOf(1)
+        expect(mismatches[0].interceptor).to.equal(interceptor)
+        expect(mismatches[0].reasons).to.deep.equal([
+          'Header mismatch: expected x-scope to match test-scope, got null',
+          'Header mismatch: expected x-interceptor to match test-interceptor, got null'
+        ])
+        done()
+      })
+
+      http.get('http://example.test/').once('error', ignore)
+    })
+
+    it('emits no match because of request headers mismatch', done => {
+      const scope = nock('http://example.test', {
+        reqheaders: {
+          'x-required': 'value'
+        }
+      })
+      const interceptor = scope.get('/')
+      interceptor.reply(200)
+
+      nock.emitter.on('no match', (req, mismatches) => {
+        expect(mismatches).to.have.lengthOf(1)
+        expect(mismatches[0].interceptor).to.equal(interceptor)
+        expect(mismatches[0].reasons).to.deep.equal(["Request headers don't match"])
+        done()
+      })
+
+      http.get('http://example.test/').once('error', ignore)
+    })
+
+    it('emits no match because of bad headers', done => {
+      const scope = nock('http://example.test', {
+        badheaders: ['x-forbidden']
+      })
+      const interceptor = scope.get('/')
+      interceptor.reply(200)
+
+      nock.emitter.on('no match', (req, mismatches) => {
+        expect(mismatches).to.have.lengthOf(1)
+        expect(mismatches[0].interceptor).to.equal(interceptor)
+        expect(mismatches[0].reasons).to.deep.equal(['Request contains bad headers: x-forbidden'])
+        done()
+      })
+
+      const req = http.request({
+        hostname: 'example.test',
+        path: '/',
+        method: 'GET',
+        headers: {
+          'x-forbidden': 'should not be here'
+        }
+      })
+      req.on('error', ignore)
+      req.end()
+    })
+
+    it('emits no match because conditionally() failed', done => {
+      const scope = nock('http://example.test', {
+        conditionally: () => false
+      })
+      const interceptor = scope.get('/')
+      interceptor.reply(200)
+
+      nock.emitter.on('no match', (req, mismatches) => {
+        expect(mismatches).to.have.lengthOf(1)
+        expect(mismatches[0].interceptor).to.equal(interceptor)
+        expect(mismatches[0].reasons).to.deep.equal(['conditionally() did not validate'])
+        done()
+      })
+
+      http.get('http://example.test/').once('error', ignore)
+    })
+  });
+
+  it('emits no match when netConnect is disabled', done => {
+    nock.disableNetConnect()
+
+    nock.emitter.on('no match', req => {
+      expect(new URL(req.url).hostname).to.equal('example.test')
+      done()
+    })
+
+    http.get('http://example.test').once('error', ignore)
   })
-
-  http.get('http://example.test/definitelymaybe').once('error', ignore)
-})
-
-it('emits no match when netConnect is disabled', done => {
-  nock.disableNetConnect()
-
-  nock.emitter.on('no match', req => {
-    expect(new URL(req.url).hostname).to.equal('example.test')
-    done()
-  })
-
-  http.get('http://example.test').once('error', ignore)
-})
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -32,7 +32,7 @@ declare namespace nock {
   function abortPendingRequests(): void
 
   let back: Back
-  let emitter: NodeJS.EventEmitter
+  let emitter: NockEmitter
   let recorder: Recorder
 
   type InterceptFunction = (
@@ -86,6 +86,42 @@ declare namespace nock {
     | readonly [StatusCode]
     | readonly [StatusCode, ReplyBody]
     | readonly [StatusCode, ReplyBody, ReplyHeaders]
+
+  /**
+   * Detailed mismatch information for the 'no match' event
+   * @experimental This interface may change in future versions based on community feedback.
+   */
+  interface InterceptorMatchResult {
+    interceptor: Interceptor
+    reasons: string[]
+  }
+
+  /**
+   * Enhanced global emitter with typed 'no match' event
+   */
+  interface NockEmitter extends NodeJS.EventEmitter {
+    on(event: 'no match', listener: (req: Request) => void): this
+    on(
+      event: 'no match',
+      listener: (
+        req: Request,
+        interceptorResults?: InterceptorMatchResult[],
+      ) => void,
+    ): this
+    once(event: 'no match', listener: (req: Request) => void): this
+    once(
+      event: 'no match',
+      listener: (
+        req: Request,
+        interceptorResults?: InterceptorMatchResult[],
+      ) => void,
+    ): this
+    emit(
+      event: 'no match',
+      req: Request,
+      interceptorResults?: InterceptorMatchResult[],
+    ): boolean
+  }
 
   interface Scope extends NodeJS.EventEmitter {
     get: InterceptFunction

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -721,6 +721,30 @@ nock.removeInterceptor(interceptor)
 /// Global no match event
 nock.emitter.on('no match', (req: Request) => {})
 
+nock.emitter.on(
+  'no match',
+  (req: Request, interceptorResults?: nock.InterceptorMatchResult[]) => {
+    if (interceptorResults) {
+      interceptorResults.forEach(result => {
+        const interceptor: nock.Interceptor = result.interceptor
+        const reasons: string[] = result.reasons
+      })
+    }
+  },
+)
+
+nock.emitter.once(
+  'no match',
+  (req: Request, interceptorResults?: nock.InterceptorMatchResult[]) => {
+    // Type checking for optional second parameter
+  },
+)
+
+// Type checking: interceptorResults should be optional
+nock.emitter.on('no match', (req: Request) => {
+  // This should still work (backward compatibility)
+})
+
 // Nock Back
 /// Setup
 nock.back.fixtures = '/path/to/fixtures/'


### PR DESCRIPTION
https://github.com/nock/nock/issues/1413

Add reasons argument for `no match` event

```js
nock.emitter.on('no match', (req, interceptorResults) => {
  console.log('Request did not match any interceptors:', req.url)
  
  if (interceptorResults && interceptorResults.length > 0) {
    interceptorResults.forEach(({ interceptor, reasons }) => {
      console.log('Interceptor:', interceptor.method, interceptor.basePath + interceptor.path)
      console.log('Reasons:', reasons)
    })
  }
})
```

The callback receives two parameters:
- `req` - The request object that didn't match
- `interceptorResults` - An array of objects containing detailed information about each interceptor that was tested

Each interceptor result object contains:
- `interceptor` - The interceptor that was tested against the request
- `reasons` - An array of strings describing why the request didn't match this interceptor

Common mismatch reasons include:
- **Method mismatch**: `"Method mismatch: expected GET, got POST"`
- **Path mismatch**: `"Path mismatch: expected /api/users, got /api/posts"`
- **Header mismatch**: `"Header mismatch: expected authorization to match Bearer token, got null"`
- **Body mismatch**: `"Body mismatch: expected "expected body", got actual body"`
- **Query mismatch**: `"query matching failed"`

----

I'm wondering if the reasons array should be object instead of strings:
```
['Path mismatch: expected /, got /api/users']
vs
[
  {
    type: 'path',
    message: 'Path mismatch: expected /, got /api/users',
    expected: '/',
    actual: '/api/users'
  }
]
```