### PR TITLE
fix: restore request body when allowing a request to pass through

### DIFF
--- a/lib/interceptors/undici.ts
+++ b/lib/interceptors/undici.ts
@@ -36,6 +36,13 @@ class NockClient extends undici.Client {
           handler.onData?.(Buffer.from(await response.arrayBuffer()))
           handler.onComplete?.([]) // responseTrailers
         } else {
+          // Checking for a match reads the request body. If the body
+          // was a stream, then that leaves `options.body` empty.
+          // Since `decompressedRequest.body` still has a copy of the body,
+          // we can send that instead.
+          if (decompressedRequest.body) {
+            options.body = decompressedRequest.body
+          }
           const dispatcher = options.dispatcher || {
             dispatch: super.dispatch.bind(this),
           }

--- a/tests/test_undici.js
+++ b/tests/test_undici.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai'
+import { Readable } from 'node:stream'
 import undici from 'undici'
 import nock from '../index.ts'
 import { startHttpServer } from './servers/index.js'
@@ -95,5 +96,76 @@ describe('Undici', () => {
 
     const { statusCode } = await undici.request(origin)
     expect(statusCode).to.equal(200)
+  })
+
+  it('passthrough forwards a buffered (Buffer) body', async () => {
+    let receivedBody = ''
+    const { origin } = await startHttpServer((request, response) => {
+      request.on('data', chunk => {
+        receivedBody += chunk
+      })
+      request.on('end', () => {
+        response.writeHead(200)
+        response.end()
+      })
+    })
+
+    const scope = nock(origin).post('/submit').passthrough()
+
+    const { body } = await undici.request(`${origin}/submit`, {
+      method: 'POST',
+      body: Buffer.from('hello'),
+    })
+    await body.dump()
+
+    expect(receivedBody).to.equal('hello')
+    scope.done()
+  })
+
+  it('passthrough forwards a streamed (Readable) body', async () => {
+    let receivedBody = ''
+    const { origin } = await startHttpServer((request, response) => {
+      request.on('data', chunk => {
+        receivedBody += chunk
+      })
+      request.on('end', () => {
+        response.writeHead(200)
+        response.end()
+      })
+    })
+
+    const scope = nock(origin).post('/submit').passthrough()
+
+    const { body } = await undici.request(`${origin}/submit`, {
+      method: 'POST',
+      body: Readable.from(['hello']),
+    })
+    await body.dump()
+
+    expect(receivedBody).to.equal('hello')
+    scope.done()
+  })
+
+  it('passthrough forwards a streamed (fetch) body', async () => {
+    let receivedBody = ''
+    const { origin } = await startHttpServer((request, response) => {
+      request.on('data', chunk => {
+        receivedBody += chunk
+      })
+      request.on('end', () => {
+        response.writeHead(200)
+        response.end()
+      })
+    })
+
+    const scope = nock(origin).post('/submit').passthrough()
+
+    await undici.fetch(`${origin}/submit`, {
+      method: 'POST',
+      body: new URLSearchParams({ hello: 'world' }),
+    })
+
+    expect(receivedBody).to.equal('hello=world')
+    scope.done()
   })
 })


### PR DESCRIPTION
### Problem

When a request that has a body matches a `.passthrough()` interceptor, nock drains the request body's stream while trying to match it, then re-dispatches the request with an empty body. This only occurs for bodies that reach the dispatcher as streams, as opposed to buffered ones. This happens specifically with nock's undici transport—this did not happen with `http`. 

The steps to reproduce are outlined in the regression tests that I added. i.e. 
```ts
let receivedBody = ''
const { origin } = await startHttpServer((request, response) => {
  request.on('data', chunk => {
    receivedBody += chunk
  })
  request.on('end', () => {
    response.writeHead(200)
    response.end()
  })
})

const scope = nock(origin).post('/submit').passthrough()

const { body } = await undici.request(`${origin}/submit`, {
  method: 'POST',
  body: Readable.from(['hello']),
})
```

As a result, receivedBody != 'hello'.

It can fail two ways depending on how the body reaches the dispatcher:

1. a fixed-length body (e.g. `fetch` + `URLSearchParams`, sets `content-length` header) throws `RequestContentLengthMismatchError` and the request never reaches the server.
2. a streamed body with no `content-length` header (e.g. a `Readable`) does not throw an error and the server receives an empty body.

### Root cause

nock wraps the outgoing request in a `new Request(url, { body: options.body })`. When the request body is a stream, the body is **not** copied—the wrapper `Request`'s body record points at the original stream; `options.body` and the wrapper `Request`'s body now share one underlying source.

To match the request against interceptors, nock creates a clone (`handle-request.ts:21`):

```ts
const requestBodyBuffer = await request.clone().arrayBuffer()
```

- request.clone() calls body.tee(), which splits the body into two branches (out1, out2), hands the clone out2, and leaves the original request reading out1.
- .arrayBuffer() reads the clone (out2). tee's single shared reader must pull every chunk out of the underlying source to do this, mirroring each chunk into both branch queues. Thus, the raw source, `options.body`, is emptied during the read.
- However, the wrapper request (`decompressedRequest`) still has a copy because it was given the out1 branch.

Then, the original request is re-dispatched using the original options object:

dispatcher.dispatch(options, handler), where options.body is now drained and causes one of the two failure modes mentioned above.

### Fix

In the passthrough (`else`) branch of `NockClient.dispatch`, re-dispatch the still-intact body branch (`decompressedRequest.body`) instead of the drained source. This reuses a copy nock already made rather than reading the body a second time.

### Tests

Three regression tests in `tests/test_undici.js`:

- **Buffered** (`undici.request` + `Buffer`) — **passes before and after the fix**. — control test proving the bug is stream-specific and guards the working path.
- **Streamed** (`fetch` + `URLSearchParams`) — pre-fix rejects with `RequestContentLengthMismatchError`.
- **Streamed** (`undici.request` + `Readable`) — fails pre-fix: server receives `''`.