### PR TITLE
fix: prevent crash when query params have conflicting dot-notation keys

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -682,6 +682,8 @@ const expand = input => {
           } else {
             resultPtr[part] = {}
           }
+        } else if (typeof resultPtr[part] !== 'object') {
+          return undefined
         }
         resultPtr = resultPtr[part]
       }

--- a/tests/got/test_query_complex.js
+++ b/tests/got/test_query_complex.js
@@ -111,6 +111,15 @@ describe('`query()` complex encoding', () => {
     scope.done()
   })
 
+  it('does not throw on unbalanced dot-notation query params', async () => {
+    const scope = nock('http://example.test')
+      .get('/path')
+      .query({ parent: 'value', 'parent.1': 'first' })
+      .reply(200)
+    await got('http://example.test/path?parent=value&parent.1=first')
+    scope.done()
+  })
+
   it('query with array and regexp', async () => {
     // In Node 10.x this can be updated:
     // const exampleQuery = new URLSearchParams([

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -629,4 +629,8 @@ describe('`expand()`', () => {
     expect(original).deep.equal({ 'foo[bar][0]': 'baz' })
     expect(original).not.equal(result)
   })
+
+  it('returns undefined when a key conflicts with an already-set primitive value', () => {
+    expect(expand({ parent: 'value', 'parent.1': 'first' })).equal(undefined)
+  })
 })


### PR DESCRIPTION
Fixes #2893.

When a query string contains params like `parent=value&parent.1=first`, the `expand()` function in `common.js` would crash with `Cannot assign to read only property '1' of string 'value'`. This happened because `expand()` first set `parent` to the string `'value'`, then tried to traverse into it as an object when processing the `parent.1` key.

The fix adds a check before descending into an intermediate path segment: if the existing value is a non-null primitive (not an object or array), return `undefined` — the same sentinel value already used when a blocklisted key is encountered. `dataEqual` then compares both sides as `undefined`, which causes them to match correctly when both the intercepted URL and the nock scope have the same unbalanced query params.