### PR TITLE
fix: count bytes, not characters, for replyContentLength

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -179,7 +179,7 @@ module.exports = class Interceptor {
     if (this.scope.contentLen) {
       // https://tools.ietf.org/html/rfc7230#section-3.3.2
       if (typeof body === 'string') {
-        this.rawHeaders.push('Content-Length', body.length)
+        this.rawHeaders.push('Content-Length', Buffer.byteLength(body))
       } else if (Buffer.isBuffer(body)) {
         this.rawHeaders.push('Content-Length', body.byteLength)
       }

--- a/tests/got/test_reply_headers.js
+++ b/tests/got/test_reply_headers.js
@@ -372,6 +372,37 @@ describe('`replyContentLength()`', () => {
     scope.done()
   })
 
+  it('counts bytes, not characters, for a multi-byte string response', async () => {
+    const response = 'héllo 🌍'
+
+    const scope = nock('http://example.test')
+      .replyContentLength()
+      .get('/')
+      .reply(200, response)
+
+    const { headers, body } = await got('http://example.test/')
+
+    expect(headers['content-length']).to.equal(`${Buffer.byteLength(response)}`)
+    expect(body).to.equal(response)
+    scope.done()
+  })
+
+  it('counts bytes, not characters, for a multi-byte JSON response', async () => {
+    const response = { hello: 'wörld' }
+
+    const scope = nock('http://example.test')
+      .replyContentLength()
+      .get('/')
+      .reply(200, response)
+
+    const { headers } = await got('http://example.test/')
+
+    expect(headers['content-length']).to.equal(
+      `${Buffer.byteLength(JSON.stringify(response))}`,
+    )
+    scope.done()
+  })
+
   it('sends explicit content-length header with buffer response', async () => {
     const response = Buffer.from([1, 2, 3, 4, 5, 6])
 


### PR DESCRIPTION
`replyContentLength()` sets `Content-Length` from `String#length` (UTF-16 code units), not bytes. One non-ASCII character under-reports the length, so the client stops reading mid-body and parses the remainder as a status line:

```
RequestError: Parse Error: Expected HTTP/, RTSP/ or ICE/
```

Reproduced on pristine `main` with a plain `http.get`, so the failure is Node's own parser, not a test helper:

| reply body | pushed | real bytes | live request |
|---|---|---|---|
| `'hello'` | 5 | 5 | ok |
| `'héllo'` | 5 | 6 | **crash** |
| `{m:'héllo'}` | 13 | 14 | **crash** |
| `Buffer.from('héllo')` | 6 | 6 | ok |

The last row points at the fix: the Buffer branch one line below already uses `byteLength`. #2294 added it and carried the older string line over unchanged. Every existing `replyContentLength()` test is ASCII, where the two agree — which is why this stayed green.

Verification — `npx mocha --recursive tests`, same command each time:

| tree | passing | failing |
|---|---|---|
| `main` pristine | 637 | 1 |
| `main` + the new tests only | 637 | 3 |
| this PR | 639 | 1 |

That 1 failure is pre-existing and unrelated (`Native Fetch › should return a url for cloned response URL`), identical on every run.

Honest note: `Buffer.from(body).length` also passes the full suite; I used `Buffer.byteLength(body)` because it measures without allocating.

Written with AI assistance (Claude Opus 5, `claude-opus-5`).
