### PR TITLE
fix: allow passthrough requests with large headers

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -252,6 +252,21 @@ function removeInterceptor(options) {
 //  Variable where we keep the ClientRequest we have overridden
 //  (which might or might not be node's original http.ClientRequest)
 let originalClientRequest
+let originalClientRequestOnSocket
+
+const maxOutgoingHeaderSize = 0xffffffff
+
+function increaseRequestParserHeaderLimit(socket) {
+  const parser = socket.requestParser
+
+  // @mswjs/interceptors <= 0.41 parses outgoing request headers with Node's
+  // default incoming-header limit. Node's ClientRequest has no equivalent
+  // limit, so large requests can otherwise stall before they are passed
+  // through or matched by Nock.
+  if (parser) {
+    parser.initialize(parser.constructor.REQUEST, {}, maxOutgoingHeaderSize)
+  }
+}
 
 function overrideClientRequest() {
   // Here's some background discussion about overriding ClientRequest:
@@ -325,6 +340,11 @@ function overrideClientRequest() {
   //  Override the http module's request but keep the original so that we can use it and later restore it.
   //  NOTE: We only override http.ClientRequest as https module also uses it.
   originalClientRequest = http.ClientRequest
+  originalClientRequestOnSocket = originalClientRequest.prototype.onSocket
+  originalClientRequest.prototype.onSocket = function (socket, ...args) {
+    increaseRequestParserHeaderLimit(socket)
+    return originalClientRequestOnSocket.call(this, socket, ...args)
+  }
   http.ClientRequest = OverriddenClientRequest
 
   debug('ClientRequest overridden')
@@ -340,7 +360,9 @@ function restoreOverriddenClientRequest() {
     isNockActive = false
     interceptor.dispose()
     http.ClientRequest = originalClientRequest
+    originalClientRequest.prototype.onSocket = originalClientRequestOnSocket
     originalClientRequest = undefined
+    originalClientRequestOnSocket = undefined
 
     debug('- ClientRequest restored')
   }

--- a/tests/got/test_request_overrider.js
+++ b/tests/got/test_request_overrider.js
@@ -22,6 +22,44 @@ const got = require('./got_client')
 const servers = require('../servers')
 
 describe('Request Overrider', () => {
+  it('completes passthrough responses when a server rejects oversized headers', async function () {
+    this.timeout(4000)
+
+    const server = http.createServer({ maxHeaderSize: 64000 })
+    await new Promise(resolve => server.listen(resolve))
+
+    const req = http.request({ port: server.address().port })
+    req.setHeader('test', 'a'.repeat(64001))
+    req.end()
+
+    let timeout
+    try {
+      const statusCode = await Promise.race([
+        new Promise((resolve, reject) => {
+          req.on('response', res => {
+            res.on('error', reject)
+            res.on('end', () => resolve(res.statusCode))
+            res.resume()
+          })
+          req.on('error', reject)
+        }),
+        new Promise((resolve, reject) => {
+          timeout = setTimeout(
+            () =>
+              reject(new Error('Timed out waiting for the response to end')),
+            1000,
+          )
+        }),
+      ])
+
+      expect(statusCode).to.equal(431)
+    } finally {
+      clearTimeout(timeout)
+      req.destroy()
+      await new Promise(resolve => server.close(resolve))
+    }
+  })
+
   it('response is an http.IncomingMessage instance', done => {
     const responseText = 'incoming message!'
     const scope = nock('http://example.test')
@@ -841,6 +879,28 @@ describe('Request Overrider', () => {
     expect(overriddenGet).not.to.have.been.called()
 
     req.abort()
+  })
+
+  it('does not alter requests made through a saved native request function', async () => {
+    nock.restore()
+    const nativeRequest = http.request
+    nock.activate()
+
+    const { origin } = await servers.startHttpServer((request, response) => {
+      response.writeHead(200)
+      response.end()
+    })
+
+    const statusCode = await new Promise((resolve, reject) => {
+      const req = nativeRequest(origin, res => {
+        res.on('end', () => resolve(res.statusCode))
+        res.resume()
+      })
+      req.on('error', reject)
+      req.end()
+    })
+
+    expect(statusCode).to.equal(200)
   })
 
   it('mocking a request which sends an empty buffer should finalize', async () => {


### PR DESCRIPTION
Fixes #3002

## Problem

`@mswjs/interceptors@0.41` parses outgoing request headers with Node's default incoming-header limit. A larger header returns `HPE_HEADER_OVERFLOW` before the request reaches Nock's request handler, and that parser result is ignored, leaving the request pending forever instead of passing it through to the server.

## Fix

Raise the interceptor-owned outgoing parser limit when its socket is assigned to `ClientRequest`. Native sockets are left untouched, and the original `onSocket` method is restored when Nock is deactivated. This keeps the current Node 18/20 support without upgrading to the Node 22-only interceptor release.

## Test

- Added a regression test that sends a 64,001-byte header to a server with a 64,000-byte limit and verifies the passthrough response completes with 431. It timed out before this change.
- Added coverage for requests made through a saved native `http.request` reference while Nock is active.
- `npm test` (640 passing, 11 pending; coverage thresholds met)
- `npm run test:jest`
- `npm run lint:js`
- `npm run format`
- Regression tests on Node 18, 20, and 22

`npm run lint:ts` cannot start because the repository does not contain the `notNeededPackages.json` file expected by its dtslint version; that job is currently disabled in CI.
