### PR TITLE
feat: add statusMessage support to .reply()

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -140,6 +140,20 @@ module.exports = class Interceptor {
       ...this.options,
     }
 
+    // Extract statusMessage from headers if provided, so it's not treated as a header
+    if (
+      rawHeaders &&
+      typeof rawHeaders === 'object' &&
+      !Array.isArray(rawHeaders) &&
+      'statusMessage' in rawHeaders
+    ) {
+      this.statusMessage = rawHeaders.statusMessage
+      rawHeaders = { ...rawHeaders }
+      delete rawHeaders.statusMessage
+    } else {
+      this.statusMessage = null
+    }
+
     this.rawHeaders = common.headersInputToRawArray(rawHeaders)
 
     if (this.scope.date) {

--- a/lib/playback_interceptor.js
+++ b/lib/playback_interceptor.js
@@ -33,14 +33,27 @@ function parseFullReplyResult(response, fullReplyResult) {
     )
   }
 
-  const [status, body = '', headers] = fullReplyResult
+  let [status, body = '', responseHeaders] = fullReplyResult
 
   if (!Number.isInteger(status)) {
     throw new Error(`Invalid ${typeof status} value for status code`)
   }
 
   response.statusCode = status
-  response.rawHeaders.push(...common.headersInputToRawArray(headers))
+
+  // Extract statusMessage from headers if provided
+  if (
+    responseHeaders &&
+    typeof responseHeaders === 'object' &&
+    !Array.isArray(responseHeaders) &&
+    'statusMessage' in responseHeaders
+  ) {
+    response.statusMessage = responseHeaders.statusMessage
+    responseHeaders = { ...responseHeaders }
+    delete responseHeaders.statusMessage
+  }
+
+  response.rawHeaders.push(...common.headersInputToRawArray(responseHeaders))
   debug('response.rawHeaders after reply: %j', response.rawHeaders)
 
   return body
@@ -144,6 +157,10 @@ function playbackInterceptor({
     // This will be null if we have a fullReplyFunction,
     // in that case status code will be set in `parseFullReplyResult`
     response.statusCode = interceptor.statusCode
+
+    if (interceptor.statusMessage) {
+      response.statusMessage = interceptor.statusMessage
+    }
 
     // Clone headers/rawHeaders to not override them when evaluating later
     response.rawHeaders = [...interceptor.rawHeaders]


### PR DESCRIPTION
Allows passing `statusMessage` in the headers object of `.reply()` to set a custom HTTP status message on the response.

Usage:
```js
nock('http://example.com')
  .get('/')
  .reply(200, 'body', { statusMessage: 'Custom', 'Content-Type': 'text/plain' })
```

Also supported in callback-style reply functions:
```js
nock('http://example.com')
  .get('/')
  .reply(() => [200, 'body', { statusMessage: 'From Callback' }])
```

The statusMessage is stripped from headers before being passed to the response so it's not included as an actual HTTP header.

Closes #1979