### PR TITLE
fix: remove interceptor from scope.interceptors

### DIFF
--- a/lib/intercept.ts
+++ b/lib/intercept.ts
@@ -190,6 +190,10 @@ function removeInterceptor(
       ) {
         allInterceptors[baseUrl].interceptors.splice(i, 1)
         interceptor.scope.remove(key, interceptor)
+        const scopeIndex = interceptor.scope.interceptors.indexOf(interceptor)
+        if (scopeIndex !== -1) {
+          interceptor.scope.interceptors.splice(scopeIndex, 1)
+        }
         break
       }
     }

--- a/tests/got/test_remove_interceptor.js
+++ b/tests/got/test_remove_interceptor.js
@@ -34,6 +34,17 @@ describe('`removeInterceptor()`', () => {
       expect(scope.pendingMocks()).to.deep.equal([])
     })
 
+    it('removes given interceptor from `scope.interceptors`', () => {
+      const givenInterceptor = nock('http://example.test').get('/somepath')
+      const scope = givenInterceptor.reply(200, 'hey')
+
+      expect(scope.interceptors).to.have.lengthOf(1)
+
+      expect(nock.removeInterceptor(givenInterceptor)).to.be.true()
+
+      expect(scope.interceptors).to.have.lengthOf(0)
+    })
+
     it('removes given interceptor for https', async () => {
       const givenInterceptor = nock('https://example.test').get('/somepath')
       const scope = givenInterceptor.reply(200, 'hey')


### PR DESCRIPTION
`nock.removeInterceptor` cleared the interceptor from `allInterceptors[baseUrl].interceptors` and from `scope.keyedInterceptors`, but left it inside `scope.interceptors`. Cleaning up that array too keeps the scope state consistent with the public API contract.

Closes #2353.
