### PR TITLE
fix: return false when no interceptor is removed

### DIFF
--- a/lib/intercept.ts
+++ b/lib/intercept.ts
@@ -190,11 +190,9 @@ function removeInterceptor(
         if (scopeIndex !== -1) {
           interceptor.scope.interceptors.splice(scopeIndex, 1)
         }
-        break
+        return true
       }
     }
-
-    return true
   }
 
   return false

--- a/tests/got/test_remove_interceptor.js
+++ b/tests/got/test_remove_interceptor.js
@@ -21,6 +21,19 @@ describe('`removeInterceptor()`', () => {
       newScope.done()
     })
 
+    it('returns false for an unregistered instance with the same request key', async () => {
+      const scope = nock('http://example.test')
+        .get('/somepath')
+        .reply(200, 'hey')
+      const unregistered = nock('http://example.test').get('/somepath')
+
+      expect(nock.removeInterceptor(unregistered)).to.be.false()
+
+      const { body } = await got('http://example.test/somepath')
+      expect(body).to.equal('hey')
+      scope.done()
+    })
+
     it('reflects the removal in `pendingMocks()`', () => {
       const givenInterceptor = nock('http://example.test').get('/somepath')
       const scope = givenInterceptor.reply(200, 'hey')
@@ -120,6 +133,41 @@ describe('`removeInterceptor()`', () => {
           path: '/somepath',
         }),
       ).to.be.false()
+    })
+
+    it('returns false when the path does not match any interceptor', async () => {
+      const scope = nock('http://example.test')
+        .get('/somepath')
+        .reply(200, 'hey')
+
+      expect(
+        nock.removeInterceptor({
+          hostname: 'example.test',
+          path: '/anotherpath',
+        }),
+      ).to.be.false()
+
+      const { body } = await got('http://example.test/somepath')
+      expect(body).to.equal('hey')
+      scope.done()
+    })
+
+    it('returns false when the method does not match any interceptor', async () => {
+      const scope = nock('http://example.test')
+        .get('/somepath')
+        .reply(200, 'hey')
+
+      expect(
+        nock.removeInterceptor({
+          hostname: 'example.test',
+          path: '/somepath',
+          method: 'POST',
+        }),
+      ).to.be.false()
+
+      const { body } = await got('http://example.test/somepath')
+      expect(body).to.equal('hey')
+      scope.done()
     })
 
     it('can match a request with a proto', () => {


### PR DESCRIPTION
`removeInterceptor()` returns `true` whenever the origin has registered interceptors, even when none matches the supplied path, method, or instance. Callers therefore cannot tell that nothing was removed.

Return `true` only after removing a matching interceptor, and fall through to `false` when the search finds no match. Matching rules and scope cleanup stay the same.

Add regressions for a different path, a different method, and an unregistered instance with the same request key. Each case also makes a mocked request to verify that the original interceptor remains usable.

Validation: the three new cases fail on the original code and pass with this change. The full suite passes on macOS (Node 22) and Linux (Node 24): 658 passing, 9 existing pending. Lint, formatting, leak checks, and the build smoke test pass on both. Linux tests ran without external networking, using a local NXDOMAIN responder for the existing DNS-error tests.
