### PR TITLE
Add example for setting custom status message in reply

### DIFF
--- a/examples/custom-status-message.js
+++ b/examples/custom-status-message.js
@@ -1,0 +1,24 @@
+const http = require('http')
+const nock = require('../')
+
+nock('http://example.com')
+  .get('/teapot')
+  .reply(418, function () {
+    this.req.response.statusMessage = "I'm a Teapot"
+    return 'short and stout'
+  })
+
+const req = http.get('http://example.com/teapot', res => {
+  console.log('Status Code:', res.statusCode)
+  console.log('Status Message:', res.statusMessage)
+
+  let body = ''
+  res.on('data', chunk => {
+    body += chunk
+  })
+  res.on('end', () => {
+    console.log('Body:', body)
+  })
+})
+
+req.on('error', console.error)


### PR DESCRIPTION
Per the request in #1979, this adds an example showing how to set a custom HTTP status message when defining a nock reply.

The example uses a callback function in the reply to access `this.req.response.statusMessage` and set it to a custom value (everyone's favorite 418 teapot).

To try it:
```
node examples/custom-status-message.js
# Output:
# Status Code: 418
# Status Message: I'm a Teapot
# Body: short and stout
```