### PR TITLE
fix: remove interceptor from scope.interceptors on nock.removeInterceptor

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -236,6 +236,10 @@ function removeInterceptor(options) {
       ) {
         allInterceptors[baseUrl].interceptors.splice(i, 1)
         interceptor.scope.remove(key, interceptor)
+        interceptor.scope.interceptors.splice(
+          interceptor.scope.interceptors.indexOf(interceptor),
+          1,
+        )
         break
       }
     }

--- a/tests/got/test_remove_interceptor.js
+++ b/tests/got/test_remove_interceptor.js
@@ -36,6 +36,15 @@ describe('`removeInterceptor()`', () => {
       expect(scope.pendingMocks()).to.deep.equal([])
     })
 
+    it('removes the interceptor from the scope.interceptors array', () => {
+      const givenInterceptor = nock('http://example.test').get('/somepath')
+      const scope = givenInterceptor.reply(200, 'hey')
+
+      expect(scope.interceptors).to.have.lengthOf(1)
+      expect(nock.removeInterceptor(givenInterceptor)).to.be.true()
+      expect(scope.interceptors).to.have.lengthOf(0)
+    })
+
     it('removes given interceptor for https', async () => {
       const givenInterceptor = nock('https://example.test').get('/somepath')
       const scope = givenInterceptor.reply(200, 'hey')


### PR DESCRIPTION
Fixes #2353

## Problem

When calling \
ock.removeInterceptor(interceptor)\ with an Interceptor instance, the interceptor was removed from \llInterceptors\ (global list) and from \keyedInterceptors\ (via \scope.remove\), but \scope.interceptors\ array was never updated. This meant \scope.interceptors.length\ remained unchanged after removal.

## Fix

Added a splice to remove the interceptor from \interceptor.scope.interceptors\ in the \emoveInterceptor\ function at \lib/intercept.js\.

## Test

Added test verifying \scope.interceptors\ goes from length 1 to length 0 after \
ock.removeInterceptor\.