### PR TITLE
fix: correct typos in source and test files

### DIFF
--- a/lib/back.js
+++ b/lib/back.js
@@ -322,15 +322,15 @@ function assertScopes(scopes, fixture) {
 }
 
 const Modes = {
-  wild, // all requests go out to the internet, dont replay anything, doesnt record anything
+  wild, // all requests go out to the internet, don't replay anything, doesn't record anything
 
-  dryrun, // use recorded nocks, allow http calls, doesnt record anything, useful for writing new tests (default)
+  dryrun, // use recorded nocks, allow http calls, doesn't record anything, useful for writing new tests (default)
 
   record, // use recorded nocks, record new nocks
 
   update, // allow http calls, record all nocks, don't use recorded nocks
 
-  lockdown, // use recorded nocks, disables all http calls even when not nocked, doesnt record
+  lockdown, // use recorded nocks, disables all http calls even when not nocked, doesn't record
 }
 
 Back.setMode = function (mode) {

--- a/tests/got/test_allow_unmocked_https.js
+++ b/tests/got/test_allow_unmocked_https.js
@@ -84,7 +84,7 @@ describe('allowUnmocked option (https)', () => {
       .query({ foo: 'bar' })
       .reply(418)
 
-    // no query so wont match the interceptor
+    // no query so won't match the interceptor
     const { statusCode, body } = await got(`${origin}/foo`, {
       https: { certificateAuthority: servers.ca },
     })

--- a/tests/got/test_basic_auth.js
+++ b/tests/got/test_basic_auth.js
@@ -23,7 +23,7 @@ describe('basic auth with username and password', () => {
     expect(response.body).to.equal('Here is the content')
   })
 
-  it('fails when it doesnt match', async () => {
+  it("fails when it doesn't match", async () => {
     await assertRejects(
       got('http://example.test/test'),
       /Nock: No match for request/,
@@ -49,7 +49,7 @@ describe('basic auth with username only', () => {
     expect(response.body).to.equal('Here is the content')
   })
 
-  it('fails when it doesnt match', async () => {
+  it("fails when it doesn't match", async () => {
     await assertRejects(
       got('http://example.test/test'),
       /Nock: No match for request/,

--- a/tests/got/test_intercept.js
+++ b/tests/got/test_intercept.js
@@ -586,7 +586,7 @@ describe('Intercept', () => {
       .end()
   })
 
-  it('explicitly specifiying port 80 works', done => {
+  it('explicitly specifying port 80 works', done => {
     const scope = nock('http://example.test:80').get('/').reply()
 
     http


### PR DESCRIPTION
## Summary

Fixed typos found by `codespell` in JS source and test files:

- `specifiying` → `specifying` in `tests/got/test_intercept.js`
- `doesnt` → `doesn't` in `tests/got/test_basic_auth.js` (2 occurrences in test descriptions)
- `doesnt` → `doesn't` and `dont` → `don't` in `lib/back.js` (3 occurrences in mode comments)
- `wont` → `won't` in `tests/got/test_allow_unmocked_https.js` (comment)

## Test plan

- [ ] No logic changes, only comment and string literal typo fixes
- [ ] Existing tests should pass without modification