### PR TITLE
fix: end keep-alive http.request mocks with Content-Length

### DIFF
--- a/lib/create_response.js
+++ b/lib/create_response.js
@@ -50,4 +50,45 @@ function createResponse(message, signal) {
   return response
 }
 
-module.exports = { createResponse }
+function requestWantsKeepAlive(rawRequest) {
+  if (!rawRequest || typeof rawRequest.getHeader !== 'function') {
+    return false
+  }
+  const connection = rawRequest.getHeader('connection')
+  return (
+    typeof connection === 'string' && connection.toLowerCase() === 'keep-alive'
+  )
+}
+
+/**
+ * Interceptors copy this Fetch response onto the real socket. A keep-alive
+ * client will not emit `end` unless the response has Content-Length or is
+ * chunked, because Fetch strips the Connection header before Nock sees it.
+ * https://github.com/nock/nock/issues/3001
+ */
+async function respondWith(controller, response, rawRequest) {
+  if (
+    !requestWantsKeepAlive(rawRequest) ||
+    response.headers.has('content-length') ||
+    response.headers.has('transfer-encoding')
+  ) {
+    controller.respondWith(response)
+    return
+  }
+
+  const body = await response.arrayBuffer()
+  const headers = new Headers(response.headers)
+  headers.set('Content-Length', String(body.byteLength))
+  const bodyInit = responseStatusCodesWithoutBody.includes(response.status)
+    ? null
+    : body
+  controller.respondWith(
+    new Response(bodyInit, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    }),
+  )
+}
+
+module.exports = { createResponse, respondWith }

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -12,7 +12,7 @@ const { intercept: debug } = require('./debug')
 const globalEmitter = require('./global_emitter')
 const { BatchInterceptor, getRawRequest } = require('@mswjs/interceptors')
 const nodeInterceptors = require('@mswjs/interceptors/presets/node')
-const { createResponse } = require('./create_response')
+const { createResponse, respondWith } = require('./create_response')
 const { once } = require('events')
 const { arrayBuffer } = require('stream/consumers')
 
@@ -401,6 +401,8 @@ function activate() {
         if (!matches && allowUnmocked) {
           globalEmitter.emit('no match', nockRequest)
         } else {
+          const rawRequest = getRawRequest(mswRequest)
+          let respondPromise = Promise.resolve()
           nockRequest.on('response', nockResponse => {
             // Guard against the case where the AbortSignal fired before nock
             // finished building the response. In that scenario the interceptor
@@ -410,7 +412,7 @@ function activate() {
               return
             }
             const response = createResponse(nockResponse, mswRequest.signal)
-            controller.respondWith(response)
+            respondPromise = respondWith(controller, response, rawRequest)
           })
 
           const promise = Promise.race([
@@ -419,8 +421,6 @@ function activate() {
             once(nockRequest, 'error'),
             once(nockRequest, 'response'),
           ])
-
-          const rawRequest = getRawRequest(mswRequest)
 
           // If this is GET request with body, we need to read the body from the socket because Fetch API doesn't support this.
           const buffer =
@@ -433,6 +433,7 @@ function activate() {
           nockRequest.write(buffer)
           nockRequest.end()
           await promise
+          await respondPromise
         }
       } else {
         globalEmitter.emit('no match', options)

--- a/tests/test_client_request.js
+++ b/tests/test_client_request.js
@@ -36,6 +36,60 @@ describe('Direct use of `ClientRequest`', () => {
     req.end()
   })
 
+  it('completes when http.request sends Connection: keep-alive', function (done) {
+    const scope = nock('http://example.test').get('/ka').reply(200, 'hello')
+
+    const req = http.request(
+      {
+        host: 'example.test',
+        path: '/ka',
+        headers: { connection: 'keep-alive' },
+      },
+      res => {
+        const chunks = []
+        res.on('data', chunk => chunks.push(chunk))
+        res.on('end', () => {
+          expect(res.statusCode).to.equal(200)
+          expect(Buffer.concat(chunks).toString()).to.equal('hello')
+          expect(res.headers['content-length']).to.equal('5')
+          scope.done()
+          done()
+        })
+      },
+    )
+    req.on('error', done)
+    req.end()
+  })
+
+  it('completes keep-alive requests when the agent reuses the socket', function (done) {
+    const scope = nock('http://example.test').get('/ka').reply(200, 'hello')
+    const agent = new http.Agent({ keepAlive: true })
+
+    const req = http.request(
+      {
+        host: 'example.test',
+        path: '/ka',
+        agent,
+      },
+      res => {
+        const chunks = []
+        res.on('data', chunk => chunks.push(chunk))
+        res.on('end', () => {
+          agent.destroy()
+          expect(res.statusCode).to.equal(200)
+          expect(Buffer.concat(chunks).toString()).to.equal('hello')
+          scope.done()
+          done()
+        })
+      },
+    )
+    req.on('error', err => {
+      agent.destroy()
+      done(err)
+    })
+    req.end()
+  })
+
   it('should intercept POST requests', done => {
     const dataSpy = sinon.spy()
 


### PR DESCRIPTION
Fixes #3001

`http.request` with `Connection: keep-alive` never emits `end` on nock 14. The mocked body is written without `Content-Length` or chunked encoding, so the client waits for the socket to close.

Fetch strips `Connection` before Nock sees the request, so the keep-alive flag is only on the original `ClientRequest`. For that case this buffers the mocked body and sets `Content-Length` on the interceptor response.

v15 / `beta` already picks this up via `@mswjs/interceptors@0.42`. This keeps the v14 line working without that breaking bump.

## Test

```
npx mocha tests/test_client_request.js --grep 'keep-alive'
```

That case timed out before the change and passes after. Full mocha suite: 639 passing. One pre-existing native fetch URL clone failure is unchanged.
