### PR TITLE
fix: handle mixed nested query keys

### DIFF
--- a/lib/common.ts
+++ b/lib/common.ts
@@ -467,6 +467,8 @@ const expand = (input: Record<string, any> | null | undefined) => {
           } else {
             resultPtr[part] = {}
           }
+        } else if (typeof resultPtr[part] !== 'object') {
+          return input
         }
         resultPtr = resultPtr[part]
       }

--- a/tests/got/test_query_complex.js
+++ b/tests/got/test_query_complex.js
@@ -109,6 +109,22 @@ describe('`query()` complex encoding', () => {
     scope.done()
   })
 
+  it('query with mixed scalar and bracketed object keys', async () => {
+    const scope = nock('http://example.test')
+      .get('/test')
+      .query({
+        include: 'record-labels,artists',
+        'include[music-videos]': 'artists',
+      })
+      .reply()
+
+    await got(
+      'http://example.test/test?include=record-labels,artists&include[music-videos]=artists',
+    )
+
+    scope.done()
+  })
+
   it('query with array and regexp', async () => {
     // In Node 10.x this can be updated:
     // const exampleQuery = new URLSearchParams([

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -462,6 +462,20 @@ describe('`dataEqual()`', () => {
     expect(result).to.equal(true)
   })
 
+  it('treats mixed scalar and nested query keys as literal keys', () => {
+    const result = common.dataEqual(
+      { include: 'record-labels,artists', 'include[music-videos]': 'artists' },
+      { include: 'record-labels,artists', 'include[music-videos]': 'artists' },
+    )
+    expect(result).to.equal(true)
+
+    const dottedResult = common.dataEqual(
+      { q: 'foo', 'q.something': 'bar' },
+      { q: 'foo', 'q.something': 'bar' },
+    )
+    expect(dottedResult).to.equal(true)
+  })
+
   it('does not equate arrays of different length', () => {
     const result = common.dataEqual(['a'], ['a', 'b'])
     expect(result).to.equal(false)


### PR DESCRIPTION
Fixes #2541.

This keeps query matching from throwing when a query string contains both a scalar parent key and a bracket/dot child key, such as:

`include=record-labels,artists&include[music-videos]=artists`

`expand()` now treats that ambiguous mixed shape as literal query keys instead of trying to descend into the existing scalar value. That preserves matching for identical flat query objects while keeping the existing JSON-path expansion behavior for unambiguous nested keys.

Tests added:

- `dataEqual()` regression for bracketed and dotted mixed scalar/nested keys
- request-level `query()` regression for the Apple Music-style query string from the issue

Local verification:

- `npx mocha --recursive tests/test_common.js --grep 'dataEqual'`
- `npx mocha --recursive tests/got/test_query_complex.js --grep 'mixed scalar'`
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:build`
- `git diff --check`