### PR TITLE
fix: Handle AbortSignal in playback interceptor

### DIFF
--- a/lib/playback_interceptor.js
+++ b/lib/playback_interceptor.js
@@ -293,7 +293,7 @@ function playbackInterceptor({
     const { delayBodyInMs, delayConnectionInMs } = interceptor
 
     function respond() {
-      if (common.isRequestDestroyed(req)) {
+      if ((options.signal && options.signal.aborted) || common.isRequestDestroyed(req)) {
         return
       }
 
@@ -318,7 +318,7 @@ function playbackInterceptor({
   // correct events are emitted first ('socket', 'finish') and any aborts in the queue or
   // called during a 'finish' listener can be called.
   common.setImmediate(() => {
-    if (!common.isRequestDestroyed(req)) {
+    if (!(options.signal && options.signal.aborted) && !common.isRequestDestroyed(req)) {
       start()
     }
   })


### PR DESCRIPTION
## Summary

This commit fixes an issue where requests aborted via AbortSignal were not handled correctly, causing an InterceptorError. The playback interceptor now checks if the signal has been aborted before attempting to send a response. This prevents trying to respond to a request that has already been terminated by the underlying interceptor library.

## Changes

- **lib/playback_interceptor.js**: Added checks for `options.signal.aborted` before starting playback and before sending the response. This prevents Nock from attempting to respond to a request that has been cancelled via an `AbortSignal`, which fixes an `InterceptorError` caused by an updated dependency.

## Related Issue

Closes #2949

