### PR TITLE
fix: guard against AbortSignal-aborted requests in response handler

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -398,6 +398,13 @@ function activate() {
           globalEmitter.emit('no match', nockRequest)
         } else {
           nockRequest.on('response', nockResponse => {
+            // Guard against the case where the AbortSignal fired before nock
+            // finished building the response. In that scenario the interceptor
+            // has already transitioned the request to an error state and calling
+            // controller.respondWith() would throw an InterceptorError.
+            if (mswRequest.signal.aborted) {
+              return
+            }
             const response = createResponse(nockResponse, mswRequest.signal)
             controller.respondWith(response)
           })

--- a/tests/test_abort_signal.js
+++ b/tests/test_abort_signal.js
@@ -174,4 +174,34 @@ describe('When `AbortSignal` is used', () => {
       })
       .catch(error => done(error))
   })
+
+  it('does not throw when AbortSignal timeout fires before the mocked response is delivered', async () => {
+    // Regression test for https://github.com/nock/nock/issues/2949.
+    //
+    // The @mswjs/interceptors upgrade in v14.0.11 changed AbortSignal handling:
+    // a timed-out request transitions to readyState ERROR immediately when the
+    // signal fires. When nock's response-ready callback ran after that
+    // transition it would call controller.respondWith() on an already-errored
+    // request and throw an uncaught InterceptorError
+    // ("the request has already been handled").
+    //
+    // Use a 50 ms reply delay with a 1 ms signal timeout so the signal is
+    // guaranteed to fire well before nock delivers the response, ensuring the
+    // guard in the response callback is exercised.
+    const signal = AbortSignal.timeout(1)
+    const scope = nock('http://example.test')
+      .get('/')
+      .delay(50) // fires after the signal has already aborted
+      .reply(200, 'OK')
+
+    const error = await makeRequest('http://example.test/', {
+      signal,
+    }).catch(error => error)
+
+    // The request must abort cleanly — no unhandled InterceptorError
+    expect(error).to.have.property('name', 'AbortError')
+    expect(error).to.have.property('code', 'ABORT_ERR')
+
+    scope.done()
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #2949.

When a request's `AbortSignal` fires, `@mswjs/interceptors` immediately transitions the request to an error state (readyState 3). If nock has a reply delay configured, the response callback can fire *after* that transition — calling `controller.respondWith()` at that point throws:

```
InterceptorError: Failed to respond to the "GET https://example.com/" request
with "200 OK": the request has already been handled (3)
```

This regression was introduced in v14.0.11 when `@mswjs/interceptors` was upgraded to fix a memory leak (#2938). The older version silently swallowed the error; the new one throws.

## Fix

Added a `signal.aborted` check before `controller.respondWith()` in the response callback inside `lib/intercept.js`. If the signal has already fired by the time the callback runs, we return early — the interceptor has already handled the abort.

## Test

Added a regression test in `tests/test_abort_signal.js` using a 50 ms reply delay with a 1 ms `AbortSignal.timeout`. The signal fires well before nock delivers the response, exercising the new guard. Without the fix this causes an unhandled `InterceptorError`; with it the request aborts cleanly.