### PR TITLE
fix(backport): apply body delay before the response end

### DIFF
--- a/lib/playback_interceptor.js
+++ b/lib/playback_interceptor.js
@@ -273,22 +273,27 @@ function playbackInterceptor({
   function continueWithResponseBody(rawBody) {
     prepareResponseHeaders(rawBody)
     const bodyAsStream = convertBodyToStream(rawBody)
-    bodyAsStream.pause()
+    // `replyWithFile` and similar reply callbacks hand back a paused stream,
+    // so force flowing mode here. `delayBody` gates only the end-of-response
+    // signal below; a slow body must present as a slow body — read timeouts
+    // on the response can fire — instead of as a slow connection.
+    bodyAsStream.resume()
 
     // IncomingMessage extends Readable so we can't simply pipe.
     bodyAsStream.on('data', function (chunk) {
       response.push(chunk)
     })
-    bodyAsStream.on('end', function () {
+    bodyAsStream.on('error', function (err) {
+      response.emit('error', err)
+    })
+
+    function emitEnd() {
       // https://nodejs.org/dist/latest-v10.x/docs/api/http.html#http_message_complete
       response.complete = true
       response.push(null)
 
       interceptor.scope.emit('replied', req, interceptor)
-    })
-    bodyAsStream.on('error', function (err) {
-      response.emit('error', err)
-    })
+    }
 
     const { delayBodyInMs, delayConnectionInMs } = interceptor
 
@@ -306,7 +311,17 @@ function playbackInterceptor({
       logger('emitting response')
       req.emit('response', response)
 
-      common.setTimeout(() => bodyAsStream.resume(), delayBodyInMs)
+      // Apply the body delay only after the response event has been emitted
+      // and the body source has finished, so `delay({ head, body })`
+      // compounds the two waits.
+      function scheduleEnd() {
+        common.setTimeout(emitEnd, delayBodyInMs)
+      }
+      if (bodyAsStream.readableEnded) {
+        scheduleEnd()
+      } else {
+        bodyAsStream.once('end', scheduleEnd)
+      }
     }
 
     socket.applyDelay(delayConnectionInMs)

--- a/tests/got/test_delay.js
+++ b/tests/got/test_delay.js
@@ -95,22 +95,27 @@ describe('`delay()`', () => {
     http.get('http://example.test', res => {
       checkDuration(start, 200)
 
-      res.once('data', function (data) {
+      let data = ''
+      res.on('data', chunk => {
+        data += chunk
+      })
+      res.once('end', () => {
         checkDuration(start, 500)
-        expect(data.toString()).to.equal('OK')
-        res.once('end', done)
+        expect(data).to.equal('OK')
+        done()
       })
     })
   })
 })
 
 describe('`delayBody()`', () => {
-  it('should delay the clock between the `response` event and the first `data` event', done => {
+  it('should delay the clock between the `response` event and the response `end` event', done => {
     nock('http://example.test').get('/').delayBody(200).reply(201, 'OK')
 
-    const start = process.hrtime()
     http.get('http://example.test', res => {
-      res.once('data', () => {
+      const start = process.hrtime()
+      res.on('data', () => {})
+      res.once('end', () => {
         checkDuration(start, 200)
         done()
       })


### PR DESCRIPTION
This fixes a regression where `delayBody(N)` no longer makes a body look slow to the caller. Read timeouts on the response stream are expected to fire when N exceeds them, but in v14 the @mswjs/interceptors-based pipeline drains the response body before delivering the response event. Pausing the body source (the v13 mechanism) ended up delaying the *whole* response — response, data, and end events all moved to `+delayBodyInMs`, indistinguishable from a slow connection.

Two coordinated pieces fix it:

1. `lib/playback_interceptor.js`: drop the pause/resume mechanism and gate only the end-of-response push (`response.push(null)`) on `delayBodyInMs`. Schedule that gate inside `respond()` so `delay({ head, body })` continues to compound — head defers the response event, body then defers the end signal by an additional `body` ms. Reply callbacks like `replyWithFile` hand back an explicitly-paused `fs.createReadStream`, so call `bodyAsStream.resume()` to ensure the body flows.
2. `tests/got/test_delay.js`: the two tests that asserted timing on the first `data` event are updated to assert on the `end` event, matching the new (and intended) semantics.

Refs: https://github.com/nock/nock/pull/2867
Fixes: https://github.com/nock/nock/issues/2863